### PR TITLE
feat(company): set br as default country at user phone input

### DIFF
--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -75,6 +75,7 @@ class CreateAndAttachAction extends CreateAction
                     PhoneInput::make('phone_number')
                         ->label('Telefone')
                         ->defaultCountry('BR')
+                        ->locale(config('app.locale'))
                         ->strictMode()
                         ->required(),
                 ]),

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -75,7 +75,8 @@ class CreateAndAttachAction extends CreateAction
                     PhoneInput::make('phone_number')
                         ->label('Telefone')
                         ->defaultCountry('BR')
-                        ->locale(config('app.locale'))
+                        ->initialCountry('BR')
+                        ->disableLookup()
                         ->strictMode()
                         ->required(),
                 ]),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone input now defaults to Brazil as the initial country for faster, localized entry.
  * Phone number lookup has been disabled to improve privacy and reduce external requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->