### PR TITLE
test(google-calendar): freeze time to fix hardcoded date assertions

### DIFF
--- a/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Actions/SyncConsultantCalendarActionTest.php
@@ -16,6 +16,7 @@ use Zap\Facades\Zap;
 use Zap\Models\Schedule;
 
 beforeEach(function (): void {
+    Date::setTestNow('2026-04-29 09:00:00');
     $this->consultant = Consultant::factory()->create(['email' => 'consultant@workspace.com']);
 });
 

--- a/app-modules/integration-google-calendar/tests/Feature/Actions/UpsertBlockedScheduleActionTest.php
+++ b/app-modules/integration-google-calendar/tests/Feature/Actions/UpsertBlockedScheduleActionTest.php
@@ -9,8 +9,13 @@ use Zap\Facades\Zap;
 use Zap\Models\Schedule;
 
 beforeEach(function (): void {
+    Date::setTestNow('2026-04-29 09:00:00');
     $this->consultant = Consultant::factory()->create(['email' => 'consultant@workspace.com']);
     $this->action = resolve(UpsertBlockedScheduleAction::class);
+});
+
+afterEach(function (): void {
+    Date::setTestNow();
 });
 
 function makeEvent(string $eventId, string $updated): GoogleEventDTO


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test suite reliability by establishing consistent baseline dates for time-dependent test scenarios, ensuring predictable behavior across calendar integration test executions with proper test time setup and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->