### PR TITLE
hotfix: make document_id nullable and remove required validation

### DIFF
--- a/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
@@ -28,7 +28,6 @@ class EditUserProfile extends BaseEditUserProfile
                     JS))
                 ->minLength(5)
                 ->maxLength(14)
-                ->required()
                 ->unique(
                     table: 'user_details',
                     column: 'document_id',

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Schemas/UserForm.php
@@ -49,7 +49,6 @@ class UserForm
                             JS))
                             ->minLength(5)
                             ->maxLength(14)
-                            ->required()
                             ->unique(),
                         Select::make('company_id')
                             ->label(__('panel-admin::resources.users.form.company'))

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -91,8 +91,7 @@ class CreateAndAttachAction extends CreateAction
                         JS))
                         ->minLength(5)
                         ->maxLength(14)
-                        ->rule(new UniqueAtCompany)
-                        ->required(),
+                        ->rule(new UniqueAtCompany),
                     PhoneInput::make('phone_number')
                         ->label(__('panel-company::resources.actions.create_and_attach.phone'))
                         ->defaultCountry('BR')

--- a/app-modules/panel-company/tests/Feature/Filament/CreateAndAttachActionTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/CreateAndAttachActionTest.php
@@ -148,7 +148,6 @@ describe('validation tests', function (): void {
             ->assertHasFormErrors(['detail.document_id' => $rule]);
 
     })->with([
-        'required' => [null, 'required'],
         'min_length' => ['AB', 'min'],
     ]);
 

--- a/database/migrations/2026_03_25_140122_make_document_id_nullable_on_user_details_table.php
+++ b/database/migrations/2026_03_25_140122_make_document_id_nullable_on_user_details_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_details', function (Blueprint $table): void {
+            $table->string('document_id', 50)->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_details', function (Blueprint $table): void {
+            $table->string('document_id', 50)->nullable(false)->change();
+        });
+    }
+};

--- a/tests/Feature/Filament/Resources/Users/CreateUserTest.php
+++ b/tests/Feature/Filament/Resources/Users/CreateUserTest.php
@@ -107,7 +107,6 @@ describe('validation tests', function () {
             ->call('create')
             ->assertHasFormErrors(['detail.document_id' => $rule]);
     })->with([
-        'required' => [null, 'required'],
         'unique' => ['268.717.480-75', 'unique'],
         'min_length' => ['AB', 'min'],
     ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The document ID field is now optional instead of mandatory in user profile and company management forms. Length and uniqueness validation rules remain in place when a value is provided.

* **Tests**
  * Updated validation tests to reflect that document ID is no longer required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->