### PR TITLE
Fix: Atualização do número de WhatsApp no link de direcionamento

### DIFF
--- a/resources/views/components/partials/split-image-with-headline.blade.php
+++ b/resources/views/components/partials/split-image-with-headline.blade.php
@@ -47,7 +47,7 @@
             {{ $description }}
         </x-slot:description>
         <x-slot:actions>
-            <x-button :variant="$buttonVariant" rel="noopener noreferrer" target="_blank" href="https://w.app/wjijp2">
+            <x-button :variant="$buttonVariant" rel="noopener noreferrer" target="_blank" href="https://wa.me/5511976205711?text=Flamma">
                 Entrar em contato
             </x-button>
         </x-slot:actions>

--- a/resources/views/components/partials/text-with-action-stacked.blade.php
+++ b/resources/views/components/partials/text-with-action-stacked.blade.php
@@ -6,7 +6,7 @@
     <p class="text-medium font-medium delay-200 max-w-full text-sm md:text-md lg:text-base text-center">
         {{ $text }}
     </p>
-    <x-button rel="noopener noreferrer" target="_blank" href="https://w.app/wjijp2">
+    <x-button rel="noopener noreferrer" target="_blank" href="https://wa.me/5511976205711?text=Flamma">
         Entrar em contato
     </x-button>
 </div>

--- a/resources/views/components/sections/faq.blade.php
+++ b/resources/views/components/sections/faq.blade.php
@@ -56,7 +56,7 @@
                 {{ $description }}
             </x-slot:description>
             <x-slot:actions>
-                <x-button rel="noopener noreferrer" target="_blank" href="https://w.app/wjijp2">
+                <x-button rel="noopener noreferrer" target="_blank" href="https://wa.me/5511976205711?text=Flamma">
                     Entre em contato
                 </x-button>
             </x-slot:actions>

--- a/resources/views/components/sections/hero-with-card.blade.php
+++ b/resources/views/components/sections/hero-with-card.blade.php
@@ -20,7 +20,7 @@
                 {{ $description }}
             </x-slot:description>
             <x-slot:actions>
-                <x-button rel="noopener noreferrer" target="_blank" href="https://w.app/wjijp2">
+                <x-button rel="noopener noreferrer" target="_blank" href="https://wa.me/5511976205711?text=Flamma">
                     Cotação gratuita
                 </x-button>
             </x-slot:actions>


### PR DESCRIPTION
## Contexto
O link de redirecionamento para WhatsApp estava apontando para um número desatualizado.

## Alterações realizadas
- Atualização do número de telefone no link de redirecionamento do WhatsApp
- Garantia de funcionamento correto do direcionamento

## Como validar
1. Acessar o botão/link de contato via WhatsApp
2. Verificar se o redirecionamento abre corretamente
3. Confirmar se o número exibido é o novo número

## Impacto
- Correção de contato com clientes
- Melhoria na comunicação e conversão

## Observações
- Nenhuma mudança estrutural ou impacto em outras funcionalidades