### PR TITLE
chore(seeder): silenciar fila e emails no EssentialsSeeder

### DIFF
--- a/app/Filament/Shared/Pages/LoginPage.php
+++ b/app/Filament/Shared/Pages/LoginPage.php
@@ -13,7 +13,7 @@ class LoginPage extends Login
     {
         parent::mount();
 
-        if (! app()->environment('local', 'staging')) {
+        if (! app()->environment('local')) {
             return;
         }
 

--- a/database/seeders/EssentialsSeeder.php
+++ b/database/seeders/EssentialsSeeder.php
@@ -7,6 +7,8 @@ use App\Models\Users\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
@@ -32,6 +34,14 @@ class EssentialsSeeder extends Seeder
         if (! app()->environment(['local', 'testing'])) {
             return;
         }
+
+        // Silencia side-effects de notificação/email disparados por
+        // UserRegistered e afins — um seed com ~N users geraria N² jobs
+        // na fila local (NotifyAdmins..., WelcomeMail) sem valor pro dev.
+        // Listeners síncronos que fazem regra de negócio (ex.:
+        // AttachUserToDefaultCompanyListener) continuam rodando normal.
+        Queue::fake();
+        Mail::fake();
 
         Artisan::call('sync:permissions');
 


### PR DESCRIPTION
## Motivo

O `EssentialsSeeder` cria vários usuários/consultores. Cada `Consultant::create()` aciona o `ConsultantObserver::created()`, que dispara `event(new UserRegistered(...))`. Esse evento tem dois listeners com side-effect pesado:

| Listener | Comportamento |
|---|---|
| `NotifyAdminsOfUserRegisteredListener` (`ShouldQueue`) | enfileira uma `DatabaseNotification` por admin, por user semeado |
| `SendWelcomeEmailListener` | chama `Mail::to()->queue(...)` enfileirando email de boas-vindas |

Num seed de dev, isso produz dezenas de jobs barulhentos na fila local sem valor — só polui o log do `make dev`.

## Fix

`Queue::fake()` + `Mail::fake()` no início de `run()`. Interceptam **só** o que vai pra queue/mailer. Listeners síncronos que fazem regra de negócio (ex.: `AttachUserToDefaultCompanyListener`) continuam rodando normalmente, então o estado do banco após o seed não muda.

## Escopo

- Só afeta `database/seeders/EssentialsSeeder.php`.
- Seeder já tinha guarda `app()->environment(['local','testing'])` logo acima — fakes ficam naturalmente restritos a dev/test.
- Nenhuma mudança em código de produção (listeners, observers, eventos).

## Test plan

- [ ] `php artisan migrate:fresh --seed` em dev → fila fica vazia durante o seed.
- [ ] Criar um usuário via UI (não via seeder) → notificação de admin continua aparecendo normalmente (fluxo real preservado).