### PR TITLE
chore(ci): modularizar workflows e rodar Pest em paralelo

### DIFF
--- a/.github/workflows/_pest.yml
+++ b/.github/workflows/_pest.yml
@@ -1,0 +1,85 @@
+name: Pest Tests
+
+on:
+  workflow_call:
+    inputs:
+      PHP_VERSION:
+        required: true
+        type: string
+      PHP_EXTENSIONS:
+        required: true
+        type: string
+      PHP_INI_PROPERTIES:
+        required: true
+        type: string
+      COMPOSER_FLAGS:
+        required: true
+        type: string
+      CACHE_KEY:
+        required: true
+        type: string
+    secrets:
+      FLUX_USERNAME:
+        required: true
+      FLUX_LICENSE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  tests:
+    name: Run
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-tests
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          ini-values: ${{ inputs.PHP_INI_PROPERTIES }}
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Setup Node
+        uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Configure Flux credentials
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          composer-options: ${{ inputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ inputs.CACHE_KEY }}
+
+      - name: Install node dependencies
+        run: |
+          npm ci
+          npm run build
+
+      - name: Copy environment file
+        run: cp .env.example .env
+
+      - name: Generate application key
+        run: php artisan key:generate
+
+      - name: Run Tests
+        env:
+          XDEBUG_MODE: off
+        run: |
+          vendor/bin/pest --ci --parallel

--- a/.github/workflows/_phpstan.yml
+++ b/.github/workflows/_phpstan.yml
@@ -1,0 +1,66 @@
+name: Phpstan
+
+on:
+  workflow_call:
+    inputs:
+      PHP_VERSION:
+        required: true
+        type: string
+      PHP_EXTENSIONS:
+        required: true
+        type: string
+      PHP_INI_PROPERTIES:
+        required: true
+        type: string
+      COMPOSER_FLAGS:
+        required: true
+        type: string
+      CACHE_KEY:
+        required: true
+        type: string
+    secrets:
+      FLUX_USERNAME:
+        required: true
+      FLUX_LICENSE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-phpstan
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          ini-values: ${{ inputs.PHP_INI_PROPERTIES }}
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Configure Flux credentials
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          composer-options: ${{ inputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ inputs.CACHE_KEY }}
+
+      - name: Run Phpstan
+        run: |
+          vendor/bin/phpstan analyse --ansi --error-format=github

--- a/.github/workflows/_pint.yml
+++ b/.github/workflows/_pint.yml
@@ -1,0 +1,68 @@
+name: Pint
+
+on:
+  workflow_call:
+    inputs:
+      PHP_VERSION:
+        required: true
+        type: string
+      PHP_EXTENSIONS:
+        required: true
+        type: string
+      PHP_INI_PROPERTIES:
+        required: true
+        type: string
+      COMPOSER_FLAGS:
+        required: true
+        type: string
+      CACHE_KEY:
+        required: true
+        type: string
+    secrets:
+      FLUX_USERNAME:
+        required: true
+      FLUX_LICENSE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-pint
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          ini-values: ${{ inputs.PHP_INI_PROPERTIES }}
+          coverage: xdebug
+          tools: composer:v2, cs2pr
+
+      - name: Configure Flux credentials
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          composer-options: ${{ inputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ inputs.CACHE_KEY }}
+
+      - name: Run Pint
+        env:
+          XDEBUG_MODE: off
+        run: |
+          vendor/bin/pint --test --parallel --format=checkstyle | cs2pr

--- a/.github/workflows/_rector.yml
+++ b/.github/workflows/_rector.yml
@@ -1,0 +1,66 @@
+name: Rector
+
+on:
+  workflow_call:
+    inputs:
+      PHP_VERSION:
+        required: true
+        type: string
+      PHP_EXTENSIONS:
+        required: true
+        type: string
+      PHP_INI_PROPERTIES:
+        required: true
+        type: string
+      COMPOSER_FLAGS:
+        required: true
+        type: string
+      CACHE_KEY:
+        required: true
+        type: string
+    secrets:
+      FLUX_USERNAME:
+        required: true
+      FLUX_LICENSE_KEY:
+        required: true
+
+permissions: {}
+
+jobs:
+  run:
+    name: Run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-rector
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          ini-values: ${{ inputs.PHP_INI_PROPERTIES }}
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Configure Flux credentials
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          composer-options: ${{ inputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ inputs.CACHE_KEY }}
+
+      - name: Run Rector
+        run: |
+          vendor/bin/rector --dry-run --output-format=github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,159 +2,142 @@ name: Continuous Integration
 
 on:
   push:
-    branches:
-      - main
-      - develop
+    branches: [main, develop]
   pull_request:
-    branches:
-      - main
-      - develop
+    branches: [main, develop]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  PHP_VERSION: 8.4
-  PHP_EXTENSIONS: mbstring,pdo,xml,ctype,fileinfo,json,curl,openssl,dom,zip
-  PHP_INI_PROPERTIES: post_max_size=256M,upload_max_filesize=256M
+permissions: {}
 
 jobs:
   setup:
     name: Setup PHP
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
     outputs:
-      combined-key: ${{ steps.prepare-env.outputs.combined-key }}
+      CACHE_KEY: ${{ steps.cache.outputs.key }}
+      PHP_VERSION: ${{ steps.setup.outputs.PHP_VERSION }}
+      PHP_EXTENSIONS: ${{ steps.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ steps.setup.outputs.PHP_INI_PROPERTIES }}
+      COMPOSER_FLAGS: ${{ steps.setup.outputs.COMPOSER_FLAGS }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      - name: Prepare environment and composer data
-        id: prepare-env
+      - name: Setup job outputs
+        id: setup
         run: |
-          composer_hash=${{ hashFiles('**/composer.lock') }}
-          os_lower=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')
-          arch_lower=$(echo ${{ runner.arch }} | tr '[:upper:]' '[:lower:]')
+          echo "PHP_VERSION=8.4" >> "$GITHUB_OUTPUT"
+          echo "PHP_EXTENSIONS=mbstring,pdo,xml,ctype,fileinfo,json,curl,openssl,dom,zip" >> "$GITHUB_OUTPUT"
+          echo "PHP_INI_PROPERTIES=post_max_size=256M,upload_max_filesize=256M" >> "$GITHUB_OUTPUT"
+          echo "COMPOSER_FLAGS=--prefer-dist --optimize-autoloader" >> "$GITHUB_OUTPUT"
+
+      - name: Create cache key
+        id: cache
+        shell: bash
+        env:
+          RUNNER_OS: ${{ runner.os }}
+          RUNNER_ARCH: ${{ runner.arch }}
+          HASHED_COMPOSER_LOCK: ${{ hashFiles('composer.lock') }}
+        run: |
+          composer_hash=${HASHED_COMPOSER_LOCK}
+          os_lower=$(echo ${RUNNER_OS} | tr '[:upper:]' '[:lower:]')
+          arch_lower=$(echo ${RUNNER_ARCH} | tr '[:upper:]' '[:lower:]')
           combined_key="${os_lower}-${arch_lower}-composer-${composer_hash}"
-          echo "combined-key=${combined_key}" >> "$GITHUB_OUTPUT"
+          echo "key=${combined_key}" >> "$GITHUB_OUTPUT"
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          ini-values: ${{ env.PHP_INI_PROPERTIES }}
+          php-version: ${{ steps.setup.outputs.PHP_VERSION }}
+          extensions: ${{ steps.setup.outputs.PHP_EXTENSIONS }}
+          ini-values: ${{ steps.setup.outputs.PHP_INI_PROPERTIES }}
           coverage: xdebug
           tools: composer:v2
 
+      - name: Configure Flux credentials
+        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
+
       - name: Install composer dependencies
-        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
         with:
-          composer-options: "--prefer-dist"
-          custom-cache-key: ${{ steps.prepare-env.outputs.combined-key }}
+          composer-options: ${{ steps.setup.outputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ steps.cache.outputs.key }}
+
   pint:
     name: Perform Pint format
-    runs-on: ubuntu-latest
-    needs:
-      - setup
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
-        with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          ini-values: ${{ env.PHP_INI_PROPERTIES }}
-          coverage: xdebug
-          tools: composer:v2
-
-      - name: Install composer dependencies
-        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
-        with:
-          composer-options: "--prefer-dist"
-          custom-cache-key: ${{ needs.setup.outputs.combined-key }}
-
-      - name: Run Pint
-        env:
-          XDEBUG_MODE: off
-        run: |
-          composer run-script test:pint
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_pint.yml
+    secrets:
+      FLUX_USERNAME: ${{ secrets.FLUX_USERNAME }}
+      FLUX_LICENSE_KEY: ${{ secrets.FLUX_LICENSE_KEY }}
+    with:
+      CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
+      COMPOSER_FLAGS: ${{ needs.setup.outputs.COMPOSER_FLAGS }}
+      PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
+      PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}
 
   rector:
     name: Perform Rector Check
-    runs-on: ubuntu-latest
-    needs:
-      - setup
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_rector.yml
+    secrets:
+      FLUX_USERNAME: ${{ secrets.FLUX_USERNAME }}
+      FLUX_LICENSE_KEY: ${{ secrets.FLUX_LICENSE_KEY }}
+    with:
+      CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
+      COMPOSER_FLAGS: ${{ needs.setup.outputs.COMPOSER_FLAGS }}
+      PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
+      PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}
 
-      - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
-        with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          ini-values: ${{ env.PHP_INI_PROPERTIES }}
-          coverage: xdebug
-          tools: composer:v2
-
-      - name: Install composer dependencies
-        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
-        with:
-          composer-options: "--prefer-dist"
-          custom-cache-key: ${{ needs.setup.outputs.combined-key }}
-
-      - name: Run Rector
-        run: |
-          composer run-script test:rector
-
-
-
-
+  phpstan:
+    name: Perform Phpstan Check
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_phpstan.yml
+    secrets:
+      FLUX_USERNAME: ${{ secrets.FLUX_USERNAME }}
+      FLUX_LICENSE_KEY: ${{ secrets.FLUX_LICENSE_KEY }}
+    with:
+      CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
+      COMPOSER_FLAGS: ${{ needs.setup.outputs.COMPOSER_FLAGS }}
+      PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
+      PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}
 
   pest:
-    name: Run Pest Tests
-    runs-on: ubuntu-latest
-    needs:
-      - setup
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ env.PHP_VERSION }}
-          extensions: ${{ env.PHP_EXTENSIONS }}
-          ini-values: ${{ env.PHP_INI_PROPERTIES }}
-          coverage: xdebug
-          tools: composer:v2
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install Node Dependencies
-        run: npm i
-
-      - name: Add Flux Credentials Loaded From ENV
-        run: composer config http-basic.composer.fluxui.dev "${{ secrets.FLUX_USERNAME }}" "${{ secrets.FLUX_LICENSE_KEY }}"
-
-      - name: Install Dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
-
-      - name: Copy Environment File
-        run: cp .env.example .env
-
-      - name: Generate Application Key
-        run: php artisan key:generate
-
-      - name: Build Assets
-        run: npm run build
-
-      - name: Run Tests
-        run: composer run-script test
+    name: Perform Pest Tests
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_pest.yml
+    secrets:
+      FLUX_USERNAME: ${{ secrets.FLUX_USERNAME }}
+      FLUX_LICENSE_KEY: ${{ secrets.FLUX_LICENSE_KEY }}
+    with:
+      CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
+      COMPOSER_FLAGS: ${{ needs.setup.outputs.COMPOSER_FLAGS }}
+      PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
+      PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}

--- a/composer.json
+++ b/composer.json
@@ -130,7 +130,7 @@
         ],
         "test": [
             "@php artisan config:clear --ansi",
-            "@php artisan test --coverage"
+            "@php artisan test --parallel"
         ]
     },
     "extra": {


### PR DESCRIPTION
Refatora o CI seguindo o padrão do repo recruit-party-quest: um caller ci.yml slim que apenas delega para workflows reutilizáveis por ferramenta.

Mudanças:
- Extrai pint, rector, phpstan e pest para _pint.yml, _rector.yml, _phpstan.yml e _pest.yml via workflow_call
- Adiciona job de PHPStan ao CI (não existia antes)
- Pest passa a rodar com --parallel e sem --coverage (ninguém consumia o relatório — sem Codecov, sem threshold, sem artifact)
- composer run-script test também passa a usar --parallel localmente
- SHA-pin em todas as actions do GitHub (antes estava misturado com tags @v4/@v2 no job pest)
- Secrets FLUX_USERNAME/FLUX_LICENSE_KEY propagados aos sub-workflows para o composer install ter auth na fluxui.dev em cache miss
- Cada sub-workflow tem timeout-minutes e concurrency group próprios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized CI pipeline into reusable workflow components for improved maintainability.
  * Enhanced code quality checks including static analysis and code formatting validation.
  * Updated test execution to run in parallel mode for faster feedback cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->