### PR TITLE
feat: form appointment url formatting

### DIFF
--- a/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
+++ b/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
@@ -60,10 +60,17 @@ class AppointmentForm
                     ->required(),
                 TextInput::make('meeting_url')
                     ->label(__('appointments::resources.appointments.form.meeting_url'))
-                    ->dehydrateStateUsing(fn (?string $state): ?string => filled($state) && ! str_starts_with($state, 'http')
-                        ? 'https://' . $state
-                        : $state
-                    ),
+                    ->dehydrateStateUsing(function (?string $state): ?string {
+                        if (blank($state)) {
+                            return $state;
+                        }
+
+                        $trimmed = trim($state);
+
+                        return str_starts_with(strtolower($trimmed), 'http')
+                            ? $trimmed
+                            : sprintf('https://%s', $trimmed);
+                    }),
             ]);
     }
 }

--- a/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
+++ b/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
@@ -6,6 +6,7 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\Date;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
@@ -59,7 +60,11 @@ class AppointmentForm
                     ->options(AppointmentStatus::class)
                     ->required(),
                 TextInput::make('meeting_url')
-                    ->label(__('appointments::resources.appointments.form.meeting_url')),
+                    ->label(__('appointments::resources.appointments.form.meeting_url'))
+                    ->dehydrateStateUsing(fn (?string $state): ?string => filled($state) && ! str_starts_with($state, 'http')
+                        ? 'https://' . $state
+                        : $state
+                    ),
             ]);
     }
 }

--- a/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
+++ b/app-modules/appointments/src/Filament/Admin/Resources/Appointments/Schemas/AppointmentForm.php
@@ -6,7 +6,6 @@ use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
-use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Illuminate\Support\Facades\Date;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Meeting URLs are now normalized when saved: leading/trailing spaces are trimmed and entries missing a protocol are automatically prefixed with "https://". Empty values remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->