### PR TITLE
test(integration-google-calendar): cobrir gaps críticos e altos #150

### DIFF
--- a/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
@@ -27,6 +27,10 @@ beforeEach(function (): void {
     );
 });
 
+afterEach(function (): void {
+    Date::setTestNow();
+});
+
 it('creates a blocked schedule for each active event returned', function (): void {
     $event = new GoogleEventDTO('event-1', 'Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
 

--- a/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+use Illuminate\Support\Facades\Date;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\RemoveCancelledGoogleEventAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\RemoveStaleBlockedSchedulesAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\SyncConsultantCalendarAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\UpsertBlockedScheduleAction;
+use TresPontosTech\IntegrationGoogleCalendar\DTO\GoogleEventDTO;
+use TresPontosTech\IntegrationGoogleCalendar\GoogleCalendarClient;
+use TresPontosTech\IntegrationGoogleCalendar\Responses\CalendarEventsResponse;
+use Zap\Enums\ScheduleTypes;
+use Zap\Facades\Zap;
+use Zap\Models\Schedule;
+
+beforeEach(function (): void {
+    $this->consultant = Consultant::factory()->create(['email' => 'consultant@workspace.com']);
+
+    $this->client = Mockery::mock(GoogleCalendarClient::class);
+    $this->client->shouldReceive('getAccessToken')->with('consultant@workspace.com')->andReturn('fake-token');
+
+    $this->action = new SyncConsultantCalendarAction(
+        $this->client,
+        new UpsertBlockedScheduleAction,
+        new RemoveCancelledGoogleEventAction,
+        new RemoveStaleBlockedSchedulesAction,
+    );
+});
+
+it('creates a blocked schedule for each active event returned', function (): void {
+    $event = new GoogleEventDTO('event-1', 'Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->client->shouldReceive('listEvents')->once()->andReturn(
+        new CalendarEventsResponse(collect([$event]), null)
+    );
+
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'event-1')
+        ->exists()
+    )->toBeTrue();
+});
+
+it('removes a blocked schedule when the event is returned as cancelled', function (): void {
+    Zap::for($this->consultant)
+        ->named('Old Block')
+        ->blocked()
+        ->allowOverlap()
+        ->from('2026-05-01')
+        ->to(null)
+        ->addPeriod('09:00', '10:00')
+        ->withMetadata(['google_event_id' => 'event-cancelled', 'source' => 'google-calendar'])
+        ->save();
+
+    $cancelled = new GoogleEventDTO('event-cancelled', '', Date::now(), Date::now(), false, true);
+
+    $this->client->shouldReceive('listEvents')->once()->andReturn(
+        new CalendarEventsResponse(collect([$cancelled]), null)
+    );
+
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()
+        ->whereJsonContains('metadata->google_event_id', 'event-cancelled')
+        ->exists()
+    )->toBeFalse();
+});
+
+it('removes stale blocked schedules that are no longer in the API response', function (): void {
+    Zap::for($this->consultant)
+        ->named('Stale Block')
+        ->blocked()
+        ->allowOverlap()
+        ->from(Date::now()->addDays(5)->toDateString())
+        ->to(null)
+        ->addPeriod('10:00', '11:00')
+        ->withMetadata(['google_event_id' => 'stale-event', 'source' => 'google-calendar'])
+        ->save();
+
+    $freshEvent = new GoogleEventDTO('fresh-event', 'Fresh Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->client->shouldReceive('listEvents')->once()->andReturn(
+        new CalendarEventsResponse(collect([$freshEvent]), null)
+    );
+
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()->whereJsonContains('metadata->google_event_id', 'stale-event')->exists())->toBeFalse()
+        ->and(Schedule::query()->whereJsonContains('metadata->google_event_id', 'fresh-event')->exists())->toBeTrue();
+});
+
+it('paginates through all pages collecting events from each', function (): void {
+    $eventPage1 = new GoogleEventDTO('event-page-1', 'E1', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+    $eventPage2 = new GoogleEventDTO('event-page-2', 'E2', Date::parse('2026-05-02 09:00'), Date::parse('2026-05-02 10:00'), false, false);
+
+    $this->client->shouldReceive('listEvents')
+        ->once()
+        ->with('fake-token', 'primary', Mockery::any(), Mockery::any(), null)
+        ->andReturn(new CalendarEventsResponse(collect([$eventPage1]), 'page-token-2'));
+
+    $this->client->shouldReceive('listEvents')
+        ->once()
+        ->with('fake-token', 'primary', Mockery::any(), Mockery::any(), 'page-token-2')
+        ->andReturn(new CalendarEventsResponse(collect([$eventPage2]), null));
+
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()->whereJsonContains('metadata->google_event_id', 'event-page-1')->exists())->toBeTrue()
+        ->and(Schedule::query()->whereJsonContains('metadata->google_event_id', 'event-page-2')->exists())->toBeTrue();
+});
+
+it('handles a cancelled event in the middle of a page without affecting other events', function (): void {
+    $active1 = new GoogleEventDTO('active-1', 'A1', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+    $cancelled = new GoogleEventDTO('cancelled-1', '', Date::now(), Date::now(), false, true);
+    $active2 = new GoogleEventDTO('active-2', 'A2', Date::parse('2026-05-01 11:00'), Date::parse('2026-05-01 12:00'), false, false);
+
+    $this->client->shouldReceive('listEvents')->once()->andReturn(
+        new CalendarEventsResponse(collect([$active1, $cancelled, $active2]), null)
+    );
+
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()->whereJsonContains('metadata->google_event_id', 'active-1')->exists())->toBeTrue()
+        ->and(Schedule::query()->whereJsonContains('metadata->google_event_id', 'active-2')->exists())->toBeTrue()
+        ->and(Schedule::query()->whereJsonContains('metadata->google_event_id', 'cancelled-1')->exists())->toBeFalse();
+});
+
+it('is idempotent when run twice with the same events', function (): void {
+    $event = new GoogleEventDTO('event-1', 'Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->client->shouldReceive('listEvents')->twice()->andReturn(
+        new CalendarEventsResponse(collect([$event]), null)
+    );
+
+    $this->action->handle($this->consultant);
+    $this->action->handle($this->consultant);
+
+    expect(Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'event-1')
+        ->count()
+    )->toBe(1);
+});
+
+it('updates google_calendar_synced_at to the current time', function (): void {
+    Date::setTestNow('2026-05-01 10:00:00');
+
+    $this->client->shouldReceive('listEvents')->once()->andReturn(new CalendarEventsResponse(collect([]), null));
+
+    $this->action->handle($this->consultant);
+
+    expect($this->consultant->fresh()->google_calendar_synced_at->toDateTimeString())->toBe('2026-05-01 10:00:00');
+});

--- a/app-modules/integration-google-calendar/tests/Feature/Actions/UpsertBlockedScheduleActionTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Actions/UpsertBlockedScheduleActionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use Illuminate\Support\Facades\Date;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\UpsertBlockedScheduleAction;
+use TresPontosTech\IntegrationGoogleCalendar\DTO\GoogleEventDTO;
+use Zap\Enums\ScheduleTypes;
+use Zap\Facades\Zap;
+use Zap\Models\Schedule;
+
+beforeEach(function (): void {
+    $this->consultant = Consultant::factory()->create();
+    $this->action = resolve(UpsertBlockedScheduleAction::class);
+});
+
+it('creates a blocked schedule for a same-day timed event', function (): void {
+    $event = new GoogleEventDTO('evt-same-day', 'Daily Standup', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->where('schedulable_type', $this->consultant->getMorphClass())
+        ->where('schedulable_id', $this->consultant->getKey())
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-same-day')
+        ->with('periods')
+        ->firstOrFail();
+
+    expect($schedule->name)->toBe('Daily Standup')
+        ->and($schedule->start_date->toDateString())->toBe('2026-05-01')
+        ->and($schedule->end_date)->toBeNull()
+        ->and($schedule->periods->first()->start_time)->toBe('09:00')
+        ->and($schedule->periods->first()->end_time)->toBe('10:00');
+});
+
+it('creates a blocked schedule for an all-day single-day event', function (): void {
+    $event = new GoogleEventDTO('evt-allday-single', 'Day Off', Date::parse('2026-05-01'), Date::parse('2026-05-02'), true, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-allday-single')
+        ->with('periods')
+        ->firstOrFail();
+
+    expect($schedule->start_date->toDateString())->toBe('2026-05-01')
+        ->and($schedule->end_date)->toBeNull()
+        ->and($schedule->periods->first()->start_time)->toBe('00:00')
+        ->and($schedule->periods->first()->end_time)->toBe('23:59');
+});
+
+it('creates a blocked schedule for an all-day multi-day event', function (): void {
+    $event = new GoogleEventDTO('evt-allday-multi', 'Vacation', Date::parse('2026-05-01'), Date::parse('2026-05-04'), true, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-allday-multi')
+        ->firstOrFail();
+
+    // Google all-day end date is exclusive, so effective end = May 4 - 1 = May 3
+    expect($schedule->start_date->toDateString())->toBe('2026-05-01')
+        ->and($schedule->end_date->toDateString())->toBe('2026-05-03');
+});
+
+it('creates a blocked schedule for a multi-day timed event', function (): void {
+    $event = new GoogleEventDTO('evt-multi-timed', 'Conference', Date::parse('2026-05-01 14:00'), Date::parse('2026-05-03 18:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-multi-timed')
+        ->with('periods')
+        ->firstOrFail();
+
+    expect($schedule->start_date->toDateString())->toBe('2026-05-01')
+        ->and($schedule->end_date->toDateString())->toBe('2026-05-03')
+        ->and($schedule->periods->first()->start_time)->toBe('00:00')
+        ->and($schedule->periods->first()->end_time)->toBe('23:59');
+});
+
+it('creates a blocked schedule ending at 23:59 for a timed event ending at midnight of the next day', function (): void {
+    $event = new GoogleEventDTO('evt-midnight', 'Night Shift', Date::parse('2026-05-01 22:00'), Date::parse('2026-05-02 00:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-midnight')
+        ->with('periods')
+        ->firstOrFail();
+
+    expect($schedule->start_date->toDateString())->toBe('2026-05-01')
+        ->and($schedule->end_date)->toBeNull()
+        ->and($schedule->periods->first()->start_time)->toBe('22:00')
+        ->and($schedule->periods->first()->end_time)->toBe('23:59');
+});
+
+it('does not create a blocked schedule when an appointment conflicts with the event', function (): void {
+    $date = '2026-05-01';
+
+    Zap::for($this->consultant)
+        ->named('Existing Appointment')
+        ->appointment()
+        ->from($date)
+        ->to(Date::parse($date)->addDay()->toDateString())
+        ->addPeriod('09:30', '10:30')
+        ->save();
+
+    $event = new GoogleEventDTO('evt-conflict', 'Blocked', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    expect(Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-conflict')
+        ->exists()
+    )->toBeFalse();
+});
+
+it('replaces an existing blocked schedule when re-upserted with the same event id', function (): void {
+    $event = new GoogleEventDTO('evt-idempotent', 'Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+    $this->action->handle($this->consultant, $event);
+
+    expect(Schedule::query()
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->whereJsonContains('metadata->google_event_id', 'evt-idempotent')
+        ->count()
+    )->toBe(1);
+});
+
+it('stores google_event_id and source in schedule metadata', function (): void {
+    $event = new GoogleEventDTO('evt-meta', 'Meta Event', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    $schedule = Schedule::query()
+        ->whereJsonContains('metadata->google_event_id', 'evt-meta')
+        ->firstOrFail();
+
+    expect($schedule->metadata['google_event_id'])->toBe('evt-meta')
+        ->and($schedule->metadata['source'])->toBe('google-calendar');
+});
+
+it('does not affect blocked schedules of other consultants', function (): void {
+    $otherConsultant = Consultant::factory()->create();
+    $event = new GoogleEventDTO('evt-shared-id', 'Meeting', Date::parse('2026-05-01 09:00'), Date::parse('2026-05-01 10:00'), false, false);
+
+    $this->action->handle($this->consultant, $event);
+
+    Zap::for($otherConsultant)
+        ->named('Other Blocked')
+        ->blocked()
+        ->allowOverlap()
+        ->from('2026-05-01')
+        ->to(null)
+        ->addPeriod('09:00', '10:00')
+        ->withMetadata(['google_event_id' => 'evt-other', 'source' => 'google-calendar'])
+        ->save();
+
+    // Re-upsert for original consultant should not touch other consultant's schedule
+    $this->action->handle($this->consultant, $event);
+
+    expect(Schedule::query()
+        ->where('schedulable_id', $otherConsultant->getKey())
+        ->where('schedule_type', ScheduleTypes::BLOCKED)
+        ->count()
+    )->toBe(1);
+});

--- a/app-modules/integration-google-calendar/tests/Feature/GoogleCalendarClientTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/GoogleCalendarClientTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use Illuminate\Support\Facades\Http;
+use TresPontosTech\IntegrationGoogleCalendar\Exceptions\GoogleCalendarApiException;
+use TresPontosTech\IntegrationGoogleCalendar\GoogleCalendarClient;
+use TresPontosTech\IntegrationGoogleCalendar\Responses\CalendarEventsResponse;
+use TresPontosTech\IntegrationGoogleCalendar\Responses\CreateEventResponse;
+
+beforeEach(function (): void {
+    static $privateKey = null;
+
+    if ($privateKey === null) {
+        $key = openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA]);
+        openssl_pkey_export($key, $privateKey);
+    }
+
+    $credPath = storage_path('testing/gc-test-credentials.json');
+    @mkdir(dirname($credPath), 0755, true);
+    file_put_contents($credPath, json_encode([
+        'client_email' => 'sa@project.iam.gserviceaccount.com',
+        'private_key' => $privateKey,
+    ]));
+
+    config(['google-calendar.service_account_credentials' => 'testing/gc-test-credentials.json']);
+
+    Http::preventStrayRequests();
+
+    $this->client = new GoogleCalendarClient;
+});
+
+afterEach(function (): void {
+    @unlink(storage_path('testing/gc-test-credentials.json'));
+});
+
+// --- getAccessToken ---
+
+it('throws a non-retryable exception for invalid_grant and unauthorized_client errors', function (string $errorCode): void {
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response(['error' => $errorCode], 200),
+    ]);
+
+    $exception = null;
+
+    try {
+        $this->client->getAccessToken('consultant@workspace.com');
+    } catch (GoogleCalendarApiException $googleCalendarApiException) {
+        $exception = $googleCalendarApiException;
+    }
+
+    expect($exception)->not->toBeNull()
+        ->and($exception->retryable)->toBeFalse();
+})->with(['invalid_grant', 'unauthorized_client']);
+
+it('throws a retryable exception on a generic token request failure', function (): void {
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response(['error' => 'server_error'], 500),
+    ]);
+
+    $exception = null;
+
+    try {
+        $this->client->getAccessToken('consultant@workspace.com');
+    } catch (GoogleCalendarApiException $googleCalendarApiException) {
+        $exception = $googleCalendarApiException;
+    }
+
+    expect($exception)->not->toBeNull()
+        ->and($exception->retryable)->toBeTrue();
+});
+
+it('returns the access token string on success', function (): void {
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response(['access_token' => 'ya29.test-token'], 200),
+    ]);
+
+    $token = $this->client->getAccessToken('consultant@workspace.com');
+
+    expect($token)->toBe('ya29.test-token');
+});
+
+// --- listEvents ---
+
+it('returns a CalendarEventsResponse with events and nextPageToken', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response([
+            'items' => [
+                [
+                    'id' => 'event-abc',
+                    'summary' => 'Test Event',
+                    'status' => 'confirmed',
+                    'start' => ['dateTime' => '2026-05-01T09:00:00-03:00'],
+                    'end' => ['dateTime' => '2026-05-01T10:00:00-03:00'],
+                ],
+            ],
+            'nextPageToken' => 'next-page-xyz',
+        ], 200),
+    ]);
+
+    $response = $this->client->listEvents('fake-token', 'primary', '2026-05-01T00:00:00Z', '2026-06-30T23:59:59Z');
+
+    expect($response)->toBeInstanceOf(CalendarEventsResponse::class)
+        ->and($response->events)->toHaveCount(1)
+        ->and($response->events->first()->eventId)->toBe('event-abc')
+        ->and($response->nextPageToken)->toBe('next-page-xyz');
+});
+
+it('passes the pageToken parameter to the API request', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response(['items' => [], 'nextPageToken' => null], 200),
+    ]);
+
+    $this->client->listEvents('fake-token', 'primary', '2026-05-01T00:00:00Z', '2026-06-30T23:59:59Z', 'my-page-token');
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'pageToken=my-page-token'));
+});
+
+it('throws a retryable exception on 429 quota exceeded', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response(['error' => 'rateLimitExceeded'], 429),
+    ]);
+
+    $exception = null;
+
+    try {
+        $this->client->listEvents('fake-token', 'primary', '2026-05-01T00:00:00Z', '2026-06-30T23:59:59Z');
+    } catch (GoogleCalendarApiException $googleCalendarApiException) {
+        $exception = $googleCalendarApiException;
+    }
+
+    expect($exception)->not->toBeNull()
+        ->and($exception->retryable)->toBeTrue();
+});
+
+// --- createEvent ---
+
+it('returns a CreateEventResponse with eventId and meetLink on success', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response([
+            'id' => 'created-event-id',
+            'conferenceData' => [
+                'entryPoints' => [
+                    ['entryPointType' => 'video', 'uri' => 'https://meet.google.com/abc-defg-hij'],
+                ],
+            ],
+        ], 200),
+    ]);
+
+    $response = $this->client->createEvent('fake-token', 'primary', []);
+
+    expect($response)->toBeInstanceOf(CreateEventResponse::class)
+        ->and($response->eventId)->toBe('created-event-id')
+        ->and($response->meetLink)->toBe('https://meet.google.com/abc-defg-hij');
+});
+
+it('throws a retryable exception when createEvent fails', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response(['error' => 'forbidden'], 403),
+    ]);
+
+    $exception = null;
+
+    try {
+        $this->client->createEvent('fake-token', 'primary', []);
+    } catch (GoogleCalendarApiException $googleCalendarApiException) {
+        $exception = $googleCalendarApiException;
+    }
+
+    expect($exception)->not->toBeNull()
+        ->and($exception->retryable)->toBeTrue();
+});
+
+// --- deleteEvent ---
+
+it('does not throw when deleteEvent succeeds with 204', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response('', 204),
+    ]);
+
+    expect(fn () => $this->client->deleteEvent('fake-token', 'primary', 'event-id'))->not->toThrow(GoogleCalendarApiException::class);
+});
+
+it('does not throw when deleteEvent receives 410 Gone (already deleted)', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response('', 410),
+    ]);
+
+    expect(fn () => $this->client->deleteEvent('fake-token', 'primary', 'gone-event-id'))->not->toThrow(GoogleCalendarApiException::class);
+});
+
+it('throws a retryable exception on deleteEvent server failure', function (): void {
+    Http::fake([
+        'https://www.googleapis.com/calendar/v3/calendars/*' => Http::response(['error' => 'server_error'], 500),
+    ]);
+
+    $exception = null;
+
+    try {
+        $this->client->deleteEvent('fake-token', 'primary', 'event-id');
+    } catch (GoogleCalendarApiException $googleCalendarApiException) {
+        $exception = $googleCalendarApiException;
+    }
+
+    expect($exception)->not->toBeNull()
+        ->and($exception->retryable)->toBeTrue();
+});

--- a/app-modules/integration-google-calendar/tests/Feature/GoogleCalendarClientTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/GoogleCalendarClientTest.php
@@ -14,14 +14,16 @@ beforeEach(function (): void {
         openssl_pkey_export($key, $privateKey);
     }
 
-    $credPath = storage_path('testing/gc-test-credentials.json');
-    @mkdir(dirname($credPath), 0755, true);
+    @mkdir(storage_path('testing'), 0755, true);
+    $credPath = tempnam(storage_path('testing'), 'gc-creds-');
     file_put_contents($credPath, json_encode([
         'client_email' => 'sa@project.iam.gserviceaccount.com',
         'private_key' => $privateKey,
     ]));
 
-    config(['google-calendar.service_account_credentials' => 'testing/gc-test-credentials.json']);
+    $this->credPath = $credPath;
+
+    config(['google-calendar.service_account_credentials' => 'testing/' . basename($credPath)]);
 
     Http::preventStrayRequests();
 
@@ -29,7 +31,7 @@ beforeEach(function (): void {
 });
 
 afterEach(function (): void {
-    @unlink(storage_path('testing/gc-test-credentials.json'));
+    @unlink($this->credPath);
 });
 
 // --- getAccessToken ---

--- a/app-modules/integration-google-calendar/tests/Feature/Jobs/SyncConsultantCalendarJobTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Jobs/SyncConsultantCalendarJobTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Support\Facades\Log;
+use TresPontosTech\Consultants\Models\Consultant;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\RemoveCancelledGoogleEventAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\RemoveStaleBlockedSchedulesAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\SyncConsultantCalendarAction;
+use TresPontosTech\IntegrationGoogleCalendar\Actions\UpsertBlockedScheduleAction;
+use TresPontosTech\IntegrationGoogleCalendar\Exceptions\GoogleCalendarApiException;
+use TresPontosTech\IntegrationGoogleCalendar\GoogleCalendarClient;
+use TresPontosTech\IntegrationGoogleCalendar\Jobs\SyncConsultantCalendarJob;
+use TresPontosTech\IntegrationGoogleCalendar\Responses\CalendarEventsResponse;
+
+function makeSyncAction(GoogleCalendarClient $client): SyncConsultantCalendarAction
+{
+    return new SyncConsultantCalendarAction(
+        $client,
+        new UpsertBlockedScheduleAction,
+        new RemoveCancelledGoogleEventAction,
+        new RemoveStaleBlockedSchedulesAction,
+    );
+}
+
+beforeEach(function (): void {
+    $this->consultant = Consultant::factory()->create(['email' => 'consultant@workspace.com']);
+    $this->job = new SyncConsultantCalendarJob($this->consultant);
+});
+
+it('calls SyncConsultantCalendarAction successfully', function (): void {
+    $client = Mockery::mock(GoogleCalendarClient::class);
+    $client->shouldReceive('getAccessToken')->andReturn('fake-token');
+    $client->shouldReceive('listEvents')->once()->andReturn(new CalendarEventsResponse(collect([]), null));
+
+    $this->job->handle(makeSyncAction($client));
+});
+
+it('logs a warning and does not rethrow for non-retryable exceptions', function (): void {
+    Log::spy();
+
+    $client = Mockery::mock(GoogleCalendarClient::class);
+    $client->shouldReceive('getAccessToken')
+        ->andThrow(new GoogleCalendarApiException('Not in Google Workspace', retryable: false));
+
+    $this->job->handle(makeSyncAction($client));
+
+    Log::shouldHaveReceived('warning')->once();
+});
+
+it('rethrows retryable exceptions so the queue can retry', function (): void {
+    $client = Mockery::mock(GoogleCalendarClient::class);
+    $client->shouldReceive('getAccessToken')
+        ->andThrow(new GoogleCalendarApiException('Rate limit exceeded', 429));
+
+    expect(fn () => $this->job->handle(makeSyncAction($client)))->toThrow(GoogleCalendarApiException::class);
+});
+
+it('has the correct retry configuration', function (): void {
+    expect($this->job->tries)->toBe(3)
+        ->and($this->job->backoff)->toBe([10, 60, 300]);
+});


### PR DESCRIPTION
## O que foi testado

Cobertura dos gaps identificados na auditoria do módulo `integration-google-calendar` (issue #150), focando nos itens críticos e altos.

---

### Sincronização do calendário (`SyncConsultantCalendarAction`)

- Quando a API retorna eventos, bloqueios são criados corretamente na agenda do consultor
- Quando um evento volta como cancelado, o bloqueio correspondente é removido
- Quando um evento deixa de aparecer na API (foi deletado ou está fora do período), o bloqueio antigo é apagado
- A sincronização percorre todas as páginas da API quando há mais de uma (paginação)
- Um evento cancelado no meio de uma página não afeta os outros eventos da mesma página
- Rodar a sincronização duas vezes com os mesmos eventos não duplica os bloqueios (idempotência)
- O campo `google_calendar_synced_at` do consultor é atualizado corretamente após cada sync

---

### Criação de bloqueios na agenda (`UpsertBlockedScheduleAction`)

- Evento de dia inteiro (ex: "Dia de folga") cria um bloqueio das 00:00 às 23:59
- Evento de dia inteiro com múltiplos dias cria um bloqueio cobrindo todo o período
- Evento com horário definido no mesmo dia cria um bloqueio com os horários corretos
- Evento com horário definido que vai até a meia-noite do dia seguinte é tratado como terminando às 23:59
- Evento que bate com um agendamento já existente do consultor **não** cria bloqueio
- Sincronizar o mesmo evento duas vezes substitui o bloqueio anterior, sem duplicar
- O ID do evento Google e a origem (`google-calendar`) são salvos nos metadados do bloqueio
- Bloqueios de outros consultores não são afetados

---

### Fila de sincronização (`SyncConsultantCalendarJob`)

- O job executa a sincronização com sucesso
- Quando o consultor não está no domínio Google (erro não-recuperável), o job registra um aviso e **não** tenta novamente
- Quando ocorre erro recuperável (ex: limite de requisições), o job relança o erro para que a fila tente novamente
- Configuração de retry: 3 tentativas, com espera de 10s, 60s e 300s entre elas

---

### Cliente da API do Google (`GoogleCalendarClient`)

- Token de acesso: erro `invalid_grant` ou `unauthorized_client` lança exceção não-recuperável
- Token de acesso: falha genérica da API lança exceção recuperável
- Token de acesso: retorna o token corretamente em caso de sucesso
- Listagem de eventos: retorna a lista com o token da próxima página quando há paginação
- Listagem de eventos: o token de página é enviado corretamente na requisição
- Listagem de eventos: erro 429 (cota excedida) lança exceção recuperável
- Criação de evento: retorna o ID e o link do Meet em caso de sucesso
- Criação de evento: falha lança exceção recuperável
- Deleção de evento: resposta 204 (sucesso) não lança exceção
- Deleção de evento: resposta 410 (evento já deletado) é ignorada silenciosamente
- Deleção de evento: falha de servidor lança exceção recuperável

---

Closes #150