### PR TITLE
tests(consultants): cobrir gaps de observers, actions e policies (#149)

### DIFF
--- a/app-modules/consultants/tests/Feature/Actions/UpsertDocumentShareActionTest.php
+++ b/app-modules/consultants/tests/Feature/Actions/UpsertDocumentShareActionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Models\Users\User;
+use TresPontosTech\Consultants\Actions\UpsertDocumentShareAction;
+use TresPontosTech\Consultants\DTOs\DocumentShareDTO;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Consultants\Models\DocumentShare;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+describe('UpsertDocumentShareAction', function (): void {
+    it('creates a new document share with active true', function (): void {
+        $consultant = Consultant::factory()->create();
+        $document = Document::factory()->forConsultant($consultant)->create();
+        $employee = User::factory()->create();
+
+        (new UpsertDocumentShareAction)->execute(
+            new DocumentShareDTO($document->getKey(), $employee->getKey(), $consultant->getKey())
+        );
+
+        expect(DocumentShare::query()->count())->toBe(1);
+        assertDatabaseHas(DocumentShare::class, [
+            'document_id' => $document->getKey(),
+            'employee_id' => $employee->getKey(),
+            'consultant_id' => $consultant->getKey(),
+            'active' => true,
+        ]);
+    });
+
+    it('does not duplicate an existing share', function (): void {
+        $share = DocumentShare::factory()
+            ->for(Document::factory()->withLink())
+            ->create();
+
+        (new UpsertDocumentShareAction)->execute(
+            new DocumentShareDTO($share->document_id, $share->employee_id, $share->consultant_id)
+        );
+
+        expect(DocumentShare::query()->count())->toBe(1);
+    });
+
+    it('does not reactivate a deactivated share', function (): void {
+        $share = DocumentShare::factory()
+            ->for(Document::factory()->withLink())
+            ->notActive()
+            ->create();
+
+        (new UpsertDocumentShareAction)->execute(
+            new DocumentShareDTO($share->document_id, $share->employee_id, $share->consultant_id)
+        );
+
+        expect($share->fresh()->active)->toBeFalse();
+    });
+});

--- a/app-modules/consultants/tests/Feature/Actions/UpsertDocumentShareActionTest.php
+++ b/app-modules/consultants/tests/Feature/Actions/UpsertDocumentShareActionTest.php
@@ -37,7 +37,13 @@ describe('UpsertDocumentShareAction', function (): void {
             new DocumentShareDTO($share->document_id, $share->employee_id, $share->consultant_id)
         );
 
-        expect(DocumentShare::query()->count())->toBe(1);
+        expect(
+            DocumentShare::query()
+                ->where('document_id', $share->document_id)
+                ->where('employee_id', $share->employee_id)
+                ->where('consultant_id', $share->consultant_id)
+                ->count()
+        )->toBe(1);
     });
 
     it('does not reactivate a deactivated share', function (): void {

--- a/app-modules/consultants/tests/Feature/Observers/ConsultantObserverTest.php
+++ b/app-modules/consultants/tests/Feature/Observers/ConsultantObserverTest.php
@@ -33,10 +33,15 @@ describe('ConsultantObserver', function (): void {
     it('does not create duplicate users when two consultants share the same email', function (): void {
         Event::fake([UserRegistered::class]);
 
-        Consultant::factory()->create(['email' => 'shared@example.com']);
-        Consultant::factory()->create(['email' => 'shared@example.com']);
+        $first = Consultant::factory()->create(['email' => 'shared@example.com']);
+        $second = Consultant::factory()->create(['email' => 'shared@example.com']);
 
         Event::assertDispatchedTimes(UserRegistered::class, 2);
-        expect(User::query()->where('email', 'shared@example.com')->count())->toBe(1);
+
+        $sharedUser = User::query()->where('email', 'shared@example.com')->firstOrFail();
+
+        expect(User::query()->where('email', 'shared@example.com')->count())->toBe(1)
+            ->and($first->fresh()->user_id)->toBe($sharedUser->getKey())
+            ->and($second->fresh()->user_id)->toBe($sharedUser->getKey());
     });
 });

--- a/app-modules/consultants/tests/Feature/Observers/ConsultantObserverTest.php
+++ b/app-modules/consultants/tests/Feature/Observers/ConsultantObserverTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Event;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\Permissions\Roles;
+use TresPontosTech\User\Events\UserRegistered;
+
+describe('ConsultantObserver', function (): void {
+    it('reuses existing user with same email', function (): void {
+        Event::fake([UserRegistered::class]);
+
+        $existingUser = User::factory()->create(['email' => 'consultor@example.com']);
+
+        $consultant = Consultant::factory()->create(['email' => 'consultor@example.com']);
+
+        expect(User::query()->where('email', 'consultor@example.com')->count())->toBe(1)
+            ->and($consultant->fresh()->user->getKey())->toBe($existingUser->getKey());
+    });
+
+    it('dispatches UserRegistered with Consultant role', function (): void {
+        Event::fake([UserRegistered::class]);
+
+        $consultant = Consultant::factory()->create();
+
+        Event::assertDispatched(
+            UserRegistered::class,
+            fn (UserRegistered $event): bool => $event->user->email === $consultant->email
+                && $event->role === Roles::Consultant
+        );
+    });
+
+    it('does not create duplicate users when two consultants share the same email', function (): void {
+        Event::fake([UserRegistered::class]);
+
+        Consultant::factory()->create(['email' => 'shared@example.com']);
+        Consultant::factory()->create(['email' => 'shared@example.com']);
+
+        Event::assertDispatchedTimes(UserRegistered::class, 2);
+        expect(User::query()->where('email', 'shared@example.com')->count())->toBe(1);
+    });
+});

--- a/app-modules/consultants/tests/Feature/Observers/MediaObserverTest.php
+++ b/app-modules/consultants/tests/Feature/Observers/MediaObserverTest.php
@@ -25,6 +25,20 @@ describe('MediaObserver', function (): void {
         'xlsx' => ['sheet.xlsx',    DocumentExtensionTypeEnum::XLSX],
     ]);
 
+    it('does not update type for uppercase extension', function (): void {
+        $document = Document::query()->create(['title' => 'test']);
+
+        $media = new Media;
+        $media->model_type = 'documents';
+        $media->collection_name = 'documents';
+        $media->file_name = 'document.PDF';
+        $media->model_id = $document->getKey();
+
+        (new MediaObserver)->created($media);
+
+        expect($document->fresh()->type)->toBeNull();
+    });
+
     it('does not change type for an unrecognized extension', function (): void {
         $document = Document::query()->create(['title' => 'test']);
 

--- a/app-modules/consultants/tests/Feature/Observers/MediaObserverTest.php
+++ b/app-modules/consultants/tests/Feature/Observers/MediaObserverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Consultants\Observers\MediaObserver;
+
+describe('MediaObserver', function (): void {
+    it('updates document type for a valid extension', function (string $fileName, DocumentExtensionTypeEnum $expected): void {
+        $document = Document::query()->create(['title' => 'test']);
+
+        $media = new Media;
+        $media->model_type = 'documents';
+        $media->collection_name = 'documents';
+        $media->file_name = $fileName;
+        $media->model_id = $document->getKey();
+
+        (new MediaObserver)->created($media);
+
+        expect($document->fresh()->type)->toBe($expected);
+    })->with([
+        'pdf' => ['document.pdf',  DocumentExtensionTypeEnum::PDF],
+        'docx' => ['document.docx', DocumentExtensionTypeEnum::Docx],
+        'jpg' => ['image.jpg',     DocumentExtensionTypeEnum::JPG],
+        'xlsx' => ['sheet.xlsx',    DocumentExtensionTypeEnum::XLSX],
+    ]);
+
+    it('does not change type for an unrecognized extension', function (): void {
+        $document = Document::query()->create(['title' => 'test']);
+
+        $media = new Media;
+        $media->model_type = 'documents';
+        $media->collection_name = 'documents';
+        $media->file_name = 'malware.exe';
+        $media->model_id = $document->getKey();
+
+        (new MediaObserver)->created($media);
+
+        expect($document->fresh()->type)->toBeNull();
+    });
+
+    it('ignores media with a different model_type', function (): void {
+        $document = Document::query()->create(['title' => 'test']);
+
+        $media = new Media;
+        $media->model_type = 'consultants';
+        $media->collection_name = 'documents';
+        $media->file_name = 'document.pdf';
+        $media->model_id = $document->getKey();
+
+        (new MediaObserver)->created($media);
+
+        expect($document->fresh()->type)->toBeNull();
+    });
+
+    it('ignores media from a different collection', function (): void {
+        $document = Document::query()->create(['title' => 'test']);
+
+        $media = new Media;
+        $media->model_type = 'documents';
+        $media->collection_name = 'avatar';
+        $media->file_name = 'document.pdf';
+        $media->model_id = $document->getKey();
+
+        (new MediaObserver)->created($media);
+
+        expect($document->fresh()->type)->toBeNull();
+    });
+});

--- a/app-modules/consultants/tests/Feature/Policies/ConsultantPolicyTest.php
+++ b/app-modules/consultants/tests/Feature/Policies/ConsultantPolicyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Gate;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\Permissions\PermissionsEnum;
+use TresPontosTech\Permissions\Roles;
+
+it('allows SuperAdmin to perform all actions', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Roles::SuperAdmin->value);
+
+    $consultant = Consultant::factory()->create();
+
+    expect(Gate::forUser($user)->allows('viewAny', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('view', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('create', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('update', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('delete', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('restore', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('forceDelete', $consultant))->toBeTrue();
+});
+
+it('denies user without permissions on all actions', function (): void {
+    $user = User::factory()->create();
+    $user->syncRoles([]);
+
+    $consultant = Consultant::factory()->create();
+
+    expect(Gate::forUser($user)->denies('viewAny', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('view', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('create', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('update', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('delete', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('restore', $consultant))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('forceDelete', $consultant))->toBeTrue();
+});
+
+it('allows user with viewAny permission to viewAny', function (): void {
+    $user = User::factory()->create();
+    $user->syncRoles([]);
+    $user->givePermissionTo(PermissionsEnum::ViewAny->buildPermissionFor(Consultant::class));
+
+    expect(Gate::forUser($user)->allows('viewAny', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('view', Consultant::factory()->create()))->toBeTrue();
+});
+
+it('allows user with view permission to view', function (): void {
+    $user = User::factory()->create();
+    $user->syncRoles([]);
+    $user->givePermissionTo(PermissionsEnum::View->buildPermissionFor(Consultant::class));
+
+    expect(Gate::forUser($user)->allows('view', Consultant::factory()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('create', Consultant::class))->toBeTrue();
+});
+
+it('allows user with create permission to create', function (): void {
+    $user = User::factory()->create();
+    $user->syncRoles([]);
+    $user->givePermissionTo(PermissionsEnum::Create->buildPermissionFor(Consultant::class));
+
+    expect(Gate::forUser($user)->allows('create', Consultant::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('update', Consultant::factory()->create()))->toBeTrue();
+});

--- a/app-modules/consultants/tests/Feature/Policies/ConsultantPolicyTest.php
+++ b/app-modules/consultants/tests/Feature/Policies/ConsultantPolicyTest.php
@@ -24,6 +24,7 @@ it('allows SuperAdmin to perform all actions', function (): void {
 it('denies user without permissions on all actions', function (): void {
     $user = User::factory()->create();
     $user->syncRoles([]);
+    $user->syncPermissions([]);
 
     $consultant = Consultant::factory()->create();
 
@@ -39,6 +40,7 @@ it('denies user without permissions on all actions', function (): void {
 it('allows user with viewAny permission to viewAny', function (): void {
     $user = User::factory()->create();
     $user->syncRoles([]);
+    $user->syncPermissions([]);
     $user->givePermissionTo(PermissionsEnum::ViewAny->buildPermissionFor(Consultant::class));
 
     expect(Gate::forUser($user)->allows('viewAny', Consultant::class))->toBeTrue()
@@ -48,6 +50,7 @@ it('allows user with viewAny permission to viewAny', function (): void {
 it('allows user with view permission to view', function (): void {
     $user = User::factory()->create();
     $user->syncRoles([]);
+    $user->syncPermissions([]);
     $user->givePermissionTo(PermissionsEnum::View->buildPermissionFor(Consultant::class));
 
     expect(Gate::forUser($user)->allows('view', Consultant::factory()->create()))->toBeTrue()
@@ -57,6 +60,7 @@ it('allows user with view permission to view', function (): void {
 it('allows user with create permission to create', function (): void {
     $user = User::factory()->create();
     $user->syncRoles([]);
+    $user->syncPermissions([]);
     $user->givePermissionTo(PermissionsEnum::Create->buildPermissionFor(Consultant::class));
 
     expect(Gate::forUser($user)->allows('create', Consultant::class))->toBeTrue()

--- a/app-modules/consultants/tests/Feature/Policies/DocumentPolicyTest.php
+++ b/app-modules/consultants/tests/Feature/Policies/DocumentPolicyTest.php
@@ -58,3 +58,35 @@ it('allows user with create permission to create', function (): void {
     expect(Gate::forUser($user)->allows('create', Document::class))->toBeTrue()
         ->and(Gate::forUser($user)->denies('update', Document::factory()->withLink()->create()))->toBeTrue();
 });
+
+it('allows user with update permission to update', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::Update->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('update', Document::factory()->withLink()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('delete', Document::factory()->withLink()->create()))->toBeTrue();
+});
+
+it('allows user with delete permission to delete', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::Delete->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('delete', Document::factory()->withLink()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('forceDelete', Document::factory()->withLink()->create()))->toBeTrue();
+});
+
+it('allows user with restore permission to restore', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::Restore->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('restore', Document::factory()->withLink()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('update', Document::factory()->withLink()->create()))->toBeTrue();
+});
+
+it('allows user with forceDelete permission to forceDelete', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::ForceDelete->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('forceDelete', Document::factory()->withLink()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('restore', Document::factory()->withLink()->create()))->toBeTrue();
+});

--- a/app-modules/consultants/tests/Feature/Policies/DocumentPolicyTest.php
+++ b/app-modules/consultants/tests/Feature/Policies/DocumentPolicyTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Gate;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\Permissions\PermissionsEnum;
+use TresPontosTech\Permissions\Roles;
+
+it('allows SuperAdmin to perform all actions', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Roles::SuperAdmin->value);
+
+    $document = Document::factory()->withLink()->create();
+
+    expect(Gate::forUser($user)->allows('viewAny', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('view', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('create', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('update', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('delete', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('restore', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->allows('forceDelete', $document))->toBeTrue();
+});
+
+it('denies user without permissions on all actions', function (): void {
+    $user = User::factory()->create();
+
+    $document = Document::factory()->withLink()->create();
+
+    expect(Gate::forUser($user)->denies('viewAny', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('view', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('create', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('update', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('delete', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('restore', $document))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('forceDelete', $document))->toBeTrue();
+});
+
+it('allows user with viewAny permission to viewAny', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::ViewAny->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('viewAny', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('view', Document::factory()->withLink()->create()))->toBeTrue();
+});
+
+it('allows user with view permission to view', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::View->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('view', Document::factory()->withLink()->create()))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('create', Document::class))->toBeTrue();
+});
+
+it('allows user with create permission to create', function (): void {
+    $user = User::factory()->create();
+    $user->givePermissionTo(PermissionsEnum::Create->buildPermissionFor(Document::class));
+
+    expect(Gate::forUser($user)->allows('create', Document::class))->toBeTrue()
+        ->and(Gate::forUser($user)->denies('update', Document::factory()->withLink()->create()))->toBeTrue();
+});


### PR DESCRIPTION
Closes #149

## O que foi testado

**Cadastro de consultor**
- Reutiliza o usuário existente quando o e-mail já está cadastrado
- Garante que dois consultores com o mesmo e-mail não geram dois usuários
- Confirma que o evento de registro é disparado com o papel correto

**Upload de arquivo em documento**
- O tipo do documento é atualizado automaticamente conforme a extensão enviada (PDF, DOCX, JPG, XLSX)
- Extensões desconhecidas não alteram o tipo do documento
- Arquivos enviados para outros contextos do sistema são ignorados

**Compartilhamento de documento**
- Um compartilhamento novo é criado como ativo
- Compartilhar com a mesma pessoa duas vezes não gera duplicata
- Um compartilhamento desativado permanece desativado

**Quem pode acessar consultores e documentos**
- Super Admin pode fazer tudo
- Usuário sem permissão não consegue fazer nada
- Permissões são isoladas: ter permissão de listar não dá permissão de ver, ter permissão de ver não dá permissão de criar, e assim por diante