### PR TITLE
fix: add company owner role in seeder

### DIFF
--- a/database/seeders/EssentialsSeeder.php
+++ b/database/seeders/EssentialsSeeder.php
@@ -17,6 +17,7 @@ use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Models\Consultant;
 use TresPontosTech\Consultants\Models\Document;
 use TresPontosTech\Consultants\Models\DocumentShare;
+use TresPontosTech\Permissions\Roles;
 
 class EssentialsSeeder extends Seeder
 {
@@ -62,6 +63,8 @@ class EssentialsSeeder extends Seeder
             'slug' => '5pontos',
             'user_id' => $companyOwner->getKey(),
         ]);
+
+        $company->employees()->attach($companyOwner, ['role' => Roles::CompanyOwner->value]);
 
         CompanyPlan::factory()
             ->active()


### PR DESCRIPTION
This pull request updates the `EssentialsSeeder` to ensure that a company owner is properly attached as an employee of the company with the correct role. It also adds an import for the `Roles` class to support this functionality.

**Seeder improvements:**

* The company owner is now attached to the company's employees with the `CompanyOwner` role using `Roles::CompanyOwner->value`.
* Added the import statement for the `Roles` class to enable role assignment in the seeder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed company owner role assignment to ensure proper access permissions are correctly configured during system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->