### PR TITLE
test(panel-company): cobrir gaps do panel-company #156

### DIFF
--- a/app-modules/panel-company/tests/Feature/Filament/RegisterCompanyTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/RegisterCompanyTest.php
@@ -55,6 +55,25 @@ it('should assign the authenticated user as the company owner', function (): voi
         ->and(auth()->user()->isCompanyOwner())->toBeTrue();
 });
 
+describe('canView', function (): void {
+    it('cannot access the register page when the company tenant is already subscribed', function (): void {
+        $company = Company::factory()->for($this->user, 'owner')->create();
+        $company->subscriptions()->create([
+            'type' => 'company',
+            'stripe_id' => 'sub_already_subscribed',
+            'stripe_status' => 'active',
+        ]);
+
+        filament()->setTenant($company);
+
+        expect(RegisterTenant::canView())->toBeFalse();
+    });
+
+    it('can access the register page when no tenant is set', function (): void {
+        expect(RegisterTenant::canView())->toBeTrue();
+    });
+});
+
 describe('validation tests', function (): void {
     test('name::field', function ($rule, $value): void {
         actingAs(User::factory()->createOneQuietly());

--- a/app-modules/panel-company/tests/Feature/Filament/TenantSeatsCounterActionTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/TenantSeatsCounterActionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\PanelCompany\Filament\Pages\Tenancy\EditTenantProfile;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    actingAsCompanyOwner();
+    $this->company = filament()->getTenant();
+});
+
+it('shows seat count using active stripe subscription quantity when no contractual plan exists', function (): void {
+    livewire(EditTenantProfile::class)
+        ->assertOk()
+        ->assertSee('Assentos: 1/10');
+});
+
+it('shows seat count using contractual plan seats when a contractual plan is active', function (): void {
+    CompanyPlan::factory()->active()->for($this->company, 'company')->create(['seats' => 5]);
+
+    livewire(EditTenantProfile::class)
+        ->assertOk()
+        ->assertSee('Assentos: 1/5');
+});
+
+it('counts only active employees in the seat display', function (): void {
+    $inactiveEmployee = User::factory()->employee()->create();
+    $this->company->employees()->attach($inactiveEmployee->getKey(), ['active' => false]);
+
+    livewire(EditTenantProfile::class)
+        ->assertOk()
+        ->assertSee('Assentos: 1/10');
+});

--- a/app-modules/tenant/tests/Feature/Filament/Pages/EditTenantProfileTest.php
+++ b/app-modules/tenant/tests/Feature/Filament/Pages/EditTenantProfileTest.php
@@ -60,6 +60,31 @@ describe('change tenant secret action tests', function (): void {
 
 describe('authorization', function (): void {
 
+    it('allows company owner to call the secret key rotation action', function (): void {
+        $companyOwner = User::factory()->companyOwner()->create();
+        $company = Company::factory()->for($companyOwner, 'owner')->create();
+        $company->subscriptions()->create([
+            'type' => 'company',
+            'stripe_id' => 'sub_owner_rotation_test',
+            'stripe_status' => 'active',
+        ]);
+
+        filament()->setCurrentPanel(FilamentPanel::Company->value);
+        filament()->setTenant($company);
+        actingAs($companyOwner);
+
+        $action = TestAction::make(TenantSecretKeyRotationPanelAction::class);
+        $oldKey = $company->integration_access_key;
+
+        livewire(EditTenantProfile::class)
+            ->assertOk()
+            ->mountAction($action)
+            ->callAction($action)
+            ->assertHasNoFormErrors();
+
+        expect($company->refresh()->integration_access_key)->not->toBe($oldKey);
+    });
+
     test('only company owner or admin can see the page', function (): void {
         $invalidUser = User::factory()->employee()->create();
         $this->company->employees()->attach($invalidUser);


### PR DESCRIPTION
Closes #156

## O que foi feito

Adicionamos testes para cobrir três comportamentos do painel da empresa que estavam sem validação automatizada.

---

### Contador de vagas (`TenantSeatsCounterAction`)

Testamos se o contador de assentos exibe o número correto em diferentes situações:

- Quando a empresa tem uma **assinatura Stripe** ativa, o total de vagas vem da quantidade contratada nessa assinatura
- Quando a empresa tem um **plano contratual** cadastrado, o total de vagas vem desse plano (que tem prioridade)
- O contador considera **apenas os colaboradores ativos** — quem está desativado na empresa não é contado

---

### Geração de nova chave de integração (`TenantSecretKeyRotationPanelAction`)

Confirmamos que o botão "Gerar nova chave" funciona corretamente para quem tem permissão:

- O **dono da empresa** consegue gerar uma nova chave (além do admin, que já estava testado)

---

### Tela de registro de empresa (`RegisterTenant`)

Verificamos quando a tela de registro de empresa deve ou não aparecer:

- Se a empresa já tem uma **assinatura ativa**, a tela de registro não fica acessível
- Se o usuário ainda **não tem nenhuma empresa vinculada**, a tela aparece normalmente