### PR TITLE
test(user): cover PersistImportedUsersAction — issue #153

### DIFF
--- a/app-modules/user/tests/Feature/Actions/ParseUsersFromFileActionTest.php
+++ b/app-modules/user/tests/Feature/Actions/ParseUsersFromFileActionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\User\Actions\ParseUsersFromFileAction;
+
+function makeParseTestCsv(array $rows, array $headers = ['name', 'email', 'document_id', 'tax_id', 'phone_number']): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'parse_test_') . '.csv';
+    $handle = fopen($path, 'w');
+    fputcsv($handle, $headers);
+    foreach ($rows as $row) {
+        fputcsv($handle, $row);
+    }
+
+    fclose($handle);
+
+    return $path;
+}
+
+it('reads a CSV file and returns a Collection of arrays', function (): void {
+    $csv = makeParseTestCsv([
+        ['João Silva', 'joao@example.com', '12345678', '12345678901', '11999999999'],
+        ['Maria Costa', 'maria@example.com', '87654321', '98765432100', '21988887777'],
+    ]);
+
+    $result = resolve(ParseUsersFromFileAction::class)->execute($csv, 'csv');
+
+    expect($result)->toHaveCount(2)
+        ->and($result[0]['email'])->toBe('joao@example.com')
+        ->and($result[1]['email'])->toBe('maria@example.com');
+});
+
+it('skips completely empty rows', function (): void {
+    $csv = makeParseTestCsv([
+        ['João Silva', 'joao@example.com', '12345678', '12345678901', '11999999999'],
+        ['', '', '', '', ''],
+        ['Maria Costa', 'maria@example.com', '87654321', '98765432100', '21988887777'],
+    ]);
+
+    $result = resolve(ParseUsersFromFileAction::class)->execute($csv, 'csv');
+
+    expect($result)->toHaveCount(2);
+});
+
+it('sanitizes tax_id and phone_number by removing non-numeric characters', function (): void {
+    $csv = makeParseTestCsv([
+        ['João Silva', 'joao@example.com', '12345678', '123.456.789-01', '(11) 99999-9999'],
+    ]);
+
+    $result = resolve(ParseUsersFromFileAction::class)->execute($csv, 'csv');
+
+    expect($result[0]['tax_id'])->toBe('12345678901')
+        ->and($result[0]['phone_number'])->toBe('11999999999');
+});
+
+it('adds __row_number to each row matching the spreadsheet line number', function (): void {
+    $csv = makeParseTestCsv([
+        ['João Silva', 'joao@example.com', '12345678', '12345678901', '11999999999'],
+        ['Maria Costa', 'maria@example.com', '87654321', '98765432100', '21988887777'],
+    ]);
+
+    $result = resolve(ParseUsersFromFileAction::class)->execute($csv, 'csv');
+
+    expect($result[0]['__row_number'])->toBe(2)
+        ->and($result[1]['__row_number'])->toBe(3);
+});

--- a/app-modules/user/tests/Feature/Actions/PersistImportedUsersActionTest.php
+++ b/app-modules/user/tests/Feature/Actions/PersistImportedUsersActionTest.php
@@ -2,7 +2,6 @@
 
 use App\Models\Users\Detail;
 use App\Models\Users\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Mail;
 use TresPontosTech\Company\Models\Company;
@@ -13,8 +12,6 @@ use TresPontosTech\User\Mail\WelcomeUserMail;
 use function Pest\Laravel\assertDatabaseCount;
 use function Pest\Laravel\assertDatabaseHas;
 use function Pest\Laravel\assertDatabaseMissing;
-
-uses(RefreshDatabase::class);
 
 function makeUserRows(int $count, int $startIndex = 1): Collection
 {

--- a/app-modules/user/tests/Feature/Actions/PersistImportedUsersActionTest.php
+++ b/app-modules/user/tests/Feature/Actions/PersistImportedUsersActionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\Users\Detail;
+use App\Models\Users\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Mail;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\Permissions\Roles;
+use TresPontosTech\User\Actions\PersistImportedUsersAction;
+use TresPontosTech\User\Mail\WelcomeUserMail;
+
+use function Pest\Laravel\assertDatabaseCount;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+
+uses(RefreshDatabase::class);
+
+function makeUserRows(int $count, int $startIndex = 1): Collection
+{
+    return collect(range($startIndex, $startIndex + $count - 1))->map(fn (int $i): array => [
+        'name' => 'User ' . $i,
+        'email' => sprintf('persistuser%d@example.com', $i),
+        'tax_id' => str_pad((string) $i, 11, '0', STR_PAD_LEFT),
+        'phone_number' => '11' . str_pad((string) $i, 9, '0', STR_PAD_LEFT),
+        'document_id' => 'DOC' . $i,
+    ]);
+}
+
+it('persists users, details, company pivot, and roles in batch', function (): void {
+    Mail::fake();
+
+    $company = Company::factory()->create();
+    $rows = makeUserRows(3);
+
+    $result = resolve(PersistImportedUsersAction::class)->execute($rows, $company);
+
+    expect($result->imported)->toBe(3)
+        ->and($result->errors)->toBeEmpty();
+
+    assertDatabaseCount(User::class, 1 + 3); // 1 company owner + 3 imported
+    assertDatabaseCount(Detail::class, 3);
+
+    foreach ($rows as $row) {
+        assertDatabaseHas(User::class, ['email' => $row['email']]);
+
+        $user = User::query()->where('email', $row['email'])->first();
+
+        expect($company->employees()->wherePivot('user_id', $user->id)->exists())->toBeTrue();
+        expect($user->hasRole(Roles::Employee))->toBeTrue();
+    }
+});
+
+it('queues a welcome email for each created user', function (): void {
+    Mail::fake();
+
+    $company = Company::factory()->create();
+    $rows = makeUserRows(2);
+
+    resolve(PersistImportedUsersAction::class)->execute($rows, $company);
+
+    Mail::assertQueued(WelcomeUserMail::class, 2);
+});
+
+it('returns an ImportUsersResultDTO with the correct imported count', function (): void {
+    Mail::fake();
+
+    $company = Company::factory()->create();
+    $rows = makeUserRows(5);
+
+    $result = resolve(PersistImportedUsersAction::class)->execute($rows, $company);
+
+    expect($result->imported)->toBe(5)
+        ->and($result->hasErrors())->toBeFalse();
+});
+
+it('a rollback in one chunk does not affect previously persisted chunks', function (): void {
+    Mail::fake();
+
+    $company = Company::factory()->create();
+
+    // Create a user that will cause a unique constraint violation in chunk 2
+    User::factory()->create(['email' => 'conflict@example.com']);
+
+    // 100 valid rows → chunk 1
+    $rows = makeUserRows(100, startIndex: 1000);
+
+    // 1 conflicting row → triggers rollback in chunk 2
+    $rows->push([
+        'name' => 'Conflict User',
+        'email' => 'conflict@example.com',
+        'tax_id' => '99999999999',
+        'phone_number' => '11999999999',
+        'document_id' => 'DOCCONFLICT',
+    ]);
+
+    $threwException = false;
+    try {
+        resolve(PersistImportedUsersAction::class)->execute($rows, $company);
+    } catch (Throwable) {
+        $threwException = true;
+    }
+
+    expect($threwException)->toBeTrue();
+
+    // 1 pre-existing conflict user + 100 users from chunk 1 (chunk 2 rolled back)
+    assertDatabaseCount(User::class, 1 + 1 + 100);
+
+    // The conflicting email is not duplicated (still only the original user)
+    expect(User::query()->where('email', 'conflict@example.com')->count())->toBe(1);
+
+    // Users from chunk 1 are persisted
+    assertDatabaseHas(User::class, ['email' => 'persistuser1000@example.com']);
+    assertDatabaseMissing(User::class, ['email' => 'persistuser1101@example.com']);
+});

--- a/app-modules/user/tests/Feature/Actions/ValidateUserImportActionTest.php
+++ b/app-modules/user/tests/Feature/Actions/ValidateUserImportActionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\Detail;
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\Enums\CompanyPlanStatusEnum;
+use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\User\Actions\ValidateUserImportAction;
+
+function makeValidationRow(array $overrides = []): array
+{
+    static $counter = 0;
+    ++$counter;
+
+    return array_merge([
+        'name' => 'User ' . $counter,
+        'email' => 'user' . $counter . '@example.com',
+        'document_id' => '1234567' . $counter,
+        'tax_id' => str_pad((string) ($counter * 100000000), 11, '0', STR_PAD_LEFT),
+        'phone_number' => '1199999' . str_pad((string) $counter, 4, '0', STR_PAD_LEFT),
+        '__row_number' => $counter + 1,
+    ], $overrides);
+}
+
+it('returns an empty array when all data is valid', function (): void {
+    $company = Company::factory()->create();
+    $rows = collect([makeValidationRow()]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->toBeEmpty();
+});
+
+it('returns an error when required columns are missing', function (): void {
+    $company = Company::factory()->create();
+    $rows = collect([['name' => 'João', '__row_number' => 2]]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0]->message)->toContain('Colunas ausentes');
+});
+
+it('returns an error for a tax_id with fewer than 11 digits', function (): void {
+    $company = Company::factory()->create();
+    $rows = collect([makeValidationRow(['tax_id' => '123456'])]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0]->message)->toContain('tax_id');
+});
+
+it('returns an error for a phone_number with fewer than 10 digits', function (): void {
+    $company = Company::factory()->create();
+    $rows = collect([makeValidationRow(['phone_number' => '12345'])]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0]->message)->toContain('phone_number');
+});
+
+it('returns an error for duplicate emails in the spreadsheet', function (): void {
+    $company = Company::factory()->create();
+    $rows = collect([
+        makeValidationRow(['email' => 'same@example.com']),
+        makeValidationRow(['email' => 'same@example.com']),
+    ]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and(collect($errors)->first(fn ($e): bool => str_contains($e->message, 'duplicado'))->message)
+        ->toContain('duplicado');
+});
+
+it('returns an error for a tax_id already registered in the system', function (): void {
+    $company = Company::factory()->create();
+    $existingUser = User::factory()->create();
+    Detail::factory()->for($existingUser)->create(['tax_id' => '12345678901']);
+
+    $rows = collect([makeValidationRow(['tax_id' => '12345678901'])]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0]->message)->toContain('já cadastrado');
+});
+
+it('returns an error when the seat limit is exceeded', function (): void {
+    $company = Company::factory()->create();
+
+    $existingEmployee = User::factory()->create();
+    $company->employees()->attach($existingEmployee->getKey(), ['active' => true]);
+
+    $plan = Plan::factory()->create(['active' => true]);
+    CompanyPlan::query()->create([
+        'company_id' => $company->id,
+        'plan_id' => $plan->id,
+        'status' => CompanyPlanStatusEnum::Active->value,
+        'monthly_appointments_per_employee' => 1,
+        'starts_at' => now()->subDay(),
+        'seats' => 1,
+    ]);
+
+    $rows = collect([makeValidationRow()]);
+
+    $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
+
+    expect($errors)->not->toBeEmpty()
+        ->and($errors[0]->message)->toContain('Limite de assentos');
+});

--- a/app-modules/user/tests/Feature/Jobs/ImportUsersJobTest.php
+++ b/app-modules/user/tests/Feature/Jobs/ImportUsersJobTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\User\Actions\PersistImportedUsersAction;
+use TresPontosTech\User\Jobs\ImportUsersJob;
+
+function makeJobRows(int $count = 2): Collection
+{
+    return collect(range(1, $count))->map(fn (int $i): array => [
+        'name' => 'User ' . $i,
+        'email' => 'jobuser' . $i . '@example.com',
+        'document_id' => 'DOC' . $i,
+        'tax_id' => str_pad((string) ($i * 100000000), 11, '0', STR_PAD_LEFT),
+        'phone_number' => '11' . str_pad((string) $i, 9, '9', STR_PAD_LEFT),
+        'password' => 'password',
+        '__row_number' => $i + 1,
+    ]);
+}
+
+it('persists users when the job is handled with a valid company', function (): void {
+    $company = Company::factory()->create();
+    $rows = makeJobRows(2);
+
+    $job = new ImportUsersJob($rows, $company->id, 'any-user-id');
+    $job->handle(resolve(PersistImportedUsersAction::class));
+
+    expect(User::query()->whereIn('email', ['jobuser1@example.com', 'jobuser2@example.com'])->count())->toBe(2);
+});
+
+it('throws ModelNotFoundException when the company does not exist', function (): void {
+    $job = new ImportUsersJob(collect(), 'non-existent-id', 'any-user-id');
+
+    expect(fn () => $job->handle(resolve(PersistImportedUsersAction::class)))
+        ->toThrow(ModelNotFoundException::class);
+});
+
+it('logs an error when the failed method is called', function (): void {
+    Log::spy();
+
+    $companyId = 'non-existent-id';
+    $job = new ImportUsersJob(collect(), $companyId, 'any-user-id');
+    $exception = new RuntimeException('Something went wrong');
+
+    $job->failed($exception);
+
+    Log::shouldHaveReceived('error')
+        ->once()
+        ->with('ImportUsersJob falhou', Mockery::subset(['company_id' => $companyId]));
+});


### PR DESCRIPTION
## What was tested

- The **PersistImportedUsersAction**, the most critical step of the user import pipeline:
  - Persists users, details, company pivot entries, and role assignments in batch
  - Queues a welcome email for each newly created user
  - Returns a result DTO with the correct imported user count
  - Guarantees that a failure in one chunk (e.g. duplicate email) does not roll back previously persisted chunks — users imported before the failing chunk are kept in the database

## Why it matters

This action processes bulk user imports using chunked transactions. Without tests, a regression in the rollback boundary logic could silently discard hundreds of already-imported users on a batch failure. These tests pin down the transactional guarantees the system must uphold.

Closes #153