### PR TITLE
test(tenant): cover middleware and key rotation action

### DIFF
--- a/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
+++ b/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Ramsey\Uuid\Uuid;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\Tenant\Actions\TenantSecretKeyRotationAction;
+
+uses(RefreshDatabase::class);
+
+it('generates a new UUID and updates the company integration access key', function (): void {
+    $company = Company::factory()->create();
+    $oldKey = $company->integration_access_key;
+
+    $newKey = resolve(TenantSecretKeyRotationAction::class)->generate($company);
+
+    $company->refresh();
+
+    expect($newKey)->not->toBe($oldKey);
+    expect($company->integration_access_key)->toBe($newKey);
+    expect(Uuid::isValid($newKey))->toBeTrue();
+});
+
+it('the generated key is a valid UUID v4', function (): void {
+    $company = Company::factory()->create();
+
+    $newKey = resolve(TenantSecretKeyRotationAction::class)->generate($company);
+
+    expect(Uuid::isValid($newKey))->toBeTrue();
+});
+
+it('replaces the previous token completely', function (): void {
+    $company = Company::factory()->create();
+    $originalKey = $company->integration_access_key;
+
+    $firstRotation = resolve(TenantSecretKeyRotationAction::class)->generate($company);
+    $company->refresh();
+    expect($company->integration_access_key)->toBe($firstRotation);
+
+    $secondRotation = resolve(TenantSecretKeyRotationAction::class)->generate($company);
+    $company->refresh();
+
+    expect($company->integration_access_key)->toBe($secondRotation);
+    expect($company->integration_access_key)->not->toBe($originalKey);
+    expect($company->integration_access_key)->not->toBe($firstRotation);
+});

--- a/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
+++ b/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
@@ -1,11 +1,8 @@
 <?php
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Ramsey\Uuid\Uuid;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Tenant\Actions\TenantSecretKeyRotationAction;
-
-uses(RefreshDatabase::class);
 
 it('generates a new UUID and updates the company integration access key', function (): void {
     $company = Company::factory()->create();

--- a/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
+++ b/app-modules/tenant/tests/Feature/Actions/TenantSecretKeyRotationActionTest.php
@@ -22,7 +22,7 @@ it('the generated key is a valid UUID v4', function (): void {
 
     $newKey = resolve(TenantSecretKeyRotationAction::class)->generate($company);
 
-    expect(Uuid::isValid($newKey))->toBeTrue();
+    expect(Uuid::fromString($newKey)->getVersion())->toBe(4);
 });
 
 it('replaces the previous token completely', function (): void {

--- a/app-modules/tenant/tests/Feature/Http/Middleware/VerifyTenantTokenMiddlewareTest.php
+++ b/app-modules/tenant/tests/Feature/Http/Middleware/VerifyTenantTokenMiddlewareTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Symfony\Component\HttpFoundation\Response;
+use TresPontosTech\Company\Models\Company;
+
+use function Pest\Laravel\postJson;
+
+beforeEach(function (): void {
+    $this->company = Company::factory()->create();
+});
+
+it('returns 401 when the required header is missing', function (): void {
+    $response = postJson(
+        route('api.v1.company.users.store', ['tenant' => $this->company->slug]),
+        ['name' => 'Test', 'email' => 'test@example.com', 'external_id' => '123'],
+        [] // No header
+    );
+
+    expect($response->status())->toBe(Response::HTTP_UNAUTHORIZED);
+    expect($response->json('error'))->toBe('Unauthorized');
+});
+
+it('returns 403 when the token does not belong to any company', function (): void {
+    $response = postJson(
+        route('api.v1.company.users.store', ['tenant' => $this->company->slug]),
+        ['name' => 'Test', 'email' => 'test@example.com', 'external_id' => '123'],
+        [config('tenant.header') => 'invalid-token-that-does-not-exist']
+    );
+
+    expect($response->status())->toBe(Response::HTTP_FORBIDDEN);
+});
+
+it('returns 403 when using a token from a different tenant', function (): void {
+    $otherCompany = Company::factory()->create();
+
+    $response = postJson(
+        route('api.v1.company.users.store', ['tenant' => $otherCompany->slug]),
+        ['name' => 'Test', 'email' => 'test@example.com', 'external_id' => '123'],
+        [config('tenant.header') => $this->company->integration_access_key]
+    );
+
+    expect($response->status())->toBe(Response::HTTP_FORBIDDEN);
+});
+
+it('allows the request when the token and tenant are both valid', function (): void {
+    $response = postJson(
+        route('api.v1.company.users.store', ['tenant' => $this->company->slug]),
+        ['name' => 'Test User', 'email' => 'test@example.com', 'external_id' => '123'],
+        [config('tenant.header') => $this->company->integration_access_key]
+    );
+
+    expect($response->status())->toBe(Response::HTTP_CREATED);
+});


### PR DESCRIPTION
## Summary

This pull request adds comprehensive tests for the tenant module's API authentication and key management:

### What's now tested

- **Middleware Authentication**: The system now verifies that requests without the required tenant header return 401, requests with invalid tokens return 403, and cross-tenant requests (using one tenant's token to access another) are rejected.

- **Valid Request Handling**: Authenticated requests with valid tokens are allowed to proceed and successfully execute their intended operations.

- **Key Rotation**: The system ensures that rotating a tenant's secret key generates a new valid UUID, completely replaces the previous key, and can be rotated multiple times without issues.

These tests strengthen the security posture of the tenant isolation layer and the key management system used for external API integrations.

Closes #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for tenant secret key rotation, validating new key generation, persistence, UUID v4 format, and that successive rotations replace prior keys reliably.
  * Added tests for tenant token verification middleware, covering missing/invalid tokens, cross-tenant token rejection, and successful tenant-matching requests for user creation endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->