### PR TITLE
feat: add company filter to appointments table and sync table filters…

### DIFF
--- a/app-modules/appointments/lang/en/resources.php
+++ b/app-modules/appointments/lang/en/resources.php
@@ -18,6 +18,7 @@ return [
                 'updated_at' => 'Updated at',
                 'from' => 'From',
                 'until' => 'Until',
+                'company' => 'Company',
             ],
             'actions' => [
                 'view' => 'View',

--- a/app-modules/appointments/lang/pt_BR/resources.php
+++ b/app-modules/appointments/lang/pt_BR/resources.php
@@ -18,6 +18,7 @@ return [
                 'updated_at' => 'Atualizado em',
                 'from' => 'De',
                 'until' => 'Até',
+                'company' => 'Empresa',
             ],
             'actions' => [
                 'view' => 'Ver',

--- a/app-modules/appointments/tests/Feature/Admin/ListAppointmentsTest.php
+++ b/app-modules/appointments/tests/Feature/Admin/ListAppointmentsTest.php
@@ -2,6 +2,7 @@
 
 use TresPontosTech\Admin\Filament\Resources\Appointments\Pages\ListAppointments;
 use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Company\Models\Company;
 
 use function Pest\Livewire\livewire;
 
@@ -19,4 +20,15 @@ it('should list appointments', function (): void {
     livewire(ListAppointments::class)
         ->assertOk()
         ->assertCanSeeTableRecords($appointments);
+});
+
+it('filters appointments by company', function (): void {
+    $company = Company::factory()->create();
+    $companyAppointments = Appointment::factory()->count(3)->create(['company_id' => $company->id]);
+    $otherAppointments = Appointment::factory()->count(2)->create();
+
+    livewire(ListAppointments::class)
+        ->filterTable('company_id', $company->id)
+        ->assertCanSeeTableRecords($companyAppointments)
+        ->assertCanNotSeeTableRecords($otherAppointments);
 });

--- a/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
+++ b/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
@@ -103,7 +103,7 @@ class GoogleCalendarClient
     public function deleteEvent(string $accessToken, string $calendarId, string $eventId): void
     {
         $url = sprintf(
-            'https://www.googleapis.com/calendar/v3/calendars/%s/events/%s',
+            'https://www.googleapis.com/calendar/v3/calendars/%s/events/%s?sendUpdates=all',
             urlencode($calendarId),
             urlencode($eventId)
         );

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ListAppointments.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ListAppointments.php
@@ -26,4 +26,11 @@ class ListAppointments extends ListRecords
             AppointmentsStatsOverview::class,
         ];
     }
+
+    protected function handleTableFilterUpdates(): void
+    {
+        parent::handleTableFilterUpdates();
+
+        $this->dispatch('appointments-table-filters-changed', filters: $this->tableFilters ?? []);
+    }
 }

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ListAppointments.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ListAppointments.php
@@ -27,6 +27,17 @@ class ListAppointments extends ListRecords
         ];
     }
 
+    public function mount(): void
+    {
+        parent::mount();
+
+        $persisted = session($this->getTableFiltersSessionKey());
+
+        if (filled($persisted)) {
+            $this->dispatch('appointments-table-filters-changed', filters: $persisted);
+        }
+    }
+
     protected function handleTableFilterUpdates(): void
     {
         parent::handleTableFilterUpdates();

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -127,6 +127,12 @@ class AppointmentsTable
                     ->label('Status')
                     ->options(AppointmentStatus::class)
                     ->multiple(),
+
+                SelectFilter::make('company_id')
+                    ->label(__('appointments::resources.appointments.table.columns.company'))
+                    ->relationship('company', 'name')
+                    ->searchable()
+                    ->preload(false),
             ])
             ->persistFiltersInSession()
             ->defaultSort('appointment_at', 'desc')

--- a/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
@@ -4,6 +4,8 @@ namespace TresPontosTech\Admin\Filament\Widgets;
 
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Database\Eloquent\Builder;
+use Livewire\Attributes\On;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
 
@@ -13,7 +15,15 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
 
     protected int|string|array $columnSpan = 'full';
 
+    public array $tableFilterState = [];
+
     private ?object $aggregates = null;
+
+    #[On('appointments-table-filters-changed')]
+    public function syncFilters(array $filters): void
+    {
+        $this->tableFilterState = $filters;
+    }
 
     protected function getStats(): array
     {
@@ -30,6 +40,36 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
     private function aggregates(): object
     {
         return $this->aggregates ??= Appointment::query()
+            ->when(
+                filled(data_get($this->tableFilterState, 'company_id.value')),
+                fn (Builder $q) => $q->where('company_id', data_get($this->tableFilterState, 'company_id.value'))
+            )
+            ->when(
+                filled(data_get($this->tableFilterState, 'date_range.from')),
+                fn (Builder $q) => $q->whereDate('appointment_at', '>=', data_get($this->tableFilterState, 'date_range.from'))
+            )
+            ->when(
+                filled(data_get($this->tableFilterState, 'date_range.until')),
+                fn (Builder $q) => $q->whereDate('appointment_at', '<=', data_get($this->tableFilterState, 'date_range.until'))
+            )
+            ->when(
+                filled(data_get($this->tableFilterState, 'user_name.user_name')),
+                fn (Builder $q) => $q->whereHas(
+                    'user',
+                    fn (Builder $q) => $q->where('name', 'like', sprintf('%%%s%%', data_get($this->tableFilterState, 'user_name.user_name')))
+                )
+            )
+            ->when(
+                filled(data_get($this->tableFilterState, 'consultant_name.consultant_name')),
+                fn (Builder $q) => $q->whereHas(
+                    'consultant',
+                    fn (Builder $q) => $q->where('name', 'like', sprintf('%%%s%%', data_get($this->tableFilterState, 'consultant_name.consultant_name')))
+                )
+            )
+            ->when(
+                filled(data_get($this->tableFilterState, 'status.values')),
+                fn (Builder $q) => $q->whereIn('status', data_get($this->tableFilterState, 'status.values'))
+            )
             ->selectRaw(
                 implode(', ', [
                     'count(*) as total',


### PR DESCRIPTION
… with stats widget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added company-based filtering for the appointments table
  * Appointments statistics overview widget now reflects active table filters, including company, date range, user/consultant names, and appointment status

* **Improvements**
  * Google Calendar event deletions now send notifications to attendees

* **Tests**
  * Added test coverage for company-based appointment filtering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->