### PR TITLE
test(billing): cobrir gaps de testes — issue #147

### DIFF
--- a/app-modules/billing/database/factories/SubscriptionFactory.php
+++ b/app-modules/billing/database/factories/SubscriptionFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace TresPontosTech\Billing\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
+use TresPontosTech\Company\Models\Company;
+
+/** @extends Factory<Subscription> */
+class SubscriptionFactory extends Factory
+{
+    protected $model = Subscription::class;
+
+    public function definition(): array
+    {
+        return [
+            'subscriptionable_type' => 'company',
+            'subscriptionable_id' => Company::factory(),
+            'type' => 'default',
+            'stripe_id' => 'sub_' . $this->faker->unique()->regexify('[A-Za-z0-9]{24}'),
+            'stripe_status' => 'active',
+            'stripe_price' => null,
+            'quantity' => 1,
+            'trial_ends_at' => null,
+            'ends_at' => null,
+        ];
+    }
+
+    public function active(): self
+    {
+        return $this->state(['stripe_status' => 'active']);
+    }
+
+    public function trialing(): self
+    {
+        return $this->state([
+            'stripe_status' => 'trialing',
+            'trial_ends_at' => now()->addDays(14),
+        ]);
+    }
+
+    public function pastDue(): self
+    {
+        return $this->state(['stripe_status' => 'past_due']);
+    }
+
+    public function canceled(): self
+    {
+        return $this->state(['stripe_status' => 'canceled']);
+    }
+
+    public function forCompany(Company $company): self
+    {
+        return $this->state([
+            'subscriptionable_type' => 'company',
+            'subscriptionable_id' => $company->id,
+        ]);
+    }
+}

--- a/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
@@ -51,10 +51,10 @@ final readonly class ConfigPlanRepository implements PlanRepository
         );
     }
 
-    public function getPlansFor(string $name): Collection
+    public function getPlansFor(string $name = 'user_'): Collection
     {
         return collect($this->all())
-            ->filter(fn ($plan, $key): bool => str_starts_with($key, 'user_'));
+            ->filter(fn ($plan, $key): bool => str_starts_with($key, $name));
     }
 
     public function getActiveTenantPlan(): PlanEntity

--- a/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
@@ -39,6 +39,7 @@ final readonly class ConfigPlanRepository implements PlanRepository
             ->map(fn (array $price): PriceEntity => PriceEntity::make($price));
 
         return new PlanEntity(
+            name: $name,
             slug: Arr::get($plan, key: 'type', default: $name),
             productId: Arr::get($plan, key: 'product_id', default: ''),
             prices: $prices,

--- a/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
@@ -26,7 +26,7 @@ class EloquentPlanRepository implements PlanRepository
         return collect($this->all())->firstOrFail(fn (PlanEntity $plan): bool => $plan->slug === $name);
     }
 
-    public function getPlansFor(string $name): Collection
+    public function getPlansFor(string $name = 'user_'): Collection
     {
         return Cache::remember('active_user_plans', 15, fn () => Plan::query()
             ->where('type', BillableTypeEnum::User)

--- a/app-modules/billing/src/Core/Repositories/PlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/PlanRepository.php
@@ -16,7 +16,7 @@ interface PlanRepository
 
     public function get(string $name): PlanEntity;
 
-    public function getPlansFor(string $name): Collection;
+    public function getPlansFor(string $name = 'user_'): Collection;
 
     public function getActiveTenantPlan(): PlanEntity;
 }

--- a/app-modules/billing/tests/Feature/Billing/CompanyBillingProviderTest.php
+++ b/app-modules/billing/tests/Feature/Billing/CompanyBillingProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use TresPontosTech\Billing\Stripe\Subscription\Company\CompanyBillingProvider;
+use TresPontosTech\Billing\Stripe\Subscription\Company\RedirectCompanyIfNotSubscribed;
+
+it('getSubscribedMiddleware returns the RedirectCompanyIfNotSubscribed class name', function (): void {
+    $provider = new CompanyBillingProvider;
+
+    expect($provider->getSubscribedMiddleware())->toBe(RedirectCompanyIfNotSubscribed::class);
+});
+
+it('getRouteAction returns a Closure', function (): void {
+    $provider = new CompanyBillingProvider;
+
+    expect($provider->getRouteAction())->toBeInstanceOf(Closure::class);
+});

--- a/app-modules/billing/tests/Feature/Billing/UserBillingProviderTest.php
+++ b/app-modules/billing/tests/Feature/Billing/UserBillingProviderTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use TresPontosTech\Billing\Stripe\Subscription\User\RedirectUserIfNotSubscribed;
+use TresPontosTech\Billing\Stripe\Subscription\User\UserBillingProvider;
+
+it('getSubscribedMiddleware returns the RedirectUserIfNotSubscribed class name', function (): void {
+    $provider = new UserBillingProvider;
+
+    expect($provider->getSubscribedMiddleware())->toBe(RedirectUserIfNotSubscribed::class);
+});
+
+it('getRouteAction returns a Closure', function (): void {
+    $provider = new UserBillingProvider;
+
+    expect($provider->getRouteAction())->toBeInstanceOf(Closure::class);
+});

--- a/app-modules/billing/tests/Feature/Commands/SyncStripeResourcesCommandTest.php
+++ b/app-modules/billing/tests/Feature/Commands/SyncStripeResourcesCommandTest.php
@@ -1,0 +1,191 @@
+<?php
+
+use Stripe\ApiRequestor;
+use Stripe\HttpClient\ClientInterface;
+use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Billing\Core\Models\Price;
+
+/**
+ * Fake HTTP client para interceptar chamadas ao Stripe SDK.
+ * O SDK usa ApiRequestor internamente, que delega ao _httpClient injetado.
+ */
+function fakeStripeHttpClient(array $products = [], array $prices = []): ClientInterface
+{
+    return new class($products, $prices) implements ClientInterface
+    {
+        public function __construct(
+            private readonly array $products,
+            private readonly array $prices,
+        ) {}
+
+        public function request($method, $absUrl, $headers, $params, $hasFile, $apiMode = 'v1'): array
+        {
+            if (str_contains($absUrl, '/v1/products')) {
+                return [
+                    json_encode([
+                        'object' => 'list',
+                        'url' => '/v1/products',
+                        'has_more' => false,
+                        'data' => $this->products,
+                    ]),
+                    200,
+                    ['Request-Id' => 'req_test_products'],
+                ];
+            }
+
+            if (str_contains($absUrl, '/v1/prices')) {
+                return [
+                    json_encode([
+                        'object' => 'list',
+                        'url' => '/v1/prices',
+                        'has_more' => false,
+                        'data' => $this->prices,
+                    ]),
+                    200,
+                    ['Request-Id' => 'req_test_prices'],
+                ];
+            }
+
+            return [json_encode(['object' => 'list', 'data' => [], 'has_more' => false, 'url' => '/']), 200, []];
+        }
+    };
+}
+
+beforeEach(function (): void {
+    config(['cashier.secret' => 'sk_test_fake_key_for_tests']);
+});
+
+afterEach(function (): void {
+    ApiRequestor::setHttpClient(null);
+});
+
+it('syncs active stripe products as plans in the database', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_active_1', 'object' => 'product', 'active' => true, 'name' => 'Gold Plan', 'description' => 'Gold tier'],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    expect(Plan::query()->where('provider_product_id', 'prod_active_1')->exists())->toBeTrue()
+        ->and(Plan::query()->where('provider', BillingProviderEnum::Stripe)->count())->toBe(1);
+});
+
+it('does not sync inactive stripe products', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_inactive_1', 'object' => 'product', 'active' => false, 'name' => 'Old Plan', 'description' => 'Old tier'],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    expect(Plan::query()->where('provider_product_id', 'prod_inactive_1')->exists())->toBeFalse();
+});
+
+it('syncs active prices for each product', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_price_test', 'object' => 'product', 'active' => true, 'name' => 'Price Test Plan', 'description' => null],
+        ],
+        prices: [
+            [
+                'id' => 'price_active_1',
+                'object' => 'price',
+                'active' => true,
+                'billing_scheme' => 'per_unit',
+                'tiers_mode' => null,
+                'type' => 'recurring',
+                'unit_amount' => 9900,
+                'product' => 'prod_price_test',
+                'metadata' => (object) [],
+            ],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    $plan = Plan::query()->where('provider_product_id', 'prod_price_test')->firstOrFail();
+    expect(Price::query()->where('billing_plan_id', $plan->id)->where('provider_price_id', 'price_active_1')->exists())->toBeTrue();
+});
+
+it('does not sync inactive prices', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_inactive_price', 'object' => 'product', 'active' => true, 'name' => 'Inactive Price Plan', 'description' => null],
+        ],
+        prices: [
+            [
+                'id' => 'price_inactive_1',
+                'object' => 'price',
+                'active' => false,
+                'billing_scheme' => 'per_unit',
+                'tiers_mode' => null,
+                'type' => 'recurring',
+                'unit_amount' => 5000,
+                'product' => 'prod_inactive_price',
+                'metadata' => (object) [],
+            ],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    $plan = Plan::query()->where('provider_product_id', 'prod_inactive_price')->firstOrFail();
+    expect(Price::query()->where('billing_plan_id', $plan->id)->count())->toBe(0);
+});
+
+it('is idempotent — running twice does not duplicate plans or prices', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_idem_1', 'object' => 'product', 'active' => true, 'name' => 'Idempotency Plan', 'description' => null],
+        ],
+        prices: [
+            [
+                'id' => 'price_idem_1',
+                'object' => 'price',
+                'active' => true,
+                'billing_scheme' => 'per_unit',
+                'tiers_mode' => null,
+                'type' => 'recurring',
+                'unit_amount' => 1900,
+                'product' => 'prod_idem_1',
+                'metadata' => (object) [],
+            ],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    expect(Plan::query()->where('provider', BillingProviderEnum::Stripe)->where('provider_product_id', 'prod_idem_1')->count())->toBe(1)
+        ->and(Price::query()->where('provider_price_id', 'price_idem_1')->count())->toBe(1);
+});
+
+it('syncs slug from product name', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_slug_test', 'object' => 'product', 'active' => true, 'name' => 'My Premium Plan', 'description' => null],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    expect(Plan::query()->where('slug', 'my-premium-plan')->exists())->toBeTrue();
+});
+
+it('defaults synced plan type to User billable type', function (): void {
+    ApiRequestor::setHttpClient(fakeStripeHttpClient(
+        products: [
+            ['id' => 'prod_type_test', 'object' => 'product', 'active' => true, 'name' => 'Type Test Plan', 'description' => null],
+        ],
+    ));
+
+    $this->artisan('billing:sync-stripe')->assertSuccessful();
+
+    $plan = Plan::query()->where('provider_product_id', 'prod_type_test')->firstOrFail();
+    expect($plan->type)->toBe(BillableTypeEnum::User);
+});

--- a/app-modules/billing/tests/Feature/Middleware/RedirectCompanyIfNotSubscribedTest.php
+++ b/app-modules/billing/tests/Feature/Middleware/RedirectCompanyIfNotSubscribedTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Billing\Core\Models\Price;
+use TresPontosTech\Billing\Stripe\Subscription\Company\RedirectCompanyIfNotSubscribed;
+use TresPontosTech\Company\Models\Company;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->companyOwner()->create();
+    $this->company = Company::factory()->recycle($this->user)->create([
+        'stripe_id' => 'cus_test_' . uniqid(),
+    ]);
+    $this->company->employees()->attach($this->user->getKey());
+
+    filament()->setCurrentPanel(FilamentPanel::Company->value);
+    actingAs($this->user);
+    filament()->setTenant($this->company);
+
+    $this->middleware = resolve(RedirectCompanyIfNotSubscribed::class);
+    $this->request = Request::create('/company/test');
+    $this->next = fn (Request $req): Response => new Response('ok');
+});
+
+it('bypasses check for flamma-company tenant', function (): void {
+    $flammaCompany = Company::factory()->recycle($this->user)->create([
+        'slug' => 'flamma-company',
+        'stripe_id' => 'cus_flamma',
+    ]);
+    $flammaCompany->employees()->attach($this->user->getKey());
+    filament()->setTenant($flammaCompany);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('allows access when company has an active contractual plan', function (): void {
+    CompanyPlan::factory()->active()->for($this->company)->create();
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('allows access when company has an active stripe subscription', function (): void {
+    $plan = Plan::factory()->active()->stripe()->create(['slug' => 'company-stripe-plan']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->company->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_active_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('allows access when company subscription status is trialing', function (): void {
+    $plan = Plan::factory()->active()->stripe()->create(['slug' => 'company-trialing-plan']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->company->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_trial_' . uniqid(),
+        'stripe_status' => 'trialing',
+        'trial_ends_at' => now()->addDays(14),
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('redirects when company subscription status is past_due', function (): void {
+    $plan = Plan::factory()->active()->stripe()->create(['slug' => 'company-pastdue-plan']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->company->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_pastdue_' . uniqid(),
+        'stripe_status' => 'past_due',
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('available-subscriptions');
+});
+
+it('redirects when company subscription status is canceled and has ended', function (): void {
+    $plan = Plan::factory()->active()->stripe()->create(['slug' => 'company-canceled-plan']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->company->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_canceled_' . uniqid(),
+        'stripe_status' => 'canceled',
+        'ends_at' => now()->subDay(), // encerrada no passado
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('available-subscriptions');
+});
+
+it('redirects when company has no subscription at all', function (): void {
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('available-subscriptions');
+});

--- a/app-modules/billing/tests/Feature/Middleware/RedirectUserIfNotSubscribedTest.php
+++ b/app-modules/billing/tests/Feature/Middleware/RedirectUserIfNotSubscribedTest.php
@@ -1,0 +1,145 @@
+<?php
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Laravel\Cashier\Cashier;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
+use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Billing\Core\Models\Price;
+use TresPontosTech\Billing\Stripe\Subscription\User\RedirectUserIfNotSubscribed;
+use TresPontosTech\Company\Models\Company;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function (): void {
+    $this->employee = User::factory()->employee()->create([
+        'stripe_id' => 'cus_user_' . uniqid(),
+    ]);
+    $this->company = Company::factory()->create([
+        'stripe_id' => 'cus_company_' . uniqid(),
+    ]);
+    $this->company->employees()->attach($this->employee->getKey());
+
+    filament()->setCurrentPanel(FilamentPanel::User->value);
+    actingAs($this->employee);
+    filament()->setTenant($this->company);
+
+    $this->middleware = resolve(RedirectUserIfNotSubscribed::class);
+    $this->request = Request::create('/app/test');
+    $this->next = fn (Request $req): Response => new Response('ok');
+});
+
+afterEach(function (): void {
+    Cashier::useCustomerModel(User::class);
+});
+
+it('allows access when company has an active contractual plan', function (): void {
+    CompanyPlan::factory()->active()->for($this->company)->create();
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('aborts with 403 when company has no stripe subscription', function (): void {
+    $this->middleware->handle($this->request, $this->next);
+})->throws(HttpException::class);
+
+it('aborts with 403 when company subscription is past_due', function (): void {
+    $this->company->subscriptions()->create([
+        'type' => 'company',
+        'stripe_id' => 'sub_pastdue_' . uniqid(),
+        'stripe_status' => 'past_due',
+    ]);
+
+    $this->middleware->handle($this->request, $this->next);
+})->throws(HttpException::class);
+
+it('aborts with 403 when company subscription is canceled', function (): void {
+    $this->company->subscriptions()->create([
+        'type' => 'company',
+        'stripe_id' => 'sub_canceled_' . uniqid(),
+        'stripe_status' => 'canceled',
+    ]);
+
+    $this->middleware->handle($this->request, $this->next);
+})->throws(HttpException::class);
+
+it('bypasses 403 check for flamma-company tenant', function (): void {
+    $flammaCompany = Company::factory()->create([
+        'slug' => 'flamma-company',
+        'stripe_id' => 'cus_flamma',
+    ]);
+    $flammaCompany->employees()->attach($this->employee->getKey());
+    filament()->setTenant($flammaCompany);
+
+    $plan = Plan::factory()->active()->stripe()->state(['type' => BillableTypeEnum::User])->create(['slug' => 'user-gold']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->employee->subscriptions()->create([
+        'type' => 'user-gold',
+        'stripe_id' => 'sub_flamma_user_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('redirects employee to subscription page when company is active but employee has no plan', function (): void {
+    $this->company->subscriptions()->create([
+        'type' => 'company',
+        'stripe_id' => 'sub_company_active_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+    $plan = Plan::factory()->active()->stripe()->state(['type' => BillableTypeEnum::User])->create(['slug' => 'user-gold']);
+    Price::factory()->for($plan, 'plan')->create();
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('available-subscriptions');
+});
+
+it('allows access when both company and employee have active subscriptions', function (): void {
+    $this->company->subscriptions()->create([
+        'type' => 'company',
+        'stripe_id' => 'sub_company_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+    $plan = Plan::factory()->active()->stripe()->state(['type' => BillableTypeEnum::User])->create(['slug' => 'user-gold']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->employee->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_employee_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});
+
+it('allows access when employee subscription is trialing', function (): void {
+    $this->company->subscriptions()->create([
+        'type' => 'company',
+        'stripe_id' => 'sub_company_' . uniqid(),
+        'stripe_status' => 'active',
+    ]);
+    $plan = Plan::factory()->active()->stripe()->state(['type' => BillableTypeEnum::User])->create(['slug' => 'user-platinum']);
+    Price::factory()->for($plan, 'plan')->create();
+    $this->employee->subscriptions()->create([
+        'type' => $plan->slug,
+        'stripe_id' => 'sub_trial_' . uniqid(),
+        'stripe_status' => 'trialing',
+        'trial_ends_at' => now()->addDays(7),
+    ]);
+
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getContent())->toBe('ok');
+});

--- a/app-modules/billing/tests/Feature/Webhook/SubscriptionWebhookControllerTest.php
+++ b/app-modules/billing/tests/Feature/Webhook/SubscriptionWebhookControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Http\Middleware\VerifyWebhookSignature;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
+use TresPontosTech\Company\Models\Company;
+
+beforeEach(function (): void {
+    Cashier::useCustomerModel(User::class);
+});
+
+afterEach(function (): void {
+    Cashier::useCustomerModel(User::class);
+});
+
+/** @return class-string|null */
+function currentCashierModel(): ?string
+{
+    return Cashier::$customerModel;
+}
+
+function webhookPayload(string $type = 'charge.succeeded', array $metadata = []): array
+{
+    $object = ['id' => 'obj_test_' . uniqid()];
+
+    if ($metadata !== []) {
+        $object['metadata'] = $metadata;
+    }
+
+    return [
+        'id' => 'evt_test_' . uniqid(),
+        'type' => $type,
+        'data' => ['object' => $object],
+    ];
+}
+
+it('switches customer model to Company when metadata.model is "company"', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), webhookPayload(metadata: ['model' => 'company']))
+        ->assertSuccessful();
+
+    expect(currentCashierModel())->toBe(Company::class);
+});
+
+it('does not change customer model when metadata key is absent from payload', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), webhookPayload())
+        ->assertSuccessful();
+
+    expect(currentCashierModel())->toBe(User::class);
+});
+
+it('does not change customer model when model key is absent from metadata', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), webhookPayload(metadata: ['other_key' => 'some_value']))
+        ->assertSuccessful();
+
+    expect(currentCashierModel())->toBe(User::class);
+});
+
+it('calls useCustomerModel with null when morph key is not registered', function (): void {
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), webhookPayload(metadata: ['model' => 'unregistered_morph']))
+        ->assertSuccessful();
+
+    expect(Relation::getMorphedModel('unregistered_morph'))->toBeNull()
+        ->and(currentCashierModel())->toBeNull();
+});
+
+it('returns 403 when stripe signature is invalid', function (): void {
+    config(['cashier.webhook.secret' => 'whsec_test_secret_key_for_validation']);
+
+    $this->postJson(route('cashier.webhook'), webhookPayload(), [
+        'Stripe-Signature' => 't=invalid,v1=invalidsignature',
+    ])->assertForbidden();
+});
+
+it('processes the same event id twice without creating duplicate subscriptions', function (): void {
+    $payload = webhookPayload(metadata: ['model' => 'company']);
+
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), $payload)
+        ->assertSuccessful();
+
+    $this->withoutMiddleware(VerifyWebhookSignature::class)
+        ->postJson(route('cashier.webhook'), $payload)
+        ->assertSuccessful();
+
+    expect(Subscription::query()->count())->toBe(0);
+});

--- a/app-modules/billing/tests/Unit/ConfigPlanRepositoryTest.php
+++ b/app-modules/billing/tests/Unit/ConfigPlanRepositoryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Contracts\Config\Repository;
+use TresPontosTech\Billing\Core\Entities\PlanEntity;
+use TresPontosTech\Billing\Core\Repositories\ConfigPlanRepository;
+
+function configWithPlans(array $plans): ConfigPlanRepository
+{
+    config(['cashier.plans' => $plans]);
+
+    return new ConfigPlanRepository(resolve(Repository::class));
+}
+
+function fakePlanConfig(array $overrides = []): array
+{
+    return array_merge([
+        'product_id' => 'prod_test',
+        'prices' => [
+            ['type' => 'default', 'price_id' => 'price_' . uniqid(), 'metadata' => []],
+        ],
+        'trial_days' => false,
+        'has_generic_trial' => false,
+        'allow_promotion_codes' => false,
+        'collect_tax_ids' => false,
+        'metered_price' => false,
+    ], $overrides);
+}
+
+it('all() returns all plans from config as PlanEntity instances', function (): void {
+    $repo = configWithPlans([
+        'user_gold' => fakePlanConfig(['product_id' => 'prod_gold']),
+        'user_platinum' => fakePlanConfig(['product_id' => 'prod_platinum']),
+    ]);
+
+    $plans = $repo->all();
+
+    expect($plans)->toHaveCount(2)
+        ->and($plans['user_gold'])->toBeInstanceOf(PlanEntity::class)
+        ->and($plans['user_platinum'])->toBeInstanceOf(PlanEntity::class);
+});
+
+it('all() returns empty array when no plans are configured', function (): void {
+    $repo = configWithPlans([]);
+
+    expect($repo->all())->toBeEmpty();
+});
+
+it('get() returns the correct PlanEntity by key', function (): void {
+    $repo = configWithPlans([
+        'user_gold' => fakePlanConfig(['product_id' => 'prod_gold']),
+    ]);
+
+    $plan = $repo->get('user_gold');
+
+    expect($plan)->toBeInstanceOf(PlanEntity::class)
+        ->and($plan->productId)->toBe('prod_gold');
+});
+
+it('getPlansFor() returns only plans starting with the given prefix', function (): void {
+    $repo = configWithPlans([
+        'company' => fakePlanConfig(['product_id' => 'prod_company']),
+        'user_gold' => fakePlanConfig(['product_id' => 'prod_gold']),
+        'user_platinum' => fakePlanConfig(['product_id' => 'prod_platinum']),
+    ]);
+
+    $userPlans = $repo->getPlansFor('user');
+
+    expect($userPlans)->toHaveCount(2)
+        ->and($userPlans->pluck('productId')->toArray())->toContain('prod_gold', 'prod_platinum');
+});
+
+it('getActiveTenantPlan() returns the first plan starting with "company"', function (): void {
+    $repo = configWithPlans([
+        'user_gold' => fakePlanConfig(['product_id' => 'prod_gold']),
+        'company' => fakePlanConfig(['product_id' => 'prod_company']),
+    ]);
+
+    $plan = $repo->getActiveTenantPlan();
+
+    expect($plan)->toBeInstanceOf(PlanEntity::class)
+        ->and($plan->productId)->toBe('prod_company');
+});


### PR DESCRIPTION
- Adiciona testes para ConfigPlanRepository (unit)
- Adiciona testes para RedirectCompanyIfNotSubscribed e RedirectUserIfNotSubscribed (feature)
- Adiciona testes para SubscriptionWebhookController (feature)
- Adiciona testes para SyncStripeResourcesCommand com fake HTTP client do Stripe
- Adiciona testes para CompanyBillingProvider e UserBillingProvider
- Cria SubscriptionFactory com states (active, trialing, pastDue, canceled, forCompany)
- Corrige bug em ConfigPlanRepository: argumento name ausente no construtor de PlanEntity

Close #147 