### PR TITLE
feat(admin): appointment table filters

### DIFF
--- a/app-modules/appointments/lang/en/resources.php
+++ b/app-modules/appointments/lang/en/resources.php
@@ -14,6 +14,8 @@ return [
                 'status' => 'Status',
                 'created_at' => 'Created at',
                 'updated_at' => 'Updated at',
+                'from' => 'From',
+                'until' => 'Until',
             ],
             'actions' => [
                 'view' => 'View',

--- a/app-modules/appointments/lang/pt_BR/resources.php
+++ b/app-modules/appointments/lang/pt_BR/resources.php
@@ -14,6 +14,8 @@ return [
                 'status' => 'Status',
                 'created_at' => 'Criado em',
                 'updated_at' => 'Atualizado em',
+                'from' => 'De',
+                'until' => 'Até',
             ],
             'actions' => [
                 'view' => 'Ver',

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -95,6 +95,28 @@ class AppointmentsTable
                             : null;
                     }),
 
+                Filter::make('consultant_name')
+                    ->label(__('appointments::resources.appointments.table.columns.consultant'))
+                    ->schema([
+                        TextInput::make('consultant_name')
+                            ->label(__('appointments::resources.appointments.table.columns.consultant'))
+                            ->live(debounce: 500),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when(
+                            $data['consultant_name'] ?? null,
+                            fn (Builder $q, string $name) => $q->whereHas(
+                                'consultant',
+                                fn (Builder $q) => $q->where('name', 'like', sprintf('%%%s%%', $name))
+                            )
+                        );
+                    })
+                    ->indicateUsing(function (array $data): ?string {
+                        return isset($data['consultant_name']) && $data['consultant_name']
+                            ? __('appointments::resources.appointments.table.columns.consultant') . ': ' . $data['consultant_name']
+                            : null;
+                    }),
+
                 SelectFilter::make('status')
                     ->label('Status')
                     ->options(AppointmentStatus::class)

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -6,8 +6,14 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\TextInput;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
 
 class AppointmentsTable
 {
@@ -34,8 +40,67 @@ class AppointmentsTable
                     ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
-                //
+                Filter::make('date_range')
+                    ->label('Data')
+                    ->schema([
+                        DatePicker::make('from')
+                            ->label(__('appointments::resources.appointments.table.columns.from')),
+                        DatePicker::make('until')
+                            ->label(__('appointments::resources.appointments.table.columns.until')),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query
+                            ->when(
+                                $data['from'] ?? null,
+                                fn (Builder $q, string $date) => $q->whereDate('appointment_at', '>=', $date)
+                            )
+                            ->when(
+                                $data['until'] ?? null,
+                                fn (Builder $q, string $date) => $q->whereDate('appointment_at', '<=', $date)
+                            );
+                    })
+                    ->indicateUsing(function (array $data): array {
+                        $indicators = [];
+
+                        if ($data['from'] ?? null) {
+                            $indicators['from'] = __('appointments::resources.appointments.table.columns.from') . ': ' . $data['from'];
+                        }
+
+                        if ($data['until'] ?? null) {
+                            $indicators['until'] = __('appointments::resources.appointments.table.columns.until') . ': ' . $data['until'];
+                        }
+
+                        return $indicators;
+                    }),
+
+                Filter::make('user_name')
+                    ->label(__('appointments::resources.appointments.table.columns.user'))
+                    ->schema([
+                        TextInput::make('user_name')
+                            ->label(__('appointments::resources.appointments.table.columns.user'))
+                            ->live(debounce: 500),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        return $query->when(
+                            $data['user_name'] ?? null,
+                            fn (Builder $q, string $name) => $q->whereHas(
+                                'user',
+                                fn (Builder $q) => $q->where('name', 'like', sprintf('%%%s%%', $name))
+                            )
+                        );
+                    })
+                    ->indicateUsing(function (array $data): ?string {
+                        return isset($data['user_name']) && $data['user_name']
+                            ? __('appointments::resources.appointments.table.columns.user') . ': ' . $data['user_name']
+                            : null;
+                    }),
+
+                SelectFilter::make('status')
+                    ->label('Status')
+                    ->options(AppointmentStatus::class)
+                    ->multiple(),
             ])
+            ->persistFiltersInSession()
             ->recordActions([
                 ViewAction::make(),
                 EditAction::make(),


### PR DESCRIPTION
This pull request enhances the appointments admin panel by adding new filtering options to the appointments table and updating localization files to support these changes. The main improvements are the introduction of date range, user name, and status filters, which make it easier for admins to search and manage appointments.

**Appointments Table Filtering Enhancements:**

* Added a date range filter using two `DatePicker` components (`from` and `until`) to allow filtering appointments by their scheduled date. The filter updates the query accordingly and displays active filter indicators.
* Introduced a user name filter with a `TextInput` field that supports live search. This filter allows searching appointments by the user's name and shows an indicator when active.
* Added a status filter using `SelectFilter`, enabling multi-select filtering based on appointment status values from the `AppointmentStatus` enum.
* Ensured that filter selections persist in the session, so filters remain active when navigating.

**Localization Updates:**

* Updated English (`resources.php`) and Brazilian Portuguese (`resources.php`) language files to add translations for the new `from` and `until` columns used in the date range filter. [[1]](diffhunk://#diff-b2e828bda8adbd754b293c6b646dae85ab7e9ad7765c55c8cd3e3ad3c7dcffdfR17-R18) [[2]](diffhunk://#diff-5dd8d1eccafda6c3ac2d5f279dc1b00c89c139a5589ab107c8bc27d25c135e96R17-R18)

**Codebase Maintenance:**

* Added necessary imports for new filter and form components in `AppointmentsTable.php`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive filtering to the Appointments module with options for date range, user name, consultant name, and appointment status.
  * Filter preferences are automatically saved and maintained during your session.

* **Localization**
  * Enhanced appointment table column labels with translations in English and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->