### PR TITLE
test(panel-app): cover RedirectIfAnamneseNotCompleted middleware — issue #155

### DIFF
--- a/app-modules/panel-app/tests/Feature/Filament/Actions/FeedbackActionTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Actions/FeedbackActionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\App\Filament\Resources\Appointments\Pages\ListAppointments;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentFeedback;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->employee = actingAsSubscribedEmployee();
+});
+
+it('is visible on a completed appointment with no feedback', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Completed)
+        ->create(['user_id' => $this->employee->id]);
+
+    livewire(ListAppointments::class)
+        ->assertTableActionVisible('feedback', $appointment);
+});
+
+it('is hidden on a completed appointment that already has feedback', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Completed)
+        ->create(['user_id' => $this->employee->id]);
+
+    AppointmentFeedback::factory()->create([
+        'appointment_id' => $appointment->id,
+        'user_id' => $this->employee->id,
+    ]);
+
+    livewire(ListAppointments::class)
+        ->assertTableActionHidden('feedback', $appointment);
+});
+
+it('is hidden on non-completed appointments', function (AppointmentStatus $status): void {
+    $appointment = Appointment::factory()
+        ->withStatus($status)
+        ->create(['user_id' => $this->employee->id]);
+
+    livewire(ListAppointments::class)
+        ->assertTableActionHidden('feedback', $appointment);
+})->with([
+    'Pending' => AppointmentStatus::Pending,
+    'Active' => AppointmentStatus::Active,
+    'Cancelled' => AppointmentStatus::Cancelled,
+]);
+
+it('creates an AppointmentFeedback record when submitted', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Completed)
+        ->create(['user_id' => $this->employee->id]);
+
+    livewire(ListAppointments::class)
+        ->callTableAction('feedback', $appointment, data: [
+            'rating' => 5,
+            'comment' => 'Excellent session!',
+        ])
+        ->assertNotified();
+
+    expect(AppointmentFeedback::query()->where('appointment_id', $appointment->id)->exists())->toBeTrue();
+});

--- a/app-modules/panel-app/tests/Feature/Filament/Pages/AnamneseWizardPageTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Pages/AnamneseWizardPageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\App\Filament\Pages\AnamneseWizardPage;
+use TresPontosTech\User\Enums\LifeMoment;
+use TresPontosTech\User\Models\UserAnamnese;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->employee = actingAsEmployee();
+});
+
+it('renders the anamnese wizard page', function (): void {
+    livewire(AnamneseWizardPage::class)
+        ->assertOk();
+});
+
+it('saves the anamnese on submit', function (): void {
+    livewire(AnamneseWizardPage::class)
+        ->set('data.life_moment', LifeMoment::Saver->value)
+        ->set('data.main_motivation', 'I want financial freedom.')
+        ->set('data.money_relationship', 'I manage money carefully.')
+        ->set('data.plans_monthly_expenses', '3000')
+        ->set('data.tried_financial_strategies', 'Budgeting and investing.')
+        ->call('submit')
+        ->assertNotified();
+
+    expect(UserAnamnese::query()->where('user_id', $this->employee->id)->exists())->toBeTrue();
+});

--- a/app-modules/panel-app/tests/Feature/Filament/Pages/UserSubscriptionPageTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Pages/UserSubscriptionPageTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\App\Filament\Pages\UserSubscriptionPage;
+use TresPontosTech\Billing\Core\Repositories\PlanRepository;
+
+use function Pest\Livewire\livewire;
+
+it('renders the subscription page with available plans', function (): void {
+    actingAsEmployee();
+
+    $this->mock(PlanRepository::class, function ($mock): void {
+        $mock->shouldReceive('getPlansFor')->andReturn(collect());
+    });
+
+    livewire(UserSubscriptionPage::class)
+        ->assertOk();
+});

--- a/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/AppointmentWizardTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/AppointmentWizardTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\App\Filament\Resources\Appointments\Pages\CreateAppointment;
+
+use function Pest\Livewire\livewire;
+
+it('renders the create appointment wizard for a subscribed employee', function (): void {
+    actingAsSubscribedEmployee();
+
+    livewire(CreateAppointment::class)
+        ->assertOk();
+});

--- a/app-modules/panel-app/tests/Feature/Http/Middleware/RedirectIfAnamneseNotCompletedTest.php
+++ b/app-modules/panel-app/tests/Feature/Http/Middleware/RedirectIfAnamneseNotCompletedTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CompanyPlanStatusEnum;
+use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Billing\Stripe\Subscription\User\RedirectUserIfNotSubscribed;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\User\Models\UserAnamnese;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function (): void {
+    $this->employee = User::factory()->employee()->create();
+    $this->company = Company::factory()->create();
+    $this->company->employees()->attach($this->employee->getKey());
+
+    $plan = Plan::factory()->createOne([
+        'provider' => BillingProviderEnum::Stripe->value,
+        'type' => BillableTypeEnum::User->value,
+        'provider_product_id' => 'prod_test',
+        'has_generic_trial' => false,
+        'allow_promotion_codes' => false,
+        'collect_tax_ids' => false,
+        'active' => true,
+        'slug' => 'plano-teste',
+        'statement_descriptor' => 'PLANO TESTE',
+    ]);
+
+    CompanyPlan::query()->create([
+        'company_id' => $this->company->id,
+        'plan_id' => $plan->id,
+        'status' => CompanyPlanStatusEnum::Active->value,
+        'monthly_appointments_per_employee' => 1,
+        'starts_at' => now()->subDay(),
+        'seats' => 10,
+    ]);
+
+    filament()->setCurrentPanel(FilamentPanel::User->value);
+    actingAs($this->employee);
+    filament()->setTenant($this->company);
+});
+
+it('redirects a user with an active plan and no anamnese to the anamnese wizard', function (): void {
+    $this->get(route('filament.app.pages.user-dashboard', ['tenant' => $this->company->slug]))
+        ->assertRedirect(route('filament.app.pages.anamnese', ['tenant' => $this->company->slug]));
+});
+
+it('allows access when the anamnese is already filled', function (): void {
+    UserAnamnese::factory()->create(['user_id' => $this->employee->id]);
+
+    $this->get(route('filament.app.pages.user-dashboard', ['tenant' => $this->company->slug]))
+        ->assertOk();
+});
+
+it('allows access to the anamnese route itself to avoid a redirect loop', function (): void {
+    $this->get(route('filament.app.pages.anamnese', ['tenant' => $this->company->slug]))
+        ->assertOk();
+});
+
+it('allows access when there is no active subscription or plan', function (): void {
+    CompanyPlan::query()->where('company_id', $this->company->id)->delete();
+
+    $this->withoutMiddleware(RedirectUserIfNotSubscribed::class)
+        ->get(route('filament.app.pages.user-dashboard', ['tenant' => $this->company->slug]))
+        ->assertOk();
+});


### PR DESCRIPTION
## What was tested

- The **Redirect If Anamnese Not Completed** middleware, which protects the employee panel:
  - Redirects a user who has an active plan but has not yet filled their anamnese to the anamnese wizard
  - Allows access normally when the user has already completed the anamnese
  - Allows access to the anamnese route itself, preventing an infinite redirect loop
  - Allows access when there is no active subscription or plan (no point redirecting to anamnese if the user can't access the system anyway)

## Why it matters

This middleware is the first gate users encounter after login. If it redirects incorrectly, users can get stuck in a loop or be blocked from content they're entitled to. These tests pin down all four branching paths so regressions are caught immediately.

Closes #155