### PR TITLE
test(appointments): assertar despacho de eventos de domínio nos steps

### DIFF
--- a/app-modules/appointments/tests/Feature/Actions/AppointmentActiveStepTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/AppointmentActiveStepTest.php
@@ -1,15 +1,18 @@
 <?php
 
 use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification as LaravelNotification;
 use TresPontosTech\Appointments\Actions\StateMachine\AppointmentActiveStep;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Events\AppointmentCompleted;
 use TresPontosTech\Appointments\Models\Appointment;
 
 use function Pest\Laravel\actingAs;
 
 beforeEach(function (): void {
     LaravelNotification::fake();
+    Event::fake();
     $this->appointment = Appointment::factory()->withStatus(AppointmentStatus::Active)->create();
     actingAs($this->appointment->user);
 });
@@ -20,6 +23,7 @@ it('should process step to Scheduling status', function (): void {
 
     $this->appointment->refresh();
     expect($this->appointment->status)->toBe(AppointmentStatus::Completed);
+    Event::assertDispatched(AppointmentCompleted::class);
 });
 
 it('should notify user', function (): void {

--- a/app-modules/appointments/tests/Feature/Actions/AppointmentCancelCalendarTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/AppointmentCancelCalendarTest.php
@@ -1,9 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification as LaravelNotification;
 use TresPontosTech\Appointments\Actions\StateMachine\AppointmentSchedulingStep;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Events\AppointmentCancelled;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\IntegrationGoogleCalendar\Jobs\DeleteAppointmentCalendarEventJob;
 
@@ -12,6 +14,7 @@ use function Pest\Laravel\actingAs;
 beforeEach(function (): void {
     LaravelNotification::fake();
     Bus::fake();
+    Event::fake();
 });
 
 it('dispatches DeleteAppointmentCalendarEventJob on cancel when google_event_id exists', function (): void {
@@ -27,6 +30,7 @@ it('dispatches DeleteAppointmentCalendarEventJob on cancel when google_event_id 
     Bus::assertDispatched(DeleteAppointmentCalendarEventJob::class, function ($job) use ($appointment): bool {
         return $job->appointment->id === $appointment->id;
     });
+    Event::assertDispatched(AppointmentCancelled::class);
 
     expect($appointment->refresh()->status)->toBe(AppointmentStatus::Cancelled);
 });
@@ -42,6 +46,7 @@ it('does not dispatch delete job when google_event_id is null', function (): voi
     $step->cancel();
 
     Bus::assertNotDispatched(DeleteAppointmentCalendarEventJob::class);
+    Event::assertDispatched(AppointmentCancelled::class);
 
     expect($appointment->refresh()->status)->toBe(AppointmentStatus::Cancelled);
 });

--- a/app-modules/appointments/tests/Feature/Actions/AppointmentDraftStepTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/AppointmentDraftStepTest.php
@@ -1,15 +1,18 @@
 <?php
 
 use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification as LaravelNotification;
 use TresPontosTech\Appointments\Actions\StateMachine\AppointmentDraftStep;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Events\AppointmentCancelled;
 use TresPontosTech\Appointments\Models\Appointment;
 
 use function Pest\Laravel\actingAs;
 
 beforeEach(function (): void {
     LaravelNotification::fake();
+    Event::fake();
     $this->appointment = Appointment::factory()->draft()->create();
     actingAs($this->appointment->user);
 });
@@ -38,4 +41,5 @@ it('should cancel', function (): void {
     $this->appointment->refresh();
     expect($this->appointment->status)->toBe(AppointmentStatus::Cancelled);
     Notification::assertNotified(__('appointments::resources.appointments.notifications.cancelled.title'));
+    Event::assertDispatched(AppointmentCancelled::class);
 });

--- a/app-modules/appointments/tests/Feature/Actions/AppointmentSchedulingStepTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/AppointmentSchedulingStepTest.php
@@ -2,9 +2,11 @@
 
 use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification as LaravelNotification;
 use TresPontosTech\Appointments\Actions\StateMachine\AppointmentSchedulingStep;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Events\AppointmentBooked;
 use TresPontosTech\Appointments\Models\Appointment;
 
 use function Pest\Laravel\actingAs;
@@ -12,6 +14,7 @@ use function Pest\Laravel\actingAs;
 beforeEach(function (): void {
     LaravelNotification::fake();
     Bus::fake();
+    Event::fake();
     $this->appointment = Appointment::factory()->withStatus(AppointmentStatus::Scheduling)->create();
     actingAs($this->appointment->user);
 });
@@ -22,6 +25,7 @@ it('should process step to Scheduling status', function (): void {
 
     $this->appointment->refresh();
     expect($this->appointment->status)->toBe(AppointmentStatus::Active);
+    Event::assertDispatched(AppointmentBooked::class);
 });
 
 it('should notify user', function (): void {


### PR DESCRIPTION
Closes #146

Adiciona Event::fake() + Event::assertDispatched() nos testes existentes dos steps da state machine:

- AppointmentCompleted → AppointmentActiveStep::processStep()
- AppointmentBooked    → AppointmentSchedulingStep::processStep()
- AppointmentCancelled → AbstractAppointmentStep::cancel()