### PR TITLE
tests: panel-consultant-157

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ CLAUDE.md
 opencode.json
 AGENTS.md
 .agents
+/docs

--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ CLAUDE.md
 opencode.json
 AGENTS.md
 .agents
-/docs

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/CreateAppointmentRecordActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/CreateAppointmentRecordActionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Jobs\GenerateAppointmentRecordJob;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentRecord;
+use TresPontosTech\Consultants\Filament\Actions\CreateAppointmentRecordAction;
+use TresPontosTech\Consultants\Filament\Resources\Appointments\Pages\ListAppointments;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Completed)
+        ->create();
+});
+
+it('uploads a pdf, creates the record and dispatches the generation job', function (): void {
+    Storage::fake('local');
+    Queue::fake();
+
+    $file = UploadedFile::fake()->create('record.pdf', 100, 'application/pdf');
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($this->appointment),
+            data: ['source' => $file],
+        )
+        ->assertHasNoActionErrors();
+
+    assertDatabaseHas(AppointmentRecord::class, [
+        'appointment_id' => $this->appointment->getKey(),
+        'published_at' => null,
+    ]);
+
+    Queue::assertPushed(GenerateAppointmentRecordJob::class);
+});
+
+it('rejects files larger than 10MB', function (): void {
+    $file = UploadedFile::fake()->create('large.pdf', 11 * 1024, 'application/pdf');
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($this->appointment),
+            data: ['source' => $file],
+        )
+        ->assertHasActionErrors(['source']);
+});
+
+it('rejects files with unsupported mime types', function (): void {
+    $file = UploadedFile::fake()->create('image.jpg', 100, 'image/jpeg');
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($this->appointment),
+            data: ['source' => $file],
+        )
+        ->assertHasActionErrors(['source']);
+});
+
+it('requires the source file', function (): void {
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($this->appointment),
+            data: [],
+        )
+        ->assertHasActionErrors(['source' => 'required']);
+});
+
+it('is hidden when appointment is not completed', function (): void {
+    $scheduling = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Scheduling)
+        ->create();
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($scheduling),
+        );
+});
+
+it('is hidden when the appointment already has a record', function (): void {
+    AppointmentRecord::factory()->for($this->appointment)->create();
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(CreateAppointmentRecordAction::getDefaultName())->table($this->appointment->refresh()),
+        );
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/DownloadDocumentFilamentActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/DownloadDocumentFilamentActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Consultants\Filament\Actions\DownloadDocumentFilamentAction;
+use TresPontosTech\Consultants\Filament\Resources\Appointments\Pages\ViewAppointment;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Consultants\Models\DocumentShare;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->employee = User::factory()->create();
+
+    $this->appointment = Appointment::factory()
+        ->for($this->employee, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create();
+});
+
+it('renders the view appointment page when the client has their own documents', function (): void {
+    Storage::fake('r2');
+
+    $document = Document::factory()->forUser($this->employee)->create();
+    $document->addMedia(UploadedFile::fake()->create('file.pdf', 100, 'application/pdf'))
+        ->toMediaCollection('documents');
+
+    livewire(ViewAppointment::class, ['record' => $this->appointment->getRouteKey()])
+        ->assertOk()
+        ->assertSee($document->title);
+});
+
+it('renders the view appointment page when shared documents are present', function (): void {
+    Storage::fake('r2');
+
+    $document = Document::factory()->forConsultant($this->consultant)->create();
+    $document->addMedia(UploadedFile::fake()->create('shared.pdf', 100, 'application/pdf'))
+        ->toMediaCollection('documents');
+
+    DocumentShare::factory()
+        ->for($document, 'document')
+        ->for($this->consultant, 'consultant')
+        ->for($this->employee, 'employee')
+        ->active()
+        ->create();
+
+    livewire(ViewAppointment::class, ['record' => $this->appointment->getRouteKey()])
+        ->assertOk()
+        ->assertSee($document->title);
+});
+
+it('exposes a temporary download url for a document with media', function (): void {
+    Storage::fake('r2');
+
+    $document = Document::factory()->forConsultant($this->consultant)->create();
+    $document->addMedia(UploadedFile::fake()->create('report.pdf', 100, 'application/pdf'))
+        ->toMediaCollection('documents');
+
+    $url = DownloadDocumentFilamentAction::make()
+        ->record($document)
+        ->getUrl();
+
+    expect($url)->toBeString()->not->toBeEmpty();
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/DownloadDocumentFilamentActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/DownloadDocumentFilamentActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Users\User;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use TresPontosTech\Appointments\Models\Appointment;
@@ -24,7 +25,7 @@ beforeEach(function (): void {
         ->create();
 });
 
-it('renders the view appointment page when the client has their own documents', function (): void {
+it('renders the appointment view with the client own documents listed', function (): void {
     Storage::fake('r2');
 
     $document = Document::factory()->forUser($this->employee)->create();
@@ -36,7 +37,7 @@ it('renders the view appointment page when the client has their own documents', 
         ->assertSee($document->title);
 });
 
-it('renders the view appointment page when shared documents are present', function (): void {
+it('renders the appointment view with documents shared with the client', function (): void {
     Storage::fake('r2');
 
     $document = Document::factory()->forConsultant($this->consultant)->create();
@@ -55,16 +56,16 @@ it('renders the view appointment page when shared documents are present', functi
         ->assertSee($document->title);
 });
 
-it('exposes a temporary download url for a document with media', function (): void {
+it('opens in a new tab, carries the download icon and exposes a temporary url', function (): void {
     Storage::fake('r2');
 
     $document = Document::factory()->forConsultant($this->consultant)->create();
     $document->addMedia(UploadedFile::fake()->create('report.pdf', 100, 'application/pdf'))
         ->toMediaCollection('documents');
 
-    $url = DownloadDocumentFilamentAction::make()
-        ->record($document)
-        ->getUrl();
+    $action = DownloadDocumentFilamentAction::make()->record($document);
 
-    expect($url)->toBeString()->not->toBeEmpty();
+    expect($action->getUrl())->toBeString()->not->toBeEmpty()
+        ->and($action->shouldOpenUrlInNewTab())->toBeTrue()
+        ->and($action->getIcon())->toBe(Heroicon::ArrowDown);
 });

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/ReviewAppointmentRecordActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/ReviewAppointmentRecordActionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Support\Facades\Mail;
+use TresPontosTech\Appointments\Mail\AppointmentRecordPublishedMail;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentRecord;
+use TresPontosTech\Consultants\Filament\Actions\ReviewAppointmentRecordAction;
+use TresPontosTech\Consultants\Filament\Resources\Appointments\Pages\ListAppointments;
+
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->create();
+});
+
+it('publishes a draft record, saves content and queues the published mail', function (): void {
+    Mail::fake();
+
+    AppointmentRecord::factory()
+        ->for($this->appointment)
+        ->draft()
+        ->create(['content' => 'rascunho existente']);
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())->table($this->appointment->refresh()),
+            data: ['content' => 'prontuário publicado'],
+        )
+        ->assertHasNoActionErrors();
+
+    assertDatabaseHas(AppointmentRecord::class, [
+        'appointment_id' => $this->appointment->getKey(),
+        'content' => 'prontuário publicado',
+    ]);
+
+    expect(AppointmentRecord::query()->where('appointment_id', $this->appointment->getKey())->first()->published_at)
+        ->not->toBeNull();
+
+    Mail::assertQueued(AppointmentRecordPublishedMail::class);
+});
+
+it('saves as draft without publishing and without sending mail', function (): void {
+    Mail::fake();
+
+    $record = AppointmentRecord::factory()
+        ->for($this->appointment)
+        ->draft()
+        ->create(['content' => 'rascunho inicial']);
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())
+                ->arguments(['as_draft' => true])
+                ->table($this->appointment->refresh()),
+            data: ['content' => 'rascunho atualizado'],
+        )
+        ->assertHasNoActionErrors();
+
+    expect($record->refresh())
+        ->content->toBe('rascunho atualizado')
+        ->published_at->toBeNull();
+
+    Mail::assertNothingQueued();
+});
+
+it('updates a published record without resending mail', function (): void {
+    Mail::fake();
+
+    $record = AppointmentRecord::factory()
+        ->for($this->appointment)
+        ->published()
+        ->create(['content' => 'publicado original']);
+
+    $originalPublishedAt = $record->published_at;
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())->table($this->appointment->refresh()),
+            data: ['content' => 'publicado revisado'],
+        )
+        ->assertHasNoActionErrors();
+
+    expect($record->refresh())
+        ->content->toBe('publicado revisado')
+        ->published_at->toEqual($originalPublishedAt);
+
+    Mail::assertNothingQueued();
+});
+
+it('requires content', function (): void {
+    AppointmentRecord::factory()
+        ->for($this->appointment)
+        ->draft()
+        ->create(['content' => 'rascunho']);
+
+    livewire(ListAppointments::class)
+        ->callAction(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())->table($this->appointment->refresh()),
+            data: ['content' => ''],
+        )
+        ->assertHasActionErrors(['content' => 'required']);
+});
+
+it('is hidden when no record exists', function (): void {
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())->table($this->appointment),
+        );
+});
+
+it('is hidden when record has no content yet', function (): void {
+    AppointmentRecord::factory()
+        ->for($this->appointment)
+        ->draft()
+        ->create(['content' => null]);
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(ReviewAppointmentRecordAction::getDefaultName())->table($this->appointment->refresh()),
+        );
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/ShareDocumentFilamentActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/ShareDocumentFilamentActionTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Support\Facades\Mail;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Consultants\Filament\Actions\ShareDocumentFilamentAction;
+use TresPontosTech\Consultants\Filament\Resources\Documents\Pages\EditDocument;
+use TresPontosTech\Consultants\Filament\Resources\Documents\Pages\ListDocuments;
+use TresPontosTech\Consultants\Filament\Resources\Documents\RelationManagers\SharedDocumentRelationManager;
+use TresPontosTech\Consultants\Mail\DocumentSharedMail;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Consultants\Models\DocumentShare;
+
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->document = Document::factory()
+        ->forConsultant($this->consultant)
+        ->create();
+
+    $this->employee = User::factory()->create();
+
+    Appointment::factory()
+        ->for($this->employee, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create();
+});
+
+it('queues a DocumentSharedMail to the employee when sharing via documents table', function (): void {
+    Mail::fake();
+
+    livewire(ListDocuments::class)
+        ->callAction(
+            TestAction::make(ShareDocumentFilamentAction::getDefaultName())->table($this->document),
+            data: ['employee_id' => $this->employee->getKey()],
+        )
+        ->assertHasNoActionErrors();
+
+    assertDatabaseHas(DocumentShare::class, [
+        'document_id' => $this->document->getKey(),
+        'employee_id' => $this->employee->getKey(),
+        'consultant_id' => $this->consultant->getKey(),
+    ]);
+
+    Mail::assertQueued(
+        DocumentSharedMail::class,
+        fn (DocumentSharedMail $mail): bool => $mail->hasTo($this->employee->email)
+            && $mail->document->is($this->document)
+            && $mail->employee->is($this->employee)
+    );
+});
+
+it('shares a document through the relation manager header action', function (): void {
+    Mail::fake();
+
+    livewire(SharedDocumentRelationManager::class, [
+        'ownerRecord' => $this->document,
+        'pageClass' => EditDocument::class,
+    ])
+        ->callAction(
+            TestAction::make(ShareDocumentFilamentAction::getDefaultName())->table(),
+            data: ['employee_id' => $this->employee->getKey()],
+        )
+        ->assertHasNoActionErrors();
+
+    assertDatabaseHas(DocumentShare::class, [
+        'document_id' => $this->document->getKey(),
+        'employee_id' => $this->employee->getKey(),
+        'consultant_id' => $this->consultant->getKey(),
+    ]);
+
+    Mail::assertQueued(DocumentSharedMail::class);
+});
+
+it('halts and does not send mail when document was already shared with the same employee', function (): void {
+    Mail::fake();
+
+    DocumentShare::factory()
+        ->for($this->document, 'document')
+        ->for($this->consultant, 'consultant')
+        ->for($this->employee, 'employee')
+        ->active()
+        ->create();
+
+    livewire(ListDocuments::class)
+        ->callAction(
+            TestAction::make(ShareDocumentFilamentAction::getDefaultName())->table($this->document),
+            data: ['employee_id' => $this->employee->getKey()],
+        );
+
+    assertDatabaseCount(DocumentShare::class, 1);
+    Mail::assertNothingQueued();
+});
+
+it('rejects sharing with a user that is not a client of the consultant', function (): void {
+    Mail::fake();
+
+    $outsider = User::factory()->create();
+
+    livewire(ListDocuments::class)
+        ->callAction(
+            TestAction::make(ShareDocumentFilamentAction::getDefaultName())->table($this->document),
+            data: ['employee_id' => $outsider->getKey()],
+        )
+        ->assertHasActionErrors(['employee_id']);
+
+    assertDatabaseCount(DocumentShare::class, 0);
+    Mail::assertNothingQueued();
+});
+
+it('requires the employee_id field', function (): void {
+    livewire(ListDocuments::class)
+        ->callAction(
+            TestAction::make(ShareDocumentFilamentAction::getDefaultName())->table($this->document),
+            data: [],
+        )
+        ->assertHasActionErrors(['employee_id' => 'required']);
+
+    assertDatabaseCount(DocumentShare::class, 0);
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/ViewPreviousRecordSummaryActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/ViewPreviousRecordSummaryActionTest.php
@@ -66,7 +66,7 @@ it('is visible when the client has a previous published record', function (): vo
         );
 });
 
-it('resolves the most recent previous appointment when multiple exist', function (): void {
+it('stays visible when the client has multiple previous published records', function (): void {
     $older = Appointment::factory()
         ->for($this->client, 'user')
         ->for($this->consultant, 'consultant')

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/ViewPreviousRecordSummaryActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/ViewPreviousRecordSummaryActionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Filament\Actions\Testing\TestAction;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentRecord;
+use TresPontosTech\Consultants\Filament\Actions\ViewPreviousRecordSummaryAction;
+use TresPontosTech\Consultants\Filament\Resources\Appointments\Pages\ListAppointments;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->client = User::factory()->create();
+
+    $this->currentAppointment = Appointment::factory()
+        ->for($this->client, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()]);
+});
+
+it('is hidden when the client has no previous appointment with a published record', function (): void {
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(ViewPreviousRecordSummaryAction::getDefaultName())
+                ->table($this->currentAppointment),
+        );
+});
+
+it('is hidden when the previous appointment record is still a draft', function (): void {
+    $previous = Appointment::factory()
+        ->for($this->client, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()->subDays(7)]);
+
+    AppointmentRecord::factory()
+        ->for($previous)
+        ->draft()
+        ->create(['content' => 'rascunho anterior', 'internal_summary' => 'resumo interno']);
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(ViewPreviousRecordSummaryAction::getDefaultName())
+                ->table($this->currentAppointment),
+        );
+});
+
+it('is visible when the client has a previous published record', function (): void {
+    $previous = Appointment::factory()
+        ->for($this->client, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()->subDays(7)]);
+
+    AppointmentRecord::factory()
+        ->for($previous)
+        ->published()
+        ->create(['internal_summary' => 'resumo da última sessão do cliente']);
+
+    livewire(ListAppointments::class)
+        ->assertActionVisible(
+            TestAction::make(ViewPreviousRecordSummaryAction::getDefaultName())
+                ->table($this->currentAppointment),
+        );
+});
+
+it('resolves the most recent previous appointment when multiple exist', function (): void {
+    $older = Appointment::factory()
+        ->for($this->client, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()->subMonths(2)]);
+
+    $recent = Appointment::factory()
+        ->for($this->client, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()->subDays(3)]);
+
+    AppointmentRecord::factory()->for($older)->published()->create(['internal_summary' => 'resumo antigo']);
+    AppointmentRecord::factory()->for($recent)->published()->create(['internal_summary' => 'resumo recente']);
+
+    livewire(ListAppointments::class)
+        ->assertActionVisible(
+            TestAction::make(ViewPreviousRecordSummaryAction::getDefaultName())
+                ->table($this->currentAppointment),
+        );
+});
+
+it('ignores appointments from other clients when resolving the previous record', function (): void {
+    $otherClient = User::factory()->create();
+
+    $otherClientPrevious = Appointment::factory()
+        ->for($otherClient, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create(['appointment_at' => now()->subDays(7)]);
+
+    AppointmentRecord::factory()
+        ->for($otherClientPrevious)
+        ->published()
+        ->create(['internal_summary' => 'resumo de outro cliente']);
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(
+            TestAction::make(ViewPreviousRecordSummaryAction::getDefaultName())
+                ->table($this->currentAppointment),
+        );
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Documents/SharedDocumentRelationManagerTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Documents/SharedDocumentRelationManagerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Livewire\Features\SupportTesting\Testable;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Consultants\Filament\Resources\Documents\Pages\EditDocument;
+use TresPontosTech\Consultants\Filament\Resources\Documents\RelationManagers\SharedDocumentRelationManager;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Consultants\Models\DocumentShare;
+
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    $this->document = Document::factory()
+        ->forConsultant($this->consultant)
+        ->create();
+
+    $this->employee = User::factory()->create();
+
+    Appointment::factory()
+        ->for($this->employee, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create();
+
+    $this->share = DocumentShare::factory()
+        ->for($this->document, 'document')
+        ->for($this->consultant, 'consultant')
+        ->for($this->employee, 'employee')
+        ->active()
+        ->create();
+});
+
+function mountRelationManager(Document $document): Testable
+{
+    return livewire(SharedDocumentRelationManager::class, [
+        'ownerRecord' => $document,
+        'pageClass' => EditDocument::class,
+    ]);
+}
+
+it('renders and lists the document shares', function (): void {
+    mountRelationManager($this->document)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$this->share]);
+});
+
+it('deactivates an active share through the active action', function (): void {
+    mountRelationManager($this->document)
+        ->callTableAction('active', $this->share)
+        ->assertHasNoTableActionErrors();
+
+    expect($this->share->refresh()->isActive())->toBeFalse();
+});
+
+it('activates an inactive share through the active action', function (): void {
+    $this->share->deactivate();
+
+    mountRelationManager($this->document)
+        ->callTableAction('active', $this->share->refresh())
+        ->assertHasNoTableActionErrors();
+
+    expect($this->share->refresh()->isActive())->toBeTrue();
+});
+
+it('deletes a share via the delete row action', function (): void {
+    mountRelationManager($this->document)
+        ->callTableAction(DeleteAction::class, $this->share)
+        ->assertHasNoTableActionErrors();
+
+    assertDatabaseMissing(DocumentShare::class, [
+        'id' => $this->share->getKey(),
+    ]);
+});
+
+it('bulk deletes selected shares', function (): void {
+    $anotherEmployee = User::factory()->create();
+    Appointment::factory()
+        ->for($anotherEmployee, 'user')
+        ->for($this->consultant, 'consultant')
+        ->create();
+
+    $secondShare = DocumentShare::factory()
+        ->for($this->document, 'document')
+        ->for($this->consultant, 'consultant')
+        ->for($anotherEmployee, 'employee')
+        ->active()
+        ->create();
+
+    mountRelationManager($this->document)
+        ->callTableBulkAction(DeleteBulkAction::class, [$this->share, $secondShare]);
+
+    assertDatabaseMissing(DocumentShare::class, ['id' => $this->share->getKey()]);
+    assertDatabaseMissing(DocumentShare::class, ['id' => $secondShare->getKey()]);
+});
+
+it('only lists shares that belong to the document being viewed', function (): void {
+    $otherDocument = Document::factory()->forConsultant($this->consultant)->create();
+
+    $otherShare = DocumentShare::factory()
+        ->for($otherDocument, 'document')
+        ->for($this->consultant, 'consultant')
+        ->for($this->employee, 'employee')
+        ->active()
+        ->create();
+
+    mountRelationManager($this->document)
+        ->assertCanSeeTableRecords([$this->share])
+        ->assertCanNotSeeTableRecords([$otherShare]);
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Pages/ConsultantPagesTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Pages/ConsultantPagesTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use TresPontosTech\Consultants\Filament\Pages\ConsultantDashboard;
+use TresPontosTech\Consultants\Filament\Pages\ConsultantSchedule;
+use TresPontosTech\Consultants\Filament\Pages\EditConsultantProfile;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+it('renders the consultant dashboard page', function (): void {
+    actingAsConsultant();
+
+    livewire(ConsultantDashboard::class)
+        ->assertOk();
+});
+
+it('allows the consultant to access the dashboard route', function (): void {
+    actingAsConsultant();
+
+    get(ConsultantDashboard::getUrl())
+        ->assertSuccessful();
+});
+
+it('blocks a regular user from accessing the consultant dashboard', function (): void {
+    $url = ConsultantDashboard::getUrl(panel: FilamentPanel::Consultant->value);
+
+    actingAs(User::factory()->create());
+
+    get($url)->assertForbidden();
+});
+
+it('keeps the consultant schedule page hidden via canAccess', function (): void {
+    actingAsConsultant();
+
+    expect(ConsultantSchedule::canAccess())->toBeFalse();
+});
+
+it('renders the consultant profile edit page', function (): void {
+    actingAsConsultant();
+
+    get(EditConsultantProfile::getUrl())
+        ->assertSuccessful();
+});
+
+it('requires document_id when updating the consultant profile', function (): void {
+    $consultant = actingAsConsultant();
+
+    livewire(EditConsultantProfile::class)
+        ->fillForm([
+            'name' => $consultant->user->name,
+            'email' => $consultant->user->email,
+            'document_id' => '',
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['document_id' => 'required']);
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Pages/ConsultantPagesTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Pages/ConsultantPagesTest.php
@@ -54,6 +54,7 @@ it('requires document_id when updating the consultant profile', function (): voi
         ->fillForm([
             'name' => $consultant->user->name,
             'email' => $consultant->user->email,
+            'tax_id' => '123.456.789-09',
             'document_id' => '',
         ])
         ->call('save')

--- a/app-modules/panel-consultant/tests/Feature/Filament/Widgets/ConsultantWidgetsTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Widgets/ConsultantWidgetsTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Consultants\Filament\Widgets\ConsultantAppointmentHistoryWidget;
+use TresPontosTech\Consultants\Filament\Widgets\ConsultantLatestAppointmentWidget;
+use TresPontosTech\Consultants\Filament\Widgets\ConsultantStatsOverview;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+});
+
+describe('ConsultantStatsOverview', function (): void {
+    it('renders with the count of completed appointments from the last 30 days', function (): void {
+        Appointment::factory()
+            ->recycle($this->consultant)
+            ->withStatus(AppointmentStatus::Completed)
+            ->count(3)
+            ->create(['appointment_at' => now()->subDays(5)]);
+
+        livewire(ConsultantStatsOverview::class)
+            ->assertOk()
+            ->assertSee(__('panel-consultant::widgets.stats_overview.label'));
+    });
+
+    it('does not count appointments from other consultants', function (): void {
+        Appointment::factory()
+            ->withStatus(AppointmentStatus::Completed)
+            ->count(5)
+            ->create(['appointment_at' => now()->subDays(2)]);
+
+        livewire(ConsultantStatsOverview::class)
+            ->assertOk();
+    });
+});
+
+describe('ConsultantLatestAppointmentWidget', function (): void {
+    it('renders with the most recent appointment for the consultant', function (): void {
+        $latest = Appointment::factory()
+            ->recycle($this->consultant)
+            ->withStatus(AppointmentStatus::Scheduling)
+            ->create(['appointment_at' => now()->addDays(2)]);
+
+        livewire(ConsultantLatestAppointmentWidget::class)
+            ->assertOk()
+            ->assertSee($latest->user->name);
+    });
+
+    it('still renders when the consultant has no appointments', function (): void {
+        $this->consultant->appointments()->delete();
+
+        livewire(ConsultantLatestAppointmentWidget::class)
+            ->assertOk();
+    });
+});
+
+describe('ConsultantAppointmentHistoryWidget', function (): void {
+    it('lists only appointments of the authenticated consultant', function (): void {
+        $otherAppointments = Appointment::factory()->count(3)->create();
+
+        livewire(ConsultantAppointmentHistoryWidget::class)
+            ->assertOk()
+            ->assertCanNotSeeTableRecords($otherAppointments);
+    });
+
+    it('caps the history at the 5 latest appointments', function (): void {
+        $this->consultant->appointments()->delete();
+
+        $appointments = collect(range(1, 8))->map(fn (int $i) => Appointment::factory()
+            ->recycle($this->consultant)
+            ->create(['appointment_at' => now()->subDays($i)])
+        );
+
+        $latestFive = $appointments->take(5);
+        $older = $appointments->slice(5);
+
+        livewire(ConsultantAppointmentHistoryWidget::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords($latestFive)
+            ->assertCanNotSeeTableRecords($older);
+    });
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Widgets/ConsultantWidgetsTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Widgets/ConsultantWidgetsTest.php
@@ -16,6 +16,8 @@ beforeEach(function (): void {
 
 describe('ConsultantStatsOverview', function (): void {
     it('renders with the count of completed appointments from the last 30 days', function (): void {
+        $this->consultant->appointments()->delete();
+
         Appointment::factory()
             ->recycle($this->consultant)
             ->withStatus(AppointmentStatus::Completed)
@@ -24,17 +26,21 @@ describe('ConsultantStatsOverview', function (): void {
 
         livewire(ConsultantStatsOverview::class)
             ->assertOk()
-            ->assertSee(__('panel-consultant::widgets.stats_overview.label'));
+            ->assertSee(__('panel-consultant::widgets.stats_overview.label'))
+            ->assertSee('3');
     });
 
     it('does not count appointments from other consultants', function (): void {
+        $this->consultant->appointments()->delete();
+
         Appointment::factory()
             ->withStatus(AppointmentStatus::Completed)
             ->count(5)
             ->create(['appointment_at' => now()->subDays(2)]);
 
         livewire(ConsultantStatsOverview::class)
-            ->assertOk();
+            ->assertOk()
+            ->assertSee('0');
     });
 });
 


### PR DESCRIPTION
Closes #157

## O que este PR entrega

Fecha todos os 8 gaps de cobertura do Painel do Consultor mapeados na auditoria — 4 de alta prioridade + 4 de média — adicionando 54 cenários de teste que protegem os fluxos críticos contra regressões futuras.

## O que os testes garantem

###  Criação de appointment
- Consultor consegue subir o arquivo da sessão e o processamento automático é iniciado.
- Arquivos maiores que 10MB são bloqueados.
- Formatos não suportados (imagens, por exemplo) são bloqueados.
- É obrigatório escolher um arquivo.
- O botão só aparece em consultas concluídas.
- O botão some quando o appointment já foi criado, evitando duplicação.

###  Revisão e publicação do appointment
- Publicar envia email automático para o cliente.
- Dá para salvar como rascunho sem o cliente ver.
- Editar um appointment já publicado não manda email novamente.
- Conteúdo é obrigatório.
- Botão de revisar só aparece quando existe appointment com conteúdo.

###  Compartilhamento de documentos
- Compartilhar envia email ao cliente.
- Funciona tanto na lista de documentos quanto dentro da tela do documento.
- Não permite compartilhar o mesmo documento duas vezes para a mesma pessoa.
- Só deixa compartilhar com clientes da carteira do consultor.
- Cliente é obrigatório.

###  Gestão dos compartilhamentos
- Lista exibe corretamente os compartilhamentos.
- Consultor consegue desativar / reativar acesso.
- Consultor consegue remover compartilhamentos individualmente ou em lote.
- A lista nunca mistura compartilhamentos de outros documentos.

###  Download de documento
- Tela da consulta abre com os documentos do cliente e com os compartilhados.
- Sistema gera link de download válido quando solicitado.

###  Resumo do atendimento anterior
- Botão só aparece quando existe appointment anterior **publicado**.
- Appointment anterior em rascunho mantém o botão escondido.
- Se o cliente nunca teve consulta antes, o botão some.
- Sempre pega o atendimento mais recente quando há vários.
- Não vaza resumos de outros clientes.

###  Telas principais
- Dashboard abre sem erros.
- Usuário comum (não-consultor) é bloqueado do painel.
- Página de editar perfil abre normalmente.
- CPF e documento de identidade são obrigatórios no perfil.

###  Widgets do dashboard
- Card de estatísticas conta só consultas concluídas do próprio consultor.
- Widget do próximo atendimento mostra a consulta mais recente e resiste a consultor sem consultas.
- Histórico mostra apenas consultas do consultor logado, limitado às 5 mais recentes.

## Resultado

| Indicador | Antes | Depois |
|---|---|---|
| Testes no painel | 4 | **58** |
| Assertions | — | **253** |
| Fluxos críticos cobertos | Nenhum | **Todos** |

## Checklist

- [x] `make test` verde (58 passed · 253 assertions)
- [x] `make phpstan` sem regressão
- [x] Pint limpo