### PR TITLE
ci(phpstan): configura analise estatica modular no level 0

### DIFF
--- a/app-modules/appointments/phpstan.ignore.neon
+++ b/app-modules/appointments/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/appointments/phpstan.neon
+++ b/app-modules/appointments/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/billing/phpstan.ignore.neon
+++ b/app-modules/billing/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/billing/phpstan.neon
+++ b/app-modules/billing/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/company/phpstan.ignore.neon
+++ b/app-modules/company/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/company/phpstan.neon
+++ b/app-modules/company/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/consultants/phpstan.ignore.neon
+++ b/app-modules/consultants/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/consultants/phpstan.neon
+++ b/app-modules/consultants/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/integration-google-calendar/phpstan.ignore.neon
+++ b/app-modules/integration-google-calendar/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/integration-google-calendar/phpstan.neon
+++ b/app-modules/integration-google-calendar/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/integration-highlevel/phpstan.ignore.neon
+++ b/app-modules/integration-highlevel/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/integration-highlevel/phpstan.neon
+++ b/app-modules/integration-highlevel/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/panel-admin/phpstan.ignore.neon
+++ b/app-modules/panel-admin/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/panel-admin/phpstan.neon
+++ b/app-modules/panel-admin/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/panel-app/phpstan.ignore.neon
+++ b/app-modules/panel-app/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/panel-app/phpstan.neon
+++ b/app-modules/panel-app/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/panel-company/phpstan.ignore.neon
+++ b/app-modules/panel-company/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/panel-company/phpstan.neon
+++ b/app-modules/panel-company/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/panel-consultant/phpstan.ignore.neon
+++ b/app-modules/panel-consultant/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/panel-consultant/phpstan.neon
+++ b/app-modules/panel-consultant/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/tenant/phpstan.ignore.neon
+++ b/app-modules/tenant/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/tenant/phpstan.neon
+++ b/app-modules/tenant/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app-modules/user/phpstan.ignore.neon
+++ b/app-modules/user/phpstan.ignore.neon
@@ -1,0 +1,2 @@
+parameters:
+    ignoreErrors:

--- a/app-modules/user/phpstan.neon
+++ b/app-modules/user/phpstan.neon
@@ -1,9 +1,6 @@
 includes:
-    - phpstan.modules.php
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
-
     paths:
-        - app
+        - src/

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -207,7 +207,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasDefaul
      * @return Builder<User>
      */
     #[Scope]
-    public function whereNotSharedWith(Builder $query, string $documentId): Builder
+    protected function whereNotSharedWith(Builder $query, string $documentId): Builder
     {
         return $query->whereDoesntHave('sharedDocuments', function (Builder $subquery) use ($documentId): void {
             $subquery->where('document_id', $documentId);

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,7 @@
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",
         "pestphp/pest-plugin-livewire": "^4.0",
+        "phpstan/extension-installer": "^1.4",
         "rector/rector": "^2.1"
     },
     "autoload": {
@@ -144,7 +145,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "phpstan/extension-installer": true
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e0d10e4b4d1136d8fbd90f682c068d1",
+    "content-hash": "d1f7b325f193288e75da0b784eaf2a89",
     "packages": [
         {
             "name": "3pontos-tech/appointments",
@@ -15227,6 +15227,54 @@
             "time": "2026-01-06T21:53:42+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "2.3.2",
             "source": {
@@ -17026,5 +17074,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Models\Users\User;
 
 return [

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 
 return [

--- a/config/cashier.php
+++ b/config/cashier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Laravel\Cashier\Console\WebhookCommand;
 use Laravel\Cashier\Invoices\DompdfInvoiceRenderer;
 

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 
 return [

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;

--- a/config/session.php
+++ b/config/session.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 
 return [

--- a/phpstan.ignore.neon
+++ b/phpstan.ignore.neon
@@ -1,0 +1,6 @@
+parameters:
+    ignoreErrors:
+        - message: '#^Call to an undefined method App\\Providers\\FilamentServiceProvider::getId\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: app/Providers/FilamentServiceProvider.php

--- a/phpstan.modules.php
+++ b/phpstan.modules.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+$includes = [];
+
+foreach (glob(__DIR__ . '/app-modules/*/phpstan.neon') as $file) {
+    if (is_file($file)) {
+        $includes[] = $file;
+    }
+}
+
+return ['includes' => $includes];


### PR DESCRIPTION
## Problema

O `phpstan.neon` da raiz rodava em `level: max`, mas analisava **somente `app/`** — os 13 módulos em `app-modules/*/src` ficavam de fora. O módulo `permissions` tinha `phpstan.neon`/`phpstan.ignore.neon`, mas o root não os incluía, então eram inertes. Na prática, a análise estática cobria uma fração do código.

## Solução

Espelha a arquitetura modular do `recruit-party-quest`: **uma única execução**, **um `level` global**, paths agregados via glob e cada módulo dono do seu próprio arquivo de ignores.

- **`phpstan/extension-installer`** adicionado ao `require-dev` e habilitado em `allow-plugins` → o larastan (e o carbon) passam a auto-registrar, dispensando os includes explícitos no root (essencial: o CI roda `composer install` do zero).
- **`phpstan.neon` (raiz):** `includes: [phpstan.modules.php, phpstan.ignore.neon]`, `level: 0`, `paths: [app]`.
- **`phpstan.modules.php`:** faz glob de `app-modules/*/phpstan.neon` e inclui cada um.
- **`phpstan.ignore.neon` (raiz):** único false positive do level 0 — `FilamentServiceProvider::getId()` (rebind de `$this` em macro do Filament).
- **13 módulos** com `phpstan.neon` (`paths: src/`) + `phpstan.ignore.neon` (vazio).

Ponto de partida: **level 0 verde**. A subida 1→7 vem em PRs seguintes (1 por nível nos saltos pequenos; saltos grandes — levels 2 e 6 — divididos por módulo). Política: corrigir de verdade, ignorar só false positives. Nenhuma mudança no workflow de CI foi necessária.

## Arquivos Alterados

- `composer.json` / `composer.lock` — extension-installer + allow-plugins
- `phpstan.neon`, `phpstan.modules.php`, `phpstan.ignore.neon` — config da raiz
- `app-modules/*/phpstan.neon` + `app-modules/*/phpstan.ignore.neon` — 12 módulos novos (`permissions` já existia)

## Verificação

- `vendor/bin/phpstan analyse` → `[OK] No errors` (level 0, cobrindo `app` + 13 módulos)
- Prova de cobertura: forçando `--level=1`, reaparecem 63 erros em 22 arquivos de `app-modules/`
- Suíte completa (`composer test`): 782 passed, 2 skipped, 0 falhas