### PR TITLE
ci(phpstan): sobe a analise estatica modular do level 1 ao 7

### DIFF
--- a/app-modules/appointments/src/Actions/GetAvailableSlotsAction.php
+++ b/app-modules/appointments/src/Actions/GetAvailableSlotsAction.php
@@ -7,6 +7,9 @@ use TresPontosTech\Consultants\Models\Consultant;
 
 readonly class GetAvailableSlotsAction
 {
+    /**
+     * @return array<string, string>
+     */
     public function handle(Carbon $date, int $durationMinutes = 60, int $bufferMinutes = 0): array
     {
         $consultants = Consultant::all();

--- a/app-modules/appointments/src/Actions/Records/CreateAppointmentRecordFromUploadAction.php
+++ b/app-modules/appointments/src/Actions/Records/CreateAppointmentRecordFromUploadAction.php
@@ -33,6 +33,10 @@ final readonly class CreateAppointmentRecordFromUploadAction
 
         $path = $file->storeAs(self::STORAGE_DIRECTORY, $filename, self::STORAGE_DISK);
 
+        if ($path === false) {
+            throw new \RuntimeException(sprintf('Failed to store appointment record file "%s".', $filename));
+        }
+
         dispatch(new GenerateAppointmentRecordJob($record->id, self::STORAGE_DISK, $path));
 
         return $record;

--- a/app-modules/appointments/src/Actions/Records/GenerateRecordDraftAction.php
+++ b/app-modules/appointments/src/Actions/Records/GenerateRecordDraftAction.php
@@ -191,9 +191,17 @@ readonly class GenerateRecordDraftAction
 
             $response = $builder->withPrompt($fullPrompt)->asStructured();
         } else {
+            $rawContent = $file->get();
+
+            throw_if(
+                $rawContent === false,
+                PrismException::class,
+                sprintf('Failed to read uploaded document "%s".', $file->getClientOriginalName()),
+            );
+
             $response = $builder->withPrompt($promptHeader, [
                 Document::fromRawContent(
-                    rawContent: $file->get(),
+                    rawContent: $rawContent,
                     mimeType: $file->getMimeType(),
                 ),
             ])->asStructured();

--- a/app-modules/appointments/src/DTO/BookAppointmentDTO.php
+++ b/app-modules/appointments/src/DTO/BookAppointmentDTO.php
@@ -16,6 +16,9 @@ class BookAppointmentDTO implements JsonSerializable
         public ?string $notes = null,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(int|string $userId, array $payload): self
     {
         return new self(

--- a/app-modules/appointments/src/Enums/AppointmentCategoryEnum.php
+++ b/app-modules/appointments/src/Enums/AppointmentCategoryEnum.php
@@ -8,7 +8,6 @@ use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Contracts\Support\Htmlable;
 
 enum AppointmentCategoryEnum: string implements HasColor, HasDescription, HasIcon, HasLabel
 {
@@ -24,7 +23,7 @@ enum AppointmentCategoryEnum: string implements HasColor, HasDescription, HasIco
 
     case RiskAndCompliance = 'risk_and_compliance';
 
-    public function getDescription(): string|Htmlable|null
+    public function getDescription(): string
     {
         return __('appointments::categories.' . $this->value . '.description');
     }
@@ -53,7 +52,7 @@ enum AppointmentCategoryEnum: string implements HasColor, HasDescription, HasIco
         };
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return __('appointments::categories.' . $this->value . '.label');
     }

--- a/app-modules/appointments/src/Enums/AppointmentStatus.php
+++ b/app-modules/appointments/src/Enums/AppointmentStatus.php
@@ -7,7 +7,6 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Contracts\Support\Htmlable;
 use TresPontosTech\Appointments\Actions\Transitions\AbstractAppointmentTransition;
 use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CancelledLateTransition;
@@ -50,7 +49,7 @@ enum AppointmentStatus: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return __(
             'appointments::enums.appointment_status.' . $this->value

--- a/app-modules/appointments/src/Mail/AppointmentCancelledMail.php
+++ b/app-modules/appointments/src/Mail/AppointmentCancelledMail.php
@@ -34,7 +34,7 @@ class AppointmentCancelledMail extends Mailable implements ShouldQueue
             markdown: 'emails.appointments.cancelled',
             with: [
                 'userName' => $this->appointment->user->name,
-                'consultantName' => $this->appointment->consultant?->name ?? __('appointments::mail.no_consultant'),
+                'consultantName' => $this->appointment->consultant->name ?? __('appointments::mail.no_consultant'),
                 'appointmentAt' => $this->appointment->appointment_at,
                 'panelUrl' => $this->resolvePanelUrl(),
             ],

--- a/app-modules/appointments/src/Mail/AppointmentUserCancelledLateMail.php
+++ b/app-modules/appointments/src/Mail/AppointmentUserCancelledLateMail.php
@@ -34,7 +34,7 @@ class AppointmentUserCancelledLateMail extends Mailable implements ShouldQueue
             markdown: 'emails.appointments.cancelled-late',
             with: [
                 'userName' => $this->appointment->user->name,
-                'consultantName' => $this->appointment->consultant?->name ?? __('appointments::mail.no_consultant'),
+                'consultantName' => $this->appointment->consultant->name ?? __('appointments::mail.no_consultant'),
                 'appointmentAt' => $this->appointment->appointment_at,
                 'panelUrl' => $this->resolvePanelUrl(),
             ],

--- a/app-modules/appointments/src/Models/Appointment.php
+++ b/app-modules/appointments/src/Models/Appointment.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Actions\Transitions\AbstractAppointmentTransition;
+use TresPontosTech\Appointments\Database\Factories\AppointmentFactory;
 use TresPontosTech\Appointments\Enums\AppointmentCategoryEnum;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Enums\CancellationActor;
@@ -39,7 +40,9 @@ use TresPontosTech\Consultants\Models\Consultant;
  */
 class Appointment extends Model
 {
+    /** @use HasFactory<AppointmentFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 
@@ -70,6 +73,9 @@ class Appointment extends Model
         ];
     }
 
+    /**
+     * @return Attribute<AbstractAppointmentTransition, never>
+     */
     protected function currentTransition(): Attribute
     {
         return Attribute::make(get: fn (): AbstractAppointmentTransition => $this->status->transition($this));

--- a/app-modules/appointments/src/Models/Appointment.php
+++ b/app-modules/appointments/src/Models/Appointment.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Actions\Transitions\AbstractAppointmentTransition;
 use TresPontosTech\Appointments\Enums\AppointmentCategoryEnum;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
@@ -18,6 +19,24 @@ use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Consultants\Models\Consultant;
 
+/**
+ * @property string $id
+ * @property string|null $consultant_id
+ * @property string $user_id
+ * @property AppointmentCategoryEnum $category_type
+ * @property Carbon $appointment_at
+ * @property AppointmentStatus $status
+ * @property string|null $notes
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property string|null $company_id
+ * @property string|null $meeting_url
+ * @property string|null $google_event_id
+ * @property string|null $cancelled_by
+ * @property CancellationActor|null $cancellation_actor
+ * @property-read AbstractAppointmentTransition $current_transition
+ */
 class Appointment extends Model
 {
     use HasFactory;
@@ -56,36 +75,57 @@ class Appointment extends Model
         return Attribute::make(get: fn (): AbstractAppointmentTransition => $this->status->transition($this));
     }
 
+    /**
+     * @return BelongsTo<Consultant, $this>
+     */
     public function consultant(): BelongsTo
     {
         return $this->belongsTo(Consultant::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function cancelledBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'cancelled_by');
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return HasOne<AppointmentFeedback, $this>
+     */
     public function feedback(): HasOne
     {
         return $this->hasOne(AppointmentFeedback::class);
     }
 
+    /**
+     * @return HasOne<AppointmentRecord, $this>
+     */
     public function record(): HasOne
     {
         return $this->hasOne(AppointmentRecord::class);
     }
 
+    /**
+     * @return HasOne<UserCredit, $this>
+     */
     public function credit(): HasOne
     {
         return $this->hasOne(UserCredit::class);

--- a/app-modules/appointments/src/Models/AppointmentFeedback.php
+++ b/app-modules/appointments/src/Models/AppointmentFeedback.php
@@ -20,6 +20,7 @@ use TresPontosTech\Appointments\Database\Factories\AppointmentFeedbackFactory;
  */
 class AppointmentFeedback extends Model
 {
+    /** @use HasFactory<AppointmentFeedbackFactory> */
     use HasFactory;
 
     protected $table = 'appointment_feedbacks';

--- a/app-modules/appointments/src/Models/AppointmentFeedback.php
+++ b/app-modules/appointments/src/Models/AppointmentFeedback.php
@@ -6,8 +6,18 @@ use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Database\Factories\AppointmentFeedbackFactory;
 
+/**
+ * @property int $id
+ * @property string $appointment_id
+ * @property string $user_id
+ * @property int $rating
+ * @property string|null $comment
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class AppointmentFeedback extends Model
 {
     use HasFactory;
@@ -33,11 +43,17 @@ class AppointmentFeedback extends Model
         return AppointmentFeedbackFactory::new();
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -33,7 +33,9 @@ use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
 {
+    /** @use HasFactory<AppointmentRecordFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 
@@ -86,6 +88,10 @@ class AppointmentRecord extends Model
         $this->update(['generation_started_at' => null]);
     }
 
+    /**
+     * @param  Builder<AppointmentRecord>  $query
+     * @return Builder<AppointmentRecord>
+     */
     #[Scope]
     protected function published(Builder $query): Builder
     {

--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -17,7 +17,18 @@ use TresPontosTech\Appointments\Database\Factories\AppointmentRecordFactory;
 use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 
 /**
+ * @property string $id
+ * @property string $appointment_id
+ * @property string|null $content
+ * @property string|null $internal_summary
+ * @property string|null $model_used
+ * @property int|null $input_tokens
+ * @property int|null $output_tokens
+ * @property Carbon|null $generation_started_at
  * @property Carbon|null $published_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
@@ -52,6 +63,9 @@ class AppointmentRecord extends Model
         return AppointmentRecordFactory::new();
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);

--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -12,9 +12,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Database\Factories\AppointmentRecordFactory;
 use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 
+/**
+ * @property Carbon|null $published_at
+ */
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
 {

--- a/app-modules/appointments/src/Support/DocumentTextExtractor.php
+++ b/app-modules/appointments/src/Support/DocumentTextExtractor.php
@@ -89,7 +89,7 @@ readonly class DocumentTextExtractor
     {
         foreach ($container->getElements() as $element) {
             if ($element instanceof Text) {
-                $lines[] = $element->getText();
+                $lines[] = $element->getText() ?? '';
 
                 continue;
             }

--- a/app-modules/billing/phpstan.ignore.neon
+++ b/app-modules/billing/phpstan.ignore.neon
@@ -1,2 +1,7 @@
 parameters:
     ignoreErrors:
+        # Cashier Checkout expõe ->url via __get mágico (encaminha para a Stripe Session).
+        - message: '#^Access to an undefined property Laravel\\Cashier\\Checkout::\$url\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Stripe/Subscription/StripeAdapter.php

--- a/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
+++ b/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
@@ -20,6 +20,7 @@ use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCreated;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionDefaulted;
 use TresPontosTech\Billing\Core\Models\BillingCustomer;
 use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Company\Models\Company;
 
 class HandleBarteWebhook
 {
@@ -117,7 +118,13 @@ class HandleBarteWebhook
 
         $billable = $modelClass::query()->findOrFail($billableId);
 
-        $owner = $billable instanceof User ? $billable : $billable->owner;
+        if ($billable instanceof User) {
+            $owner = $billable;
+        } elseif ($billable instanceof Company) {
+            $owner = $billable->owner;
+        } else {
+            return;
+        }
 
         Notification::make()
             ->title(__('billing::notifications.credit_order_created.title'))

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -149,6 +149,9 @@ final readonly class BarteAdapter implements BillingContract
 
     }
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(User|Company $billable, string $returnUrl, array $options = []): string
     {
         if ($billable instanceof Company) {

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -35,7 +35,7 @@ final readonly class BarteAdapter implements BillingContract
             return;
         }
 
-        if ($billable instanceof User && blank($billable?->detail)) {
+        if ($billable instanceof User && blank($billable->detail)) {
             return;
         }
 

--- a/app-modules/billing/src/Barte/BarteClient.php
+++ b/app-modules/billing/src/Barte/BarteClient.php
@@ -19,6 +19,9 @@ final class BarteClient
             ->timeout(30);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getPlans(): array
     {
         $response = $this->http->get('/v2/plans');
@@ -33,6 +36,9 @@ final class BarteClient
         return $response->json();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function createBuyer(CreateBuyerDto $dto): array
     {
         $response = $this->http->post('/v2/buyers', $dto->toArray());
@@ -47,6 +53,9 @@ final class BarteClient
         return $response->json();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function createPaymentLink(CreatePaymentLinkDto $dto): array
     {
         $response = $this->http->post('/v2/payment-links', $dto->toArray());

--- a/app-modules/billing/src/Barte/Commands/SyncBartePlans.php
+++ b/app-modules/billing/src/Barte/Commands/SyncBartePlans.php
@@ -18,23 +18,34 @@ class SyncBartePlans extends Command
     {
         $response = $client->getPlans();
 
-        $plans = collect($response['content'] ?? $response);
+        /** @var list<array<string, mixed>> $bartePlans */
+        $bartePlans = $response['content'] ?? $response;
+
+        $plans = collect($bartePlans);
 
         $this->table(
             ['UUID', 'Título', 'Ativo', 'Métodos', 'Valores'],
-            $plans->map(fn (array $p): array => [
-                $p['uuid'],
-                $p['title'],
-                $p['active'] ? 'sim' : 'não',
-                implode(', ', $p['acceptPaymentMethods'] ?? []),
-                collect($p['values'] ?? [])->map(fn ($v): string => sprintf('%s: %s', $v['type'], $v['valuePerMonth']))->join(' | '),
-            ])
+            $plans->map(function (array $p): array {
+                /** @var list<array<string, mixed>> $values */
+                $values = $p['values'] ?? [];
+
+                return [
+                    $p['uuid'],
+                    $p['title'],
+                    $p['active'] ? 'sim' : 'não',
+                    implode(', ', $p['acceptPaymentMethods'] ?? []),
+                    collect($values)->map(fn (array $v): string => sprintf('%s: %s', $v['type'], $v['valuePerMonth']))->join(' | '),
+                ];
+            })
         );
 
         foreach ($plans as $bartePlan) {
             $plan = $this->persistPlan($bartePlan);
 
-            collect($bartePlan['values'] ?? [])
+            /** @var list<array<string, mixed>> $planValues */
+            $planValues = $bartePlan['values'] ?? [];
+
+            collect($planValues)
                 ->filter(fn (array $value): bool => $value['type'] === 'MONTHLY')
                 ->each(fn (array $value) => $plan->prices()->updateOrCreate(
                     ['provider_price_id' => $bartePlan['uuid']],
@@ -60,6 +71,9 @@ class SyncBartePlans extends Command
         'flamma-platinum-barte' => 30000,
     ];
 
+    /**
+     * @param  array<string, mixed>  $bartePlan
+     */
     private function syncFlammaPrices(Plan $plan, array $bartePlan): void
     {
         $flammaPriceInCents = self::FLAMMA_PRICES[$plan->slug] ?? null;
@@ -82,6 +96,9 @@ class SyncBartePlans extends Command
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $bartePlan
+     */
     private function persistPlan(array $bartePlan): Plan
     {
         return Plan::query()->updateOrCreate(

--- a/app-modules/billing/src/Barte/DTOs/BarteWebhookDto.php
+++ b/app-modules/billing/src/Barte/DTOs/BarteWebhookDto.php
@@ -9,6 +9,9 @@ use TresPontosTech\Billing\Barte\Enums\BarteWebhookEventEnum;
 
 readonly class BarteWebhookDto
 {
+    /**
+     * @param  Collection<string, mixed>  $metadata
+     */
     public function __construct(
         public string $uuid,
         public string $domain,
@@ -17,14 +20,20 @@ readonly class BarteWebhookDto
         public Collection $metadata,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function fromArray(array $payload): self
     {
+        /** @var list<array<string, mixed>> $metadata */
+        $metadata = $payload['metadata'] ?? [];
+
         return new self(
             uuid: $payload['uuid'],
             domain: $payload['domain'],
             event: BarteWebhookEventEnum::tryFrom($payload['status']),
             uuidBuyer: $payload['uuidBuyer'] ?? null,
-            metadata: collect($payload['metadata'] ?? [])->pluck('value', 'key'),
+            metadata: collect($metadata)->pluck('value', 'key'),
         );
     }
 }

--- a/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
+++ b/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
@@ -23,7 +23,7 @@ readonly class CreateBuyerDto
             documentNumber: $billable instanceof Company ? $billable->tax_id : $billable->detail->tax_id,
             documentType: $billable instanceof Company ? 'cnpj' : 'cpf',
             name: $billable->name,
-            email: $billable->email ?? $billable->owner->email,
+            email: $billable instanceof Company ? $billable->owner->email : $billable->email,
         );
     }
 

--- a/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
+++ b/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
@@ -27,6 +27,9 @@ readonly class CreateBuyerDto
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/DTOs/CreatePaymentLinkDto.php
+++ b/app-modules/billing/src/Barte/DTOs/CreatePaymentLinkDto.php
@@ -6,6 +6,10 @@ namespace TresPontosTech\Billing\Barte\DTOs;
 
 readonly class CreatePaymentLinkDto
 {
+    /**
+     * @param  list<array<string, mixed>>  $metadata
+     * @param  list<string>  $paymentMethods
+     */
     public function __construct(
         public string $uuidSellerClient,
         public string $scheduledDate,
@@ -16,6 +20,9 @@ readonly class CreatePaymentLinkDto
         public ?PaymentOrderDto $paymentOrder = null,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $data = [

--- a/app-modules/billing/src/Barte/DTOs/PaymentOrderDto.php
+++ b/app-modules/billing/src/Barte/DTOs/PaymentOrderDto.php
@@ -6,6 +6,9 @@ namespace TresPontosTech\Billing\Barte\DTOs;
 
 readonly class PaymentOrderDto
 {
+    /**
+     * @param  list<array<string, mixed>>  $customInstallmentsValues
+     */
     public function __construct(
         public string $title,
         public float $value,
@@ -18,6 +21,9 @@ readonly class PaymentOrderDto
         public bool $requiresLiabilityShift = false,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/DTOs/PaymentSubscriptionDto.php
+++ b/app-modules/billing/src/Barte/DTOs/PaymentSubscriptionDto.php
@@ -12,6 +12,9 @@ readonly class PaymentSubscriptionDto
         public string $type = 'MONTHLY',
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/Jobs/HandleBarteWebhookJob.php
+++ b/app-modules/billing/src/Barte/Jobs/HandleBarteWebhookJob.php
@@ -24,6 +24,9 @@ class HandleBarteWebhookJob implements ShouldQueue
 
     public int $timeout = 60;
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public function __construct(public readonly array $payload) {}
 
     public function handle(HandleBarteWebhook $action): void

--- a/app-modules/billing/src/Core/Commands/SyncBillingCustomersCommand.php
+++ b/app-modules/billing/src/Core/Commands/SyncBillingCustomersCommand.php
@@ -29,6 +29,9 @@ class SyncBillingCustomersCommand extends Command
         $this->info('Done.');
     }
 
+    /**
+     * @param  iterable<int, Company|User>  $billables
+     */
     private function syncBillables(iterable $billables, string $label): void
     {
         $created = 0;

--- a/app-modules/billing/src/Core/Contracts/BillingContract.php
+++ b/app-modules/billing/src/Core/Contracts/BillingContract.php
@@ -20,6 +20,9 @@ interface BillingContract
 
     public function checkoutOpensInNewTab(): bool;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(Company|User $billable, string $returnUrl, array $options = []): string;
 
     public function hasActiveSubscription(Company|User $billable): bool;

--- a/app-modules/billing/src/Core/DTOs/CheckoutData.php
+++ b/app-modules/billing/src/Core/DTOs/CheckoutData.php
@@ -6,6 +6,9 @@ namespace TresPontosTech\Billing\Core\DTOs;
 
 final readonly class CheckoutData
 {
+    /**
+     * @param  array<string, string>  $metadata
+     */
     public function __construct(
         public string $planSlug,
         public string $priceId,

--- a/app-modules/billing/src/Core/Entities/PriceEntity.php
+++ b/app-modules/billing/src/Core/Entities/PriceEntity.php
@@ -4,6 +4,9 @@ namespace TresPontosTech\Billing\Core\Entities;
 
 class PriceEntity implements \JsonSerializable
 {
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
     public function __construct(
         public string $type,
         public string $priceId,
@@ -14,6 +17,9 @@ class PriceEntity implements \JsonSerializable
         public array $metadata = []
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(
@@ -23,6 +29,9 @@ class PriceEntity implements \JsonSerializable
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function fromEloquent(array $payload): self
     {
         return new self(

--- a/app-modules/billing/src/Core/Enums/BillableTypeEnum.php
+++ b/app-modules/billing/src/Core/Enums/BillableTypeEnum.php
@@ -9,7 +9,6 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Contracts\Support\Htmlable;
 use TresPontosTech\Company\Models\Company;
 
 enum BillableTypeEnum: string implements HasColor, HasIcon, HasLabel
@@ -18,7 +17,7 @@ enum BillableTypeEnum: string implements HasColor, HasIcon, HasLabel
 
     case Company = Company::class;
 
-    public function getColor(): string|array|null
+    public function getColor(): array
     {
         return match ($this) {
             self::User => Color::Blue,
@@ -26,7 +25,7 @@ enum BillableTypeEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getIcon(): string|BackedEnum|null
+    public function getIcon(): BackedEnum
     {
         return match ($this) {
             self::User => Heroicon::User,
@@ -34,7 +33,7 @@ enum BillableTypeEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return $this->name;
     }

--- a/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
+++ b/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
@@ -38,6 +38,8 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
     /**
      * Providers whose existing subscriptions are considered valid for access.
      * Includes legacy providers while their plans have not yet expired.
+     *
+     * @return list<self>
      */
     public static function activeCases(): array
     {
@@ -46,6 +48,8 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
 
     /**
      * Available Providers for NEW Subscriptions.
+     *
+     * @return list<self>
      */
     public static function checkoutCases(): array
     {

--- a/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
+++ b/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
@@ -2,12 +2,10 @@
 
 namespace TresPontosTech\Billing\Core\Enums;
 
-use BackedEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
-use Illuminate\Contracts\Support\Htmlable;
 
 enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
 {
@@ -15,7 +13,7 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
     case Contractual = 'contractual';
     case Barte = 'barte';
 
-    public function getColor(): string|array|null
+    public function getColor(): array
     {
         return match ($this) {
             self::Stripe => Color::Indigo,
@@ -24,7 +22,7 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getIcon(): string|BackedEnum|null
+    public function getIcon(): string
     {
         return match ($this) {
             self::Stripe, self::Barte => 'heroicon-o-credit-card',
@@ -32,7 +30,7 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return $this->name;
     }

--- a/app-modules/billing/src/Core/Enums/CompanyPlanStatusEnum.php
+++ b/app-modules/billing/src/Core/Enums/CompanyPlanStatusEnum.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace TresPontosTech\Billing\Core\Enums;
 
-use BackedEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
-use Illuminate\Contracts\Support\Htmlable;
 
 enum CompanyPlanStatusEnum: string implements HasColor, HasIcon, HasLabel
 {
@@ -18,7 +16,7 @@ enum CompanyPlanStatusEnum: string implements HasColor, HasIcon, HasLabel
     case Suspended = 'suspended';
     case Cancelled = 'cancelled';
 
-    public function getColor(): string|array|null
+    public function getColor(): array
     {
         return match ($this) {
             self::Active => Color::Emerald,
@@ -28,7 +26,7 @@ enum CompanyPlanStatusEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getIcon(): string|BackedEnum|null
+    public function getIcon(): string
     {
         return match ($this) {
             self::Active => 'heroicon-o-check-circle',
@@ -38,7 +36,7 @@ enum CompanyPlanStatusEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return match ($this) {
             self::Active => 'Ativo',

--- a/app-modules/billing/src/Core/Enums/UserCreditStatusEnum.php
+++ b/app-modules/billing/src/Core/Enums/UserCreditStatusEnum.php
@@ -7,7 +7,6 @@ namespace TresPontosTech\Billing\Core\Enums;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
-use Illuminate\Contracts\Support\Htmlable;
 
 enum UserCreditStatusEnum: string implements HasColor, HasLabel
 {
@@ -16,7 +15,7 @@ enum UserCreditStatusEnum: string implements HasColor, HasLabel
     case Used = 'used';
     case Expired = 'expired';
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return match ($this) {
             self::Available => __('billing::enums.user_credit_status.available'),
@@ -26,7 +25,7 @@ enum UserCreditStatusEnum: string implements HasColor, HasLabel
         };
     }
 
-    public function getColor(): array|string
+    public function getColor(): array
     {
         return match ($this) {
             self::Available => Color::Emerald,

--- a/app-modules/billing/src/Core/Models/BillingCustomer.php
+++ b/app-modules/billing/src/Core/Models/BillingCustomer.php
@@ -6,10 +6,21 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Billing\Database\Factories\BillingCustomerFactory;
 
+/**
+ * @property int $id
+ * @property string $billable_type
+ * @property string $billable_id
+ * @property BillingProviderEnum $provider
+ * @property string $provider_customer_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class BillingCustomer extends Model
 {
     use HasFactory;

--- a/app-modules/billing/src/Core/Models/BillingCustomer.php
+++ b/app-modules/billing/src/Core/Models/BillingCustomer.php
@@ -61,7 +61,7 @@ class BillingCustomer extends Model
             ->value('provider_customer_id');
     }
 
-    public static function getActiveProvider(Model $billable): null|BillingProviderEnum|string
+    public static function getActiveProvider(Model $billable): ?BillingProviderEnum
     {
         $provider = Subscription::query()
             ->where('subscriptionable_type', $billable->getMorphClass())
@@ -76,10 +76,14 @@ class BillingCustomer extends Model
             return BillingProviderEnum::from($provider);
         }
 
-        return static::query()
+        $fallbackProvider = static::query()
             ->where('billable_type', $billable->getMorphClass())
             ->where('billable_id', $billable->getKey())
             ->latest()
             ->value('provider');
+
+        return $fallbackProvider !== null
+            ? BillingProviderEnum::from($fallbackProvider)
+            : null;
     }
 }

--- a/app-modules/billing/src/Core/Models/BillingCustomer.php
+++ b/app-modules/billing/src/Core/Models/BillingCustomer.php
@@ -23,11 +23,16 @@ use TresPontosTech\Billing\Database\Factories\BillingCustomerFactory;
  */
 class BillingCustomer extends Model
 {
+    /** @use HasFactory<BillingCustomerFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_customers';
 
+    /**
+     * @return BillingCustomerFactory
+     */
     protected static function newFactory(): Factory
     {
         return BillingCustomerFactory::new();

--- a/app-modules/billing/src/Core/Models/CompanyPlan.php
+++ b/app-modules/billing/src/Core/Models/CompanyPlan.php
@@ -28,7 +28,9 @@ use TresPontosTech\Company\Models\Company;
  */
 class CompanyPlan extends Model
 {
+    /** @use HasFactory<CompanyPlanFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 

--- a/app-modules/billing/src/Core/Models/CompanyPlan.php
+++ b/app-modules/billing/src/Core/Models/CompanyPlan.php
@@ -7,12 +7,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\CompanyPlanStatusEnum;
 use TresPontosTech\Billing\Database\Factories\CompanyPlanFactory;
 use TresPontosTech\Company\Models\Company;
 
 /**
+ * @property string $id
+ * @property string $company_id
+ * @property int $plan_id
+ * @property int $seats
  * @property int $monthly_appointments_per_employee
+ * @property CompanyPlanStatusEnum $status
+ * @property Carbon|null $starts_at
+ * @property Carbon|null $ends_at
+ * @property string|null $notes
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 class CompanyPlan extends Model
 {
@@ -43,11 +55,17 @@ class CompanyPlan extends Model
         ];
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class, 'plan_id');

--- a/app-modules/billing/src/Core/Models/Plan.php
+++ b/app-modules/billing/src/Core/Models/Plan.php
@@ -6,10 +6,30 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Database\Factories\PlanFactory;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property BillingProviderEnum $provider
+ * @property string|null $provider_product_id
+ * @property int|null $trial_days
+ * @property bool|null $has_generic_trial
+ * @property bool|null $allow_promotion_codes
+ * @property bool|null $collect_tax_ids
+ * @property bool $active
+ * @property string $slug
+ * @property BillableTypeEnum $type
+ * @property string|null $unit_label
+ * @property string|null $statement_descriptor
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class Plan extends Model
 {
     use HasFactory;
@@ -44,6 +64,9 @@ class Plan extends Model
         ];
     }
 
+    /**
+     * @return HasMany<Price, $this>
+     */
     public function prices(): HasMany
     {
         return $this->hasMany(Price::class, 'billing_plan_id');

--- a/app-modules/billing/src/Core/Models/Plan.php
+++ b/app-modules/billing/src/Core/Models/Plan.php
@@ -32,7 +32,9 @@ use TresPontosTech\Billing\Database\Factories\PlanFactory;
  */
 class Plan extends Model
 {
+    /** @use HasFactory<PlanFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_plans';

--- a/app-modules/billing/src/Core/Models/Price.php
+++ b/app-modules/billing/src/Core/Models/Price.php
@@ -29,7 +29,9 @@ use TresPontosTech\Billing\Database\Factories\PriceFactory;
  */
 class Price extends Model
 {
+    /** @use HasFactory<PriceFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_plan_prices';

--- a/app-modules/billing/src/Core/Models/Price.php
+++ b/app-modules/billing/src/Core/Models/Price.php
@@ -6,10 +6,26 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Database\Factories\PriceFactory;
 
 /**
+ * @property int $id
+ * @property int $billing_plan_id
+ * @property string $billing_scheme
+ * @property string $tiers_mode
+ * @property string $type
+ * @property int $unit_amount_decimal
+ * @property bool $active
+ * @property bool $default
+ * @property string $provider_price_id
+ * @property bool $whatsapp_enabled
+ * @property bool $materials_enabled
  * @property int $monthly_appointments
+ * @property array<array-key, mixed>|null $metadata
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 class Price extends Model
 {
@@ -33,6 +49,9 @@ class Price extends Model
         'metadata',
     ];
 
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class, 'billing_plan_id');

--- a/app-modules/billing/src/Core/Models/Subscriptions/Subscription.php
+++ b/app-modules/billing/src/Core/Models/Subscriptions/Subscription.php
@@ -6,10 +6,24 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
 use Laravel\Cashier\Subscription as BaseSubscriptionModel;
 use TresPontosTech\Billing\Core\Models\Plan;
 use TresPontosTech\Billing\Core\Models\Price;
 
+/**
+ * @property string $subscriptionable_type
+ * @property string $subscriptionable_id
+ * @property string $type
+ * @property string $stripe_id
+ * @property string $stripe_status
+ * @property string|null $stripe_price
+ * @property int|null $quantity
+ * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $ends_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class Subscription extends BaseSubscriptionModel
 {
     protected $table = 'billing_subscriptions';

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -10,11 +10,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Database\Factories\UserCreditFactory;
 use TresPontosTech\Company\Models\Company;
 
+/**
+ * @property string $id
+ * @property string $owner_id
+ * @property string $holder_id
+ * @property string $company_id
+ * @property UserCreditStatusEnum $status
+ * @property string|null $appointment_id
+ * @property Carbon|null $transferred_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class UserCredit extends Model
 {
     use HasFactory;
@@ -38,21 +51,33 @@ class UserCredit extends Model
         ];
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function holder(): BelongsTo
     {
         return $this->belongsTo(User::class, 'holder_id');
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -30,7 +30,9 @@ use TresPontosTech\Company\Models\Company;
  */
 class UserCredit extends Model
 {
+    /** @use HasFactory<UserCreditFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 

--- a/app-modules/billing/src/Core/Pages/TenantSubscriptionPage.php
+++ b/app-modules/billing/src/Core/Pages/TenantSubscriptionPage.php
@@ -76,7 +76,7 @@ class TenantSubscriptionPage extends Page
             collectTaxIds: $plan->collectTaxIds,
             successUrl: Dashboard::getUrl(),
             cancelUrl: Dashboard::getUrl(),
-            metadata: ['model' => Relation::getMorphAlias(Company::class)],
+            metadata: ['model' => (string) Relation::getMorphAlias(Company::class)],
         );
 
         $driver = resolve(BillingManager::class)->getDriver($this->checkoutProvider());

--- a/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
@@ -37,9 +37,15 @@ final readonly class ConfigPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $plan
+     */
     private function createPlanFromArray(array $plan, string $name): PlanEntity
     {
-        $prices = collect(Arr::get($plan, key: 'prices', default: []))
+        /** @var list<array<string, mixed>> $pricesConfig */
+        $pricesConfig = Arr::get($plan, key: 'prices', default: []);
+
+        $prices = collect($pricesConfig)
             ->map(fn (array $price): PriceEntity => PriceEntity::make($price));
 
         return new PlanEntity(
@@ -56,12 +62,18 @@ final readonly class ConfigPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @return Collection<string, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection
     {
         return collect($this->all())
             ->filter(fn ($plan, $key): bool => str_starts_with($key, $name));
     }
 
+    /**
+     * @return Collection<string, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection
     {
         return $this->getPlansFor($name);

--- a/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
@@ -16,6 +16,9 @@ final readonly class ConfigPlanRepository implements PlanRepository
         private Repository $config,
     ) {}
 
+    /**
+     * @return array<string, PlanEntity>
+     */
     #[Override]
     public function all(): array
     {

--- a/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
@@ -29,6 +29,9 @@ class EloquentPlanRepository implements PlanRepository
         return collect($this->all())->firstOrFail(fn (PlanEntity $plan): bool => $plan->slug === $name);
     }
 
+    /**
+     * @return Collection<int, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection
     {
         return Cache::remember('active_user_plans', 15, fn () => Plan::query()
@@ -40,6 +43,9 @@ class EloquentPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @return Collection<int, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection
     {
         return Cache::remember('checkout_user_plans', 15, fn () => Plan::query()

--- a/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
@@ -11,13 +11,16 @@ use TresPontosTech\Billing\Core\Models\Plan;
 
 class EloquentPlanRepository implements PlanRepository
 {
+    /**
+     * @return array<string, PlanEntity>
+     */
     public function all(): array
     {
         return Plan::query()
             ->where('active', true)
             ->whereIn('provider', BillingProviderEnum::activeCases())
             ->get()
-            ->map(fn (Plan $plan): PlanEntity => PlanEntity::fromEloquent($plan))
+            ->mapWithKeys(fn (Plan $plan): array => [$plan->slug => PlanEntity::fromEloquent($plan)])
             ->all();
     }
 

--- a/app-modules/billing/src/Core/Repositories/PlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/PlanRepository.php
@@ -17,9 +17,16 @@ interface PlanRepository
 
     public function get(string $name): PlanEntity;
 
+    /**
+     * @return Collection<array-key, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection;
 
-    /** Planos disponíveis para NOVAS assinaturas (usa checkoutCases). */
+    /**
+     * Planos disponíveis para NOVAS assinaturas (usa checkoutCases).
+     *
+     * @return Collection<array-key, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection;
 
     public function getActiveTenantPlan(BillingProviderEnum $provider): PlanEntity;

--- a/app-modules/billing/src/Core/Repositories/PlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/PlanRepository.php
@@ -11,7 +11,7 @@ use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 interface PlanRepository
 {
     /**
-     * @return array<int, PlanEntity>
+     * @return array<string, PlanEntity>
      */
     public function all(): array;
 

--- a/app-modules/billing/src/Stripe/Subscription/Company/CompanyBillingProvider.php
+++ b/app-modules/billing/src/Stripe/Subscription/Company/CompanyBillingProvider.php
@@ -9,7 +9,6 @@ use Filament\Billing\Providers\Contracts\BillingProvider;
 use Filament\Facades\Filament;
 use Filament\Pages\Dashboard;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Routing\Redirector;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Models\BillingCustomer;
@@ -19,7 +18,7 @@ class CompanyBillingProvider implements BillingProvider
 {
     public function getRouteAction(): string|Closure|array
     {
-        return static function (): Redirector|RedirectResponse {
+        return static function (): RedirectResponse {
             /** @var Company $tenant */
             $tenant = Filament::getTenant();
 

--- a/app-modules/billing/src/Stripe/Subscription/Company/CompanyBillingProvider.php
+++ b/app-modules/billing/src/Stripe/Subscription/Company/CompanyBillingProvider.php
@@ -28,7 +28,7 @@ class CompanyBillingProvider implements BillingProvider
 
             $driver = $providerEnum instanceof BillingProviderEnum
                 ? $billing->getDriver(BillingProviderEnum::from($providerEnum->value))
-                : $billing->getDefaultDriver();
+                : $billing->getDriver();
 
             $driver->ensureCustomerExists($tenant);
 

--- a/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
@@ -19,7 +19,7 @@ class RedirectCompanyIfNotSubscribed
 
     public function handle(Request $request, Closure $next, string ...$plans): Response
     {
-        /** @var Company|Filament $tenant */
+        /** @var Company $tenant */
         $tenant = Filament::getTenant();
 
         if ($tenant->slug === 'flamma-company') {

--- a/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Billing\Stripe\Subscription\Company;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Repositories\PlanRepository;
@@ -16,7 +17,7 @@ class RedirectCompanyIfNotSubscribed
         private readonly BillingManager $billingManager,
     ) {}
 
-    public function handle(Request $request, Closure $next, string ...$plans)
+    public function handle(Request $request, Closure $next, string ...$plans): Response
     {
         /** @var Company|Filament $tenant */
         $tenant = Filament::getTenant();

--- a/app-modules/billing/src/Stripe/Subscription/StripeAdapter.php
+++ b/app-modules/billing/src/Stripe/Subscription/StripeAdapter.php
@@ -72,6 +72,9 @@ class StripeAdapter implements BillingContract
         return $session->asStripeCheckoutSession()->url;
     }
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(Company|User $billable, string $returnUrl, array $options = []): string
     {
         return $billable

--- a/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
+++ b/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
@@ -57,7 +57,7 @@ class SubscriptionWebhookController extends WebhookController
 
         $company = Company::query()->find($companyId);
 
-        if (! $company) {
+        if (! $company instanceof Company) {
             return $this->successMethod();
         }
 
@@ -65,7 +65,7 @@ class SubscriptionWebhookController extends WebhookController
             ? User::query()->find($ownerId)
             : $company->owner;
 
-        if (! $owner) {
+        if (! $owner instanceof User) {
             return $this->successMethod();
         }
 

--- a/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
+++ b/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
@@ -31,6 +31,9 @@ class SubscriptionWebhookController extends WebhookController
         return parent::handleWebhook($request);
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     protected function handleCheckoutSessionCompleted(array $payload): Response
     {
         $session = $payload['data']['object'];

--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -25,7 +25,7 @@ class RedirectUserIfNotSubscribed
 
     public function handle(Request $request, Closure $next): Response
     {
-        /** @var Company|Filament $tenant */
+        /** @var Company $tenant */
         $tenant = Filament::getTenant();
 
         if ($tenant->hasActivePlan()) {

--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -7,6 +7,7 @@ use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\Response;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Entities\PlanEntity;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
@@ -22,7 +23,7 @@ class RedirectUserIfNotSubscribed
         private readonly BillingManager $billingManager,
     ) {}
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
         /** @var Company|Filament $tenant */
         $tenant = Filament::getTenant();

--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -6,7 +6,7 @@ use App\Models\Users\User;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
-use Stripe\Collection;
+use Illuminate\Support\Collection;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Entities\PlanEntity;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
@@ -49,7 +49,6 @@ class RedirectUserIfNotSubscribed
 
         // TODO: Employee needs to pick a plan to continue
         // TODO: the plan is already settled up (by pila) so, let them continue
-
         /** @var Collection<string, PlanEntity> $availableEmployeesPlans */
         $availableEmployeesPlans = $this->planRepository->getPlansFor('user');
 

--- a/app-modules/billing/src/Stripe/Subscription/User/UserBillingProvider.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/UserBillingProvider.php
@@ -23,7 +23,7 @@ class UserBillingProvider implements BillingProvider
 
             $driver = $providerEnum instanceof BillingProviderEnum
                 ? $billing->getDriver(BillingProviderEnum::from($providerEnum->value))
-                : $billing->getDefaultDriver();
+                : $billing->getDriver();
 
             $driver->ensureCustomerExists($user);
 

--- a/app-modules/billing/src/Stripe/Subscription/User/UserBillingProvider.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/UserBillingProvider.php
@@ -5,7 +5,6 @@ namespace TresPontosTech\Billing\Stripe\Subscription\User;
 use Closure;
 use Filament\Billing\Providers\Contracts\BillingProvider;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Routing\Redirector;
 use TresPontosTech\App\Filament\Pages\UserDashboard;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
@@ -15,7 +14,7 @@ class UserBillingProvider implements BillingProvider
 {
     public function getRouteAction(): string|Closure|array
     {
-        return static function (): RedirectResponse|Redirector {
+        return static function (): RedirectResponse {
             $user = auth()->user();
 
             $providerEnum = BillingCustomer::getActiveProvider($user);

--- a/app-modules/billing/tests/Feature/Subscription/CheckoutPlansTest.php
+++ b/app-modules/billing/tests/Feature/Subscription/CheckoutPlansTest.php
@@ -64,7 +64,7 @@ it('getPlansFor() still returns plans from all active providers for subscription
 
     $plans = (new EloquentPlanRepository)->getPlansFor('user');
 
-    $productIds = $plans->map(fn ($p) => $p->productId);
+    $productIds = $plans->map(fn ($p): string => $p->productId);
 
     expect($plans)->toHaveCount(2)
         ->and($productIds)->toContain($stripePlan->provider_product_id)

--- a/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
+++ b/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
@@ -224,7 +224,7 @@ describe('user access during gateway migration', function (): void {
             barte: new FakeBillingContract(isSubscribed: false, hasActiveSubscription: false),
         );
 
-        expect(fn () => $middleware->handle(fakeRequest(), passThrough()))
+        expect(fn (): Symfony\Component\HttpFoundation\Response => $middleware->handle(fakeRequest(), passThrough()))
             ->toThrow(HttpException::class);
     });
 

--- a/app-modules/company/src/DTOs/CompanyDTO.php
+++ b/app-modules/company/src/DTOs/CompanyDTO.php
@@ -14,6 +14,9 @@ final readonly class CompanyDTO implements JsonSerializable
         public string $userId,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data): self
     {
         return new self(
@@ -25,6 +28,9 @@ final readonly class CompanyDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/company/src/Enums/DepartmentCategory.php
+++ b/app-modules/company/src/Enums/DepartmentCategory.php
@@ -42,7 +42,7 @@ enum DepartmentCategory: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getColor(): string|array|null
+    public function getColor(): string
     {
         return match ($this) {
             self::HumanResources => 'info',

--- a/app-modules/company/src/Models/Company.php
+++ b/app-modules/company/src/Models/Company.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Laravel\Cashier\Billable;
 use Ramsey\Uuid\Uuid;
 use Spatie\Image\Enums\Fit;
@@ -33,11 +34,20 @@ use TresPontosTech\Tenant\Models\TenantMember;
 use TresPontosTech\Tenant\Policies\CompanyPolicy;
 
 /**
+ * @property string $id
  * @property string $user_id
- * @property string $panel
+ * @property string $name
+ * @property string $integration_access_key
  * @property string $slug
  * @property string $tax_id
- * @property string $integration_access_key
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property string|null $stripe_id
+ * @property string|null $pm_type
+ * @property string|null $pm_last_four
+ * @property Carbon|null $trial_ends_at
+ * @property string $panel
  */
 #[UsePolicy(CompanyPolicy::class)]
 class Company extends Model implements HasAvatar, HasMedia
@@ -76,21 +86,33 @@ class Company extends Model implements HasAvatar, HasMedia
             ->first();
     }
 
+    /**
+     * @return HasMany<Appointment, $this>
+     */
     public function appointments(): HasMany
     {
         return $this->hasMany(Appointment::class);
     }
 
+    /**
+     * @return HasManyThrough<AppointmentFeedback, Appointment, $this>
+     */
     public function feedbacks(): HasManyThrough
     {
         return $this->hasManyThrough(AppointmentFeedback::class, Appointment::class);
     }
 
+    /**
+     * @return HasMany<CompanyPlan, $this>
+     */
     public function companyPlans(): HasMany
     {
         return $this->hasMany(CompanyPlan::class);
     }
 
+    /**
+     * @return BelongsToMany<Plan, $this>
+     */
     public function plans(): BelongsToMany
     {
         return $this->belongsToMany(Plan::class, 'company_plans', 'company_id', 'plan_id')
@@ -99,11 +121,17 @@ class Company extends Model implements HasAvatar, HasMedia
             ->wherePivotNull('deleted_at');
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    /**
+     * @return BelongsToMany<User, $this, TenantMember>
+     */
     public function employees(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'company_employees', 'company_id', 'user_id')
@@ -112,6 +140,9 @@ class Company extends Model implements HasAvatar, HasMedia
             ->using(TenantMember::class);
     }
 
+    /**
+     * @return HasMany<Department, $this>
+     */
     public function departments(): HasMany
     {
         return $this->hasMany(Department::class);
@@ -128,6 +159,9 @@ class Company extends Model implements HasAvatar, HasMedia
         return CompanyFactory::new();
     }
 
+    /**
+     * @return MorphMany<Subscription, $this>
+     */
     public function subscriptions(): MorphMany
     {
         return $this->morphMany(Subscription::class, 'subscriptionable');
@@ -148,10 +182,10 @@ class Company extends Model implements HasAvatar, HasMedia
     {
         $this->addMediaConversion('company-logo-avatar')
             ->performOnCollections('company_logo')
+            ->nonQueued()
             ->width(32)
             ->height(32)
-            ->fit(Fit::Crop, 32, 32)
-            ->nonQueued();
+            ->fit(Fit::Crop, 32, 32);
 
     }
 

--- a/app-modules/company/src/Models/Company.php
+++ b/app-modules/company/src/Models/Company.php
@@ -53,7 +53,10 @@ use TresPontosTech\Tenant\Policies\CompanyPolicy;
 class Company extends Model implements HasAvatar, HasMedia
 {
     use Billable;
+
+    /** @use HasFactory<CompanyFactory> */
     use HasFactory;
+
     use HasUuids;
     use InteractsWithMedia;
     use SoftDeletes;
@@ -148,8 +151,11 @@ class Company extends Model implements HasAvatar, HasMedia
         return $this->hasMany(Department::class);
     }
 
+    /**
+     * @return BelongsToMany<User, $this, TenantMember>
+     */
     #[Scope]
-    protected function onlyEmployees()
+    protected function onlyEmployees(): BelongsToMany
     {
         return $this->employees()->wherePivot('active', true)->whereNot('id', $this->user_id);
     }

--- a/app-modules/company/src/Models/Department.php
+++ b/app-modules/company/src/Models/Department.php
@@ -14,8 +14,6 @@ use TresPontosTech\Company\Database\Factories\DepartmentFactory;
 use TresPontosTech\Company\Enums\DepartmentCategory;
 
 /**
- * @use HasFactory<DepartmentFactory>
- *
  * @property string $id
  * @property string $company_id
  * @property DepartmentCategory $category
@@ -27,7 +25,9 @@ use TresPontosTech\Company\Enums\DepartmentCategory;
  */
 class Department extends Model
 {
+    /** @use HasFactory<DepartmentFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 

--- a/app-modules/company/src/Models/Department.php
+++ b/app-modules/company/src/Models/Department.php
@@ -23,6 +23,7 @@ use TresPontosTech\Company\Enums\DepartmentCategory;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
+ * @property-read int $total
  */
 class Department extends Model
 {

--- a/app-modules/company/src/Models/Department.php
+++ b/app-modules/company/src/Models/Department.php
@@ -9,10 +9,21 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Company\Database\Factories\DepartmentFactory;
 use TresPontosTech\Company\Enums\DepartmentCategory;
 
-/** @use HasFactory<DepartmentFactory> */
+/**
+ * @use HasFactory<DepartmentFactory>
+ *
+ * @property string $id
+ * @property string $company_id
+ * @property DepartmentCategory $category
+ * @property string $name
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class Department extends Model
 {
     use HasFactory;
@@ -29,6 +40,9 @@ class Department extends Model
         'category' => DepartmentCategory::class,
     ];
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);

--- a/app-modules/consultants/phpstan.ignore.neon
+++ b/app-modules/consultants/phpstan.ignore.neon
@@ -1,2 +1,7 @@
 parameters:
     ignoreErrors:
+        # $media->model é tipado como Model base pela medialibrary; para mídia de Document acessa ->documentable.
+        - message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$documentable\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Support/DocumentPathGenerator.php

--- a/app-modules/consultants/src/DTOs/DocumentShareDTO.php
+++ b/app-modules/consultants/src/DTOs/DocumentShareDTO.php
@@ -10,6 +10,9 @@ final readonly class DocumentShareDTO
         public string|int $consultantId,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data): self
     {
         return new self(

--- a/app-modules/consultants/src/Models/Consultant.php
+++ b/app-modules/consultants/src/Models/Consultant.php
@@ -22,6 +22,7 @@ use Spatie\Tags\HasTags;
 use Spatie\Tags\Tag;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
+use TresPontosTech\Consultants\Database\Factories\ConsultantFactory;
 use TresPontosTech\Consultants\Observers\ConsultantObserver;
 use TresPontosTech\Consultants\Policies\ConsultantPolicy;
 use Zap\Models\Concerns\HasSchedules;
@@ -37,7 +38,7 @@ use Zap\Models\Concerns\HasSchedules;
  * @property string $short_description
  * @property string $biography
  * @property string $readme
- * @property array $socials_urls
+ * @property array<string, string> $socials_urls
  * @property Carbon|null $google_calendar_synced_at
  * @property string|null $google_calendar_sync_token
  * @property Carbon|null $created_at
@@ -50,7 +51,9 @@ use Zap\Models\Concerns\HasSchedules;
 #[UsePolicy(ConsultantPolicy::class)]
 class Consultant extends Model implements HasMedia
 {
+    /** @use HasFactory<ConsultantFactory> */
     use HasFactory;
+
     use HasSchedules;
     use HasTags;
     use HasUuids;

--- a/app-modules/consultants/src/Models/Consultant.php
+++ b/app-modules/consultants/src/Models/Consultant.php
@@ -4,7 +4,6 @@ namespace TresPontosTech\Consultants\Models;
 
 use App\Enums\AvailableTagsEnum;
 use App\Models\Users\User;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -16,9 +15,11 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Tags\HasTags;
+use Spatie\Tags\Tag;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
 use TresPontosTech\Consultants\Observers\ConsultantObserver;
@@ -26,16 +27,23 @@ use TresPontosTech\Consultants\Policies\ConsultantPolicy;
 use Zap\Models\Concerns\HasSchedules;
 
 /**
+ * @property string $id
+ * @property string|null $user_id
+ * @property string|null $crm_id
  * @property string $name
+ * @property string $slug
  * @property string $phone
  * @property string $email
  * @property string $short_description
  * @property string $biography
  * @property string $readme
  * @property array $socials_urls
- * @property string|null $crm_id
  * @property Carbon|null $google_calendar_synced_at
  * @property string|null $google_calendar_sync_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read int|null $completed_count
  * @property-read User|null $user
  */
 #[ObservedBy(ConsultantObserver::class)]
@@ -77,6 +85,9 @@ class Consultant extends Model implements HasMedia
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return MorphMany<Document, $this>
+     */
     public function documents(): MorphMany
     {
         return $this->morphMany(Document::class, 'documentable');
@@ -90,6 +101,9 @@ class Consultant extends Model implements HasMedia
         return $this->hasMany(Appointment::class);
     }
 
+    /**
+     * @return HasManyThrough<User, Appointment, $this>
+     */
     public function clients(): HasManyThrough
     {
         return $this->hasManyThrough(User::class, Appointment::class, 'consultant_id', 'id', 'id', 'user_id');
@@ -103,24 +117,36 @@ class Consultant extends Model implements HasMedia
         return $this->hasManyThrough(AppointmentFeedback::class, Appointment::class);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function languages(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Language->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function degrees(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Education->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function expertises(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Expertise->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function specializations(): MorphToMany
     {
         return $this->tags()

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -2,6 +2,7 @@
 
 namespace TresPontosTech\Consultants\Models;
 
+use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -9,15 +10,24 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
 /**
- * @property string|null $link
+ * @property string $id
+ * @property string|null $documentable_type
+ * @property string|null $documentable_id
+ * @property string $title
+ * @property DocumentExtensionTypeEnum|null $type
  * @property bool $active
- * @property DocumentExtensionTypeEnum $type
+ * @property string|null $link
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read Consultant|User|null $documentable
  */
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
@@ -44,6 +54,9 @@ class Document extends Model implements HasMedia
         ];
     }
 
+    /**
+     * @return MorphTo<Model, $this>
+     */
     public function documentable(): MorphTo
     {
         return $this->morphTo();

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use TresPontosTech\Consultants\Database\Factories\DocumentFactory;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
@@ -32,7 +33,9 @@ use TresPontosTech\Consultants\Policies\DocumentPolicy;
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
 {
+    /** @use HasFactory<DocumentFactory> */
     use HasFactory;
+
     use HasUuids;
     use InteractsWithMedia;
     use SoftDeletes;

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -14,6 +14,11 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
+/**
+ * @property string|null $link
+ * @property bool $active
+ * @property DocumentExtensionTypeEnum $type
+ */
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
 {

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property bool $active
+ */
 class DocumentShare extends Model
 {
     use HasFactory;

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -6,9 +6,16 @@ use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
+ * @property int $id
+ * @property string $document_id
+ * @property string $consultant_id
+ * @property string $employee_id
  * @property bool $active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class DocumentShare extends Model
 {
@@ -45,16 +52,25 @@ class DocumentShare extends Model
         $this->update(['active' => false]);
     }
 
+    /**
+     * @return BelongsTo<Consultant, $this>
+     */
     public function consultant(): BelongsTo
     {
         return $this->belongsTo(Consultant::class)->withTrashed();
     }
 
+    /**
+     * @return BelongsTo<Document, $this>
+     */
     public function document(): BelongsTo
     {
         return $this->belongsTo(Document::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function employee(): BelongsTo
     {
         return $this->belongsTo(User::class, 'employee_id');

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use TresPontosTech\Consultants\Database\Factories\DocumentShareFactory;
 
 /**
  * @property int $id
@@ -19,6 +20,7 @@ use Illuminate\Support\Carbon;
  */
 class DocumentShare extends Model
 {
+    /** @use HasFactory<DocumentShareFactory> */
     use HasFactory;
 
     protected $table = 'document_shares';

--- a/app-modules/consultants/src/Support/DocumentPathGenerator.php
+++ b/app-modules/consultants/src/Support/DocumentPathGenerator.php
@@ -15,7 +15,7 @@ class DocumentPathGenerator implements PathGenerator
         $owner = $media->model->documentable;
 
         if (! $owner) {
-            $owner = auth()->user()?->consultant ?? auth()->user();
+            $owner = auth()->user()->consultant ?? auth()->user();
         }
 
         $folderName = Str::slug($owner->name ?? $owner->user->name);

--- a/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
+++ b/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TresPontosTech\IntegrationGoogleCalendar\Actions;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use TresPontosTech\Consultants\Models\Consultant;
 use Zap\Enums\ScheduleTypes;
@@ -14,12 +15,15 @@ readonly class RemoveStaleBlockedSchedulesAction
     public function handle(Consultant $consultant, array $syncedEventIds): void
     {
         DB::transaction(function () use ($consultant, $syncedEventIds): void {
-            $staleIds = Schedule::query()
+            /** @var Collection<int, Schedule> $schedules */
+            $schedules = Schedule::query()
                 ->where('schedulable_type', $consultant->getMorphClass())
                 ->where('schedulable_id', $consultant->getKey())
                 ->where('schedule_type', ScheduleTypes::BLOCKED)
                 ->whereJsonContains('metadata->source', 'google-calendar')
-                ->get(['id', 'metadata'])
+                ->get(['id', 'metadata']);
+
+            $staleIds = $schedules
                 ->filter(function (Schedule $schedule) use ($syncedEventIds): bool {
                     $eventId = $schedule->metadata['google_event_id'] ?? null;
 

--- a/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
+++ b/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
@@ -12,6 +12,9 @@ use Zap\Models\Schedule;
 
 readonly class RemoveStaleBlockedSchedulesAction
 {
+    /**
+     * @param  array<int, string>  $syncedEventIds
+     */
     public function handle(Consultant $consultant, array $syncedEventIds): void
     {
         DB::transaction(function () use ($consultant, $syncedEventIds): void {

--- a/app-modules/integration-google-calendar/src/DTO/CreateGoogleEventDTO.php
+++ b/app-modules/integration-google-calendar/src/DTO/CreateGoogleEventDTO.php
@@ -27,9 +27,7 @@ readonly class CreateGoogleEventDTO
 
         $descriptionParts = [];
 
-        if ($appointment->category_type) {
-            $descriptionParts[] = sprintf('Categoria: %s', $appointment->category_type->getLabel());
-        }
+        $descriptionParts[] = sprintf('Categoria: %s', $appointment->category_type->getLabel());
 
         if (filled($appointment->notes)) {
             $descriptionParts[] = $appointment->notes;

--- a/app-modules/integration-google-calendar/src/DTO/GoogleEventDTO.php
+++ b/app-modules/integration-google-calendar/src/DTO/GoogleEventDTO.php
@@ -18,6 +18,9 @@ readonly class GoogleEventDTO
         public ?Carbon $updated,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $event
+     */
     public static function fromApiPayload(array $event): self
     {
         $isCancelled = ($event['status'] ?? '') === 'cancelled';

--- a/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
+++ b/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
@@ -168,9 +168,9 @@ class GoogleCalendarClient
 
         $credentials = json_decode(file_get_contents($credentialsPath), true);
 
-        throw_unless(is_array($credentials), GoogleCalendarApiException::class, 'Google service account credentials file contains invalid JSON', retryable: false);
+        throw_unless(is_array($credentials), GoogleCalendarApiException::class, 'Google service account credentials file contains invalid JSON', 0, false);
 
-        throw_if(blank($credentials['client_email'] ?? null) || blank($credentials['private_key'] ?? null), GoogleCalendarApiException::class, 'Google service account credentials file is missing required fields (client_email, private_key)', retryable: false);
+        throw_if(blank($credentials['client_email'] ?? null) || blank($credentials['private_key'] ?? null), GoogleCalendarApiException::class, 'Google service account credentials file is missing required fields (client_email, private_key)', 0, false);
 
         $this->credentials = $credentials;
     }

--- a/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
+++ b/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
@@ -10,6 +10,9 @@ use TresPontosTech\IntegrationGoogleCalendar\Responses\CreateEventResponse;
 
 class GoogleCalendarClient
 {
+    /**
+     * @var array<string, mixed>
+     */
     private array $credentials;
 
     public function __construct()

--- a/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
+++ b/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
@@ -130,15 +130,26 @@ class GoogleCalendarClient
     {
         $now = Date::now()->getTimestamp();
 
-        $header = $this->base64url(json_encode(['alg' => 'RS256', 'typ' => 'JWT']));
-        $claimSet = $this->base64url(json_encode([
+        $encodedHeader = json_encode(['alg' => 'RS256', 'typ' => 'JWT']);
+        $encodedClaimSet = json_encode([
             'iss' => $this->credentials['client_email'],
             'sub' => $email,
             'scope' => 'https://www.googleapis.com/auth/calendar',
             'aud' => 'https://oauth2.googleapis.com/token',
             'iat' => $now,
             'exp' => $now + 3600,
-        ]));
+        ]);
+
+        throw_if(
+            $encodedHeader === false || $encodedClaimSet === false,
+            GoogleCalendarApiException::class,
+            'Failed to encode JWT payload',
+            0,
+            false,
+        );
+
+        $header = $this->base64url($encodedHeader);
+        $claimSet = $this->base64url($encodedClaimSet);
 
         $signatureInput = sprintf('%s.%s', $header, $claimSet);
         $signed = openssl_sign($signatureInput, $signature, $this->credentials['private_key'], 'SHA256');
@@ -169,7 +180,11 @@ class GoogleCalendarClient
             );
         }
 
-        $credentials = json_decode(file_get_contents($credentialsPath), true);
+        $rawCredentials = file_get_contents($credentialsPath);
+
+        throw_if($rawCredentials === false, GoogleCalendarApiException::class, sprintf('Failed to read Google service account credentials file at %s', $credentialsPath), 0, false);
+
+        $credentials = json_decode($rawCredentials, true);
 
         throw_unless(is_array($credentials), GoogleCalendarApiException::class, 'Google service account credentials file contains invalid JSON', 0, false);
 

--- a/app-modules/integration-google-calendar/src/Jobs/CreateAppointmentCalendarEventJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/CreateAppointmentCalendarEventJob.php
@@ -19,6 +19,9 @@ class CreateAppointmentCalendarEventJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Jobs/DeleteAppointmentCalendarEventJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/DeleteAppointmentCalendarEventJob.php
@@ -19,6 +19,9 @@ class DeleteAppointmentCalendarEventJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Jobs/SyncConsultantCalendarJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/SyncConsultantCalendarJob.php
@@ -15,6 +15,9 @@ class SyncConsultantCalendarJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Responses/CalendarEventsResponse.php
+++ b/app-modules/integration-google-calendar/src/Responses/CalendarEventsResponse.php
@@ -7,12 +7,18 @@ use TresPontosTech\IntegrationGoogleCalendar\DTO\GoogleEventDTO;
 
 readonly class CalendarEventsResponse
 {
+    /**
+     * @param  Collection<int, GoogleEventDTO>  $events
+     */
     public function __construct(
         public Collection $events,
         public ?string $nextPageToken,
         public ?string $nextSyncToken,
     ) {}
 
+    /**
+     * @param  array{items?: array<int, array<string, mixed>>, nextPageToken?: string|null, nextSyncToken?: string|null}  $payload
+     */
     public static function make(array $payload): self
     {
         $events = collect($payload['items'] ?? [])

--- a/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
@@ -10,6 +10,9 @@ final readonly class FetchConsultants
         private HighLevelClient $client,
     ) {}
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function populateAction(): array
     {
         sprintf(
@@ -19,7 +22,7 @@ final readonly class FetchConsultants
 
         //        return Cache::flexible($cacheKey, [$baseTtl, $baseTtl * 2], function () {
         return collect($this->client->getCompanyEmployees()['users'])
-            ->mapWithKeys(fn ($employee): array => [$employee['id'] => $employee['name']])
+            ->mapWithKeys(fn (array $employee): array => [$employee['id'] => $employee['name']])
             ->toArray();
         //        });
     }

--- a/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
@@ -21,7 +21,7 @@ final readonly class FetchConsultants
         );
 
         //        return Cache::flexible($cacheKey, [$baseTtl, $baseTtl * 2], function () {
-        return collect($this->client->getCompanyEmployees()['users'])
+        return collect($this->client->getCompanyEmployees()['users'] ?? [])
             ->mapWithKeys(fn (array $employee): array => [$employee['id'] => $employee['name']])
             ->toArray();
         //        });

--- a/app-modules/integration-highlevel/src/Actions/FetchOpportunityPipelines.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchOpportunityPipelines.php
@@ -7,7 +7,10 @@ use TresPontosTech\IntegrationHighlevel\HighLevelClient;
 
 final readonly class FetchOpportunityPipelines
 {
-    public function populateAction()
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function populateAction(): array
     {
         $baseTtl = 60 * 60;
         $cacheKey = sprintf(

--- a/app-modules/integration-highlevel/src/HighLevelClient.php
+++ b/app-modules/integration-highlevel/src/HighLevelClient.php
@@ -2,6 +2,7 @@
 
 namespace TresPontosTech\IntegrationHighlevel;
 
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use TresPontosTech\IntegrationHighlevel\Requests\CreateAppointmentDTO;
 use TresPontosTech\IntegrationHighlevel\Requests\FetchCalendarSlotsDTO;
@@ -13,7 +14,7 @@ use TresPontosTech\IntegrationHighlevel\Responses\UpsertOpportunityResponse;
 
 class HighLevelClient
 {
-    public function searchContacts(string $query = '')
+    public function searchContacts(string $query = ''): Response
     {
         return Http::withToken(config('highlevel.secret'))
             ->withLocation()
@@ -33,6 +34,9 @@ class HighLevelClient
         return ContactResponse::make($response->json());
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getLocationPipelines(): array
     {
         return Http::withToken(config('highlevel.secret'))
@@ -42,7 +46,10 @@ class HighLevelClient
             ->json();
     }
 
-    public function getCompanyEmployees()
+    /**
+     * @return array{users?: array<int, array<string, mixed>>}
+     */
+    public function getCompanyEmployees(): array
     {
         return Http::withToken(config('highlevel.secret'))
             ->withLocation()
@@ -67,7 +74,10 @@ class HighLevelClient
         return UpsertOpportunityResponse::make($response->json());
     }
 
-    public function getCalendarFreeSlots(FetchCalendarSlotsDTO $dto)
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCalendarFreeSlots(FetchCalendarSlotsDTO $dto): array
     {
         $url = sprintf('https://services.leadconnectorhq.com/calendars/%s/free-slots', $dto->calendarId);
 

--- a/app-modules/integration-highlevel/src/Requests/CreateAppointmentDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/CreateAppointmentDTO.php
@@ -41,6 +41,9 @@ class CreateAppointmentDTO implements \JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return get_object_vars($this);

--- a/app-modules/integration-highlevel/src/Requests/FetchCalendarSlotsDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/FetchCalendarSlotsDTO.php
@@ -26,6 +26,9 @@ class FetchCalendarSlotsDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array{startDate: int, endDate: int, timezone: string|null}
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/integration-highlevel/src/Requests/UpsertContactDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/UpsertContactDTO.php
@@ -35,6 +35,9 @@ class UpsertContactDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/integration-highlevel/src/Responses/ContactResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/ContactResponse.php
@@ -9,6 +9,9 @@ readonly class ContactResponse
         public bool $isNewContact
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $json
+     */
     public static function make(array $json): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/OpportunityResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/OpportunityResponse.php
@@ -22,6 +22,9 @@ class OpportunityResponse
         public ?string $lastActionDate,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/ScheduledAppointmentResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/ScheduledAppointmentResponse.php
@@ -16,6 +16,9 @@ class ScheduledAppointmentResponse
         public string $traceId
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/UpsertOpportunityResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/UpsertOpportunityResponse.php
@@ -9,6 +9,9 @@ class UpsertOpportunityResponse
         public OpportunityResponse $opportunity,
     ) {}
 
+    /**
+     * @param  array{new: bool, opportunity: array<string, mixed>}  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/panel-admin/phpstan.ignore.neon
+++ b/app-modules/panel-admin/phpstan.ignore.neon
@@ -1,7 +1,2 @@
 parameters:
     ignoreErrors:
-        # Coluna agregada dinâmica (COUNT(...) as total) selecionada sobre Department.
-        - message: '#^Access to an undefined property TresPontosTech\\Company\\Models\\Department::\$total\.$#'
-          identifier: property.notFound
-          count: 1
-          path: src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php

--- a/app-modules/panel-admin/phpstan.ignore.neon
+++ b/app-modules/panel-admin/phpstan.ignore.neon
@@ -1,2 +1,12 @@
 parameters:
     ignoreErrors:
+        # Cast do pacote Zap declara array|FrequencyConfig; ->days existe em FrequencyConfig.
+        - message: '#^Cannot access property \$days on array\|Zap\\Data\\FrequencyConfig\.$#'
+          identifier: property.nonObject
+          count: 2
+          path: src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
+        # Coluna agregada dinâmica (COUNT(...) as total) selecionada sobre Department.
+        - message: '#^Access to an undefined property TresPontosTech\\Company\\Models\\Department::\$total\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php

--- a/app-modules/panel-admin/phpstan.ignore.neon
+++ b/app-modules/panel-admin/phpstan.ignore.neon
@@ -1,10 +1,5 @@
 parameters:
     ignoreErrors:
-        # Cast do pacote Zap declara array|FrequencyConfig; ->days existe em FrequencyConfig.
-        - message: '#^Cannot access property \$days on array\|Zap\\Data\\FrequencyConfig\.$#'
-          identifier: property.nonObject
-          count: 2
-          path: src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
         # Coluna agregada dinâmica (COUNT(...) as total) selecionada sobre Department.
         - message: '#^Access to an undefined property TresPontosTech\\Company\\Models\\Department::\$total\.$#'
           identifier: property.notFound

--- a/app-modules/panel-admin/src/Filament/Pages/Dashboard.php
+++ b/app-modules/panel-admin/src/Filament/Pages/Dashboard.php
@@ -11,6 +11,9 @@ use TresPontosTech\Admin\Filament\Widgets\StatsOverview;
 
 class Dashboard extends BaseDashboard
 {
+    /**
+     * @var int|string|array<string, int|string>
+     */
     protected int|string|array $columnSpan = 'full';
 
     public function getColumns(): int|array

--- a/app-modules/panel-admin/src/Filament/Pages/DepartmentCategories.php
+++ b/app-modules/panel-admin/src/Filament/Pages/DepartmentCategories.php
@@ -61,6 +61,9 @@ class DepartmentCategories extends Page implements HasTable
             ->paginated(false);
     }
 
+    /**
+     * @return array<int, array{case: DepartmentCategory, total: mixed}>
+     */
     private function getCategoryData(): array
     {
         $counts = Department::query()

--- a/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Pages;
 use App\Filament\Shared\Fields\DocumentIdInput;
 use App\Filament\Shared\Fields\TaxIdInput;
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Schemas\Components\Component;
 
 class EditUserProfile extends BaseEditUserProfile
@@ -14,6 +15,9 @@ class EditUserProfile extends BaseEditUserProfile
      */
     protected function getExtraDetailFormComponents(): array
     {
+        /** @var User $user */
+        $user = $this->getUser();
+
         return [
             TaxIdInput::make()
                 ->label(__('panel-admin::resources.pages.edit_profile.cpf')),
@@ -24,7 +28,7 @@ class EditUserProfile extends BaseEditUserProfile
                 ->unique(
                     table: 'user_details',
                     column: 'document_id',
-                    ignorable: $this->getUser()->detail,
+                    ignorable: $user->detail,
                     ignoreRecord: false
                 ),
         ];

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
@@ -28,6 +28,9 @@ use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Consultants\Models\Document;
 use TresPontosTech\IntegrationGoogleCalendar\Jobs\CreateAppointmentCalendarEventJob;
 
+/**
+ * @property-read Appointment $record
+ */
 class ViewAppointment extends ViewRecord
 {
     protected static string $resource = AppointmentResource::class;
@@ -148,7 +151,7 @@ class ViewAppointment extends ViewRecord
 
     public function getEmployeeDocuments(): Collection
     {
-        $record = $this->getRecord();
+        $record = $this->record;
 
         return Document::query()
             ->whereMorphedTo('documentable', $record->user)
@@ -157,7 +160,7 @@ class ViewAppointment extends ViewRecord
 
     public function getSharedDocuments(): Collection
     {
-        $record = $this->getRecord();
+        $record = $this->record;
 
         return Document::query()
             ->whereHas('shares', function ($query) use ($record): void {
@@ -205,7 +208,7 @@ class ViewAppointment extends ViewRecord
         }
 
         $document = Document::query()
-            ->whereMorphedTo('documentable', $this->getRecord()->user)
+            ->whereMorphedTo('documentable', $this->record->user)
             ->find($documentId);
 
         return $document?->getFirstMedia('documents');
@@ -217,7 +220,7 @@ class ViewAppointment extends ViewRecord
             return null;
         }
 
-        $appointment = $this->getRecord();
+        $appointment = $this->record;
 
         $document = Document::query()
             ->whereHas('shares', function ($query) use ($appointment): void {

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
@@ -149,6 +149,9 @@ class ViewAppointment extends ViewRecord
         ];
     }
 
+    /**
+     * @return Collection<int, Document>
+     */
     public function getEmployeeDocuments(): Collection
     {
         $record = $this->record;
@@ -158,6 +161,9 @@ class ViewAppointment extends ViewRecord
             ->get();
     }
 
+    /**
+     * @return Collection<int, Document>
+     */
     public function getSharedDocuments(): Collection
     {
         $record = $this->record;

--- a/app-modules/panel-admin/src/Filament/Resources/Companies/Pages/CreateCompany.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Companies/Pages/CreateCompany.php
@@ -6,8 +6,12 @@ use App\Models\Users\User;
 use Filament\Resources\Pages\CreateRecord;
 use Ramsey\Uuid\Uuid;
 use TresPontosTech\Admin\Filament\Resources\Companies\CompanyResource;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Permissions\Roles;
 
+/**
+ * @property-read Company $record
+ */
 class CreateCompany extends CreateRecord
 {
     protected static string $resource = CompanyResource::class;

--- a/app-modules/panel-admin/src/Filament/Resources/Companies/RelationManagers/ContractualPlansRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Companies/RelationManagers/ContractualPlansRelationManager.php
@@ -130,7 +130,7 @@ class ContractualPlansRelationManager extends RelationManager
                 TextColumn::make('status')
                     ->label(__('panel-admin::resources.companies.relation_managers.contractual_plans.table.status'))
                     ->badge()
-                    ->color(fn (CompanyPlanStatusEnum $state): string|array => $state->getColor()),
+                    ->color(fn (CompanyPlanStatusEnum $state): array => $state->getColor()),
 
                 TextColumn::make('starts_at')
                     ->label(__('panel-admin::resources.companies.relation_managers.contractual_plans.table.starts_at'))

--- a/app-modules/panel-admin/src/Filament/Resources/Companies/RelationManagers/ContractualPlansRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Companies/RelationManagers/ContractualPlansRelationManager.php
@@ -73,7 +73,8 @@ class ContractualPlansRelationManager extends RelationManager
                             }
 
                             $companyId = $this->getOwnerRecord()->getKey();
-                            $recordId = $this->getMountedAction()?->getRecord()?->getKey();
+                            $mountedRecord = $this->getMountedAction()?->getRecord();
+                            $recordId = $mountedRecord instanceof Model ? $mountedRecord->getKey() : null;
                             $startsAt = $get('starts_at') ?? now()->toDateString();
                             $endsAt = $get('ends_at') ?? '9999-12-31';
 

--- a/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
@@ -40,7 +40,7 @@ class SchedulesRelationManager extends RelationManager
                     ->searchable(),
                 TextColumn::make('frequency_config')
                     ->label(__('consultants::resources.schedules.table.columns.days'))
-                    ->state(fn (Schedule $record): string => collect($record->frequency_config?->days ?? [])
+                    ->state(fn (Schedule $record): string => collect($record->frequency_config->days ?? [])
                         ->map(fn (string $day): string => __('consultants::resources.schedules.days.' . $day))
                         ->join(', ')
                     ),
@@ -63,7 +63,7 @@ class SchedulesRelationManager extends RelationManager
                     ->form($this->availabilityFormSchema())
                     ->mutateRecordDataUsing(function (array $data, Schedule $record): array {
                         $data['frequency_config'] = [
-                            'days' => $record->frequency_config?->days ?? [],
+                            'days' => $record->frequency_config->days ?? [],
                         ];
 
                         $data['periods'] = $record->periods

--- a/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
@@ -10,10 +10,12 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Component;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Zap\Enums\Frequency;
 use Zap\Enums\ScheduleTypes;
 use Zap\Models\Schedule;
@@ -24,7 +26,7 @@ class SchedulesRelationManager extends RelationManager
 
     protected static ?string $title = null;
 
-    public static function getTitle($ownerRecord, string $pageClass): string
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
     {
         return __('consultants::resources.schedules.title');
     }
@@ -40,10 +42,14 @@ class SchedulesRelationManager extends RelationManager
                     ->searchable(),
                 TextColumn::make('frequency_config')
                     ->label(__('consultants::resources.schedules.table.columns.days'))
-                    ->state(fn (Schedule $record): string => collect($record->frequency_config->days ?? [])
-                        ->map(fn (string $day): string => __('consultants::resources.schedules.days.' . $day))
-                        ->join(', ')
-                    ),
+                    ->state(function (Schedule $record): string {
+                        /** @var array<int, string> $days */
+                        $days = $record->frequency_config->days ?? [];
+
+                        return collect($days)
+                            ->map(fn (string $day): string => __('consultants::resources.schedules.days.' . $day))
+                            ->join(', ');
+                    }),
                 TextColumn::make('periods_summary')
                     ->label(__('consultants::resources.schedules.table.columns.periods'))
                     ->state(fn (Schedule $record): string => $record->periods
@@ -100,6 +106,9 @@ class SchedulesRelationManager extends RelationManager
             ]);
     }
 
+    /**
+     * @return array<Component>
+     */
     private function availabilityFormSchema(): array
     {
         return [

--- a/app-modules/panel-admin/src/Filament/Resources/Consultants/Schemas/ConsultantForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Consultants/Schemas/ConsultantForm.php
@@ -44,7 +44,7 @@ class ConsultantForm
                                         })
                                         ->required(),
                                     TextInput::make('slug')
-                                        ->formatStateUsing(fn ($get) => str($get('name'))->slug),
+                                        ->formatStateUsing(fn ($get) => str($get('name'))->slug()),
                                     PhoneInput::make('phone')
                                         ->defaultCountry('BR')
                                         ->initialCountry('BR')

--- a/app-modules/panel-admin/src/Filament/Resources/Permissions/Actions/AssignRoleAction.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Permissions/Actions/AssignRoleAction.php
@@ -6,6 +6,7 @@ use App\Models\Users\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Support\Icons\Heroicon;
 use TresPontosTech\Permissions\Roles;
 
@@ -26,6 +27,9 @@ class AssignRoleAction extends Action
         return 'assign-role-action';
     }
 
+    /**
+     * @return array<Component>
+     */
     private function roleSchema(): array
     {
         return [

--- a/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
@@ -140,8 +140,8 @@ class PriceResource extends Resource
                             ->schema([
                                 CodeEditor::make('metadata')
                                     ->formatStateUsing(fn (mixed $state): string => match (true) {
-                                        is_array($state) => json_encode($state, JSON_PRETTY_PRINT),
-                                        is_string($state) && filled($state) => json_encode(json_decode($state), JSON_PRETTY_PRINT),
+                                        is_array($state) => json_encode($state, JSON_PRETTY_PRINT) ?: '',
+                                        is_string($state) && filled($state) => json_encode(json_decode($state), JSON_PRETTY_PRINT) ?: '',
                                         default => '',
                                     })
                                     ->dehydrateStateUsing(fn (?string $state): ?array => $state ? json_decode($state, true) : null)

--- a/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
@@ -236,6 +236,9 @@ class PriceResource extends Resource
         return ['plan.name'];
     }
 
+    /**
+     * @param  Price  $record
+     */
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         $details = [];

--- a/app-modules/panel-admin/src/Filament/Resources/Users/Pages/CreateUser.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Users/Pages/CreateUser.php
@@ -2,11 +2,15 @@
 
 namespace TresPontosTech\Admin\Filament\Resources\Users\Pages;
 
+use App\Models\Users\User;
 use Filament\Resources\Pages\CreateRecord;
 use TresPontosTech\Admin\Filament\Resources\Users\UserResource;
 use TresPontosTech\Permissions\Roles;
 use TresPontosTech\User\Events\UserRegistered;
 
+/**
+ * @property-read User $record
+ */
 class CreateUser extends CreateRecord
 {
     protected static string $resource = UserResource::class;

--- a/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
@@ -15,10 +15,16 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
 
     protected int|string|array $columnSpan = 'full';
 
+    /**
+     * @var array<string, mixed>
+     */
     public array $tableFilterState = [];
 
     private ?object $aggregates = null;
 
+    /**
+     * @param  array<string, mixed>  $filters
+     */
     #[On('appointments-table-filters-changed')]
     public function syncFilters(array $filters): void
     {

--- a/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
@@ -20,6 +20,9 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
      */
     public array $tableFilterState = [];
 
+    /**
+     * @var object{total: int, scheduled: int, pending: int, cancelled: int, completed: int}|null
+     */
     private ?object $aggregates = null;
 
     /**
@@ -43,9 +46,16 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
         ];
     }
 
+    /**
+     * @return object{total: int, scheduled: int, pending: int, cancelled: int, completed: int}
+     */
     private function aggregates(): object
     {
-        return $this->aggregates ??= Appointment::query()
+        if ($this->aggregates !== null) {
+            return $this->aggregates;
+        }
+
+        $row = Appointment::query()
             ->when(
                 filled(data_get($this->tableFilterState, 'company_id.value')),
                 fn (Builder $q) => $q->where('company_id', data_get($this->tableFilterState, 'company_id.value'))
@@ -92,7 +102,16 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
                     AppointmentStatus::Completed->value,
                 ]
             )
+            ->toBase()
             ->first();
+
+        return $this->aggregates = (object) [
+            'total' => (int) ($row->total ?? 0),
+            'scheduled' => (int) ($row->scheduled ?? 0),
+            'pending' => (int) ($row->pending ?? 0),
+            'cancelled' => (int) ($row->cancelled ?? 0),
+            'completed' => (int) ($row->completed ?? 0),
+        ];
     }
 
     private function totalRequestsStat(): Stat

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByCategory.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByCategory.php
@@ -22,8 +22,8 @@ class AppointmentsByCategory extends ChartWidget
 
     protected function getData(): array
     {
-        $start = $this->filters['startDate'] ? now()->parse($this->filters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
-        $end = $this->filters['endDate'] ? now()->parse($this->filters['endDate'])->endOfDay() : now()->endOfDay();
+        $start = $this->pageFilters['startDate'] ? now()->parse($this->pageFilters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
+        $end = $this->pageFilters['endDate'] ? now()->parse($this->pageFilters['endDate'])->endOfDay() : now()->endOfDay();
 
         $results = Appointment::query()
             ->whereBetween('created_at', [$start, $end])

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
@@ -21,7 +21,7 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
 
     public function getHeading(): ?string
     {
-        $category = data_get($this->filters, 'departmentCategory');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         if (filled($category)) {
             $enum = DepartmentCategory::tryFrom($category);
@@ -36,9 +36,9 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
 
     protected function getData(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
-        $category = data_get($this->filters, 'departmentCategory');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         $start = filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay();
         $end = filled($endDate) ? now()->parse($endDate)->endOfDay() : now()->endOfDay();

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
@@ -81,6 +81,10 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
         return $this->buildChartData($counts);
     }
 
+    /**
+     * @param  Collection<int, mixed>  $counts
+     * @return array<string, mixed>
+     */
     private function buildChartData(
         Collection $counts,
         string $color = 'rgba(59, 130, 246, 0.7)',

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
@@ -22,8 +22,8 @@ class AppointmentsByStatus extends ChartWidget
 
     protected function getData(): array
     {
-        $start = $this->filters['startDate'] ? now()->parse($this->filters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
-        $end = $this->filters['endDate'] ? now()->parse($this->filters['endDate'])->endOfDay() : now()->endOfDay();
+        $start = $this->pageFilters['startDate'] ? now()->parse($this->pageFilters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
+        $end = $this->pageFilters['endDate'] ? now()->parse($this->pageFilters['endDate'])->endOfDay() : now()->endOfDay();
 
         $results = Appointment::query()
             ->whereBetween('created_at', [$start, $end])

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Widgets\Metrics;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
@@ -84,6 +85,9 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
         ]);
     }
 
+    /**
+     * @return array{start: Carbon, end: Carbon}
+     */
     private function dateRange(): array
     {
         $startDate = data_get($this->pageFilters, 'startDate');

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
@@ -22,7 +22,7 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $category = data_get($this->filters, 'departmentCategory');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         $base = Appointment::query()
             ->whereBetween('appointment_at', [$start, $end])
@@ -86,8 +86,8 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
 
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
@@ -57,7 +57,7 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
             ->first();
 
         $topCompany = $topCompanyData
-            ? Company::query()->find($topCompanyData->company_id)
+            ? Company::query()->whereKey($topCompanyData->company_id)->first()
             : null;
 
         return array_filter([

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
@@ -28,8 +28,8 @@ class KPIsOverview extends StatsOverviewWidget
 
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
@@ -47,8 +47,8 @@ class KPIsOverview extends StatsOverviewWidget
             ->toBase()
             ->first();
 
-        $avg = round((float) ($result?->avg_rating ?? 0), 1);
-        $total = (int) ($result?->total ?? 0);
+        $avg = round((float) ($result->avg_rating ?? 0), 1);
+        $total = (int) ($result->total ?? 0);
 
         return Stat::make(__('panel-admin::widgets.metrics.kpis_overview.avg_rating'), $avg . '/5')
             ->description(__('panel-admin::widgets.metrics.kpis_overview.avg_rating_description', ['total' => $total]))
@@ -67,8 +67,8 @@ class KPIsOverview extends StatsOverviewWidget
             ->toBase()
             ->first();
 
-        $consultantCount = (int) ($result?->consultant_count ?? 0);
-        $total = (int) ($result?->total ?? 0);
+        $consultantCount = (int) ($result->consultant_count ?? 0);
+        $total = (int) ($result->total ?? 0);
 
         $avg = $consultantCount > 0
             ? round($total / $consultantCount, 1)

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Widgets\Metrics;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
 use TresPontosTech\Consultants\Models\Consultant;
@@ -26,6 +27,9 @@ class KPIsOverview extends StatsOverviewWidget
         ];
     }
 
+    /**
+     * @return array{start: Carbon, end: Carbon}
+     */
     private function dateRange(): array
     {
         $startDate = data_get($this->pageFilters, 'startDate');

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
@@ -31,8 +31,8 @@ class RankingsWidget extends TableWidget
 
     public function table(Table $table): Table
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         $start = filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay();
         $end = filled($endDate) ? now()->parse($endDate)->endOfDay() : now()->endOfDay();

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
@@ -85,6 +85,7 @@ class RankingsWidget extends TableWidget
 
     /**
      * @param  class-string<Company|Consultant>  $model
+     * @return Builder<Company>|Builder<Consultant>
      */
     private function rankingQuery(string $model, CarbonInterface $start, CarbonInterface $end): Builder
     {

--- a/app-modules/panel-admin/src/Filament/Widgets/StatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/StatsOverview.php
@@ -8,7 +8,6 @@ use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
-use Illuminate\Database\Eloquent\Builder;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Company\Models\Company;
 
@@ -26,31 +25,6 @@ class StatsOverview extends StatsOverviewWidget
             $this->mountTotalAppointmentsStat(),
 
         ];
-    }
-
-    private function mountActivePlansStat(): Stat
-    {
-        $activePlans = Company::query()
-            ->whereHas('plans', function (Builder $query): void {
-                $query->where('company_plans.status', 'active');
-            })
-            ->count();
-
-        $data = Trend::query(Company::query()
-            ->whereHas('plans', function (Builder $query): void {
-                $query->where('company_plans.status', 'active');
-            }))
-            ->between(
-                start: now()->subDays(7),
-                end: now(),
-            )
-            ->perWeek()
-            ->count();
-
-        return Stat::make(__('panel-admin::widgets.stats_overview.active_plans'), $activePlans)
-            ->chart($data->map(fn (TrendValue $value): mixed => $value->aggregate))
-            ->color('success')
-            ->description(__('panel-admin::widgets.stats_overview.active_plans_description'));
     }
 
     private function mountNewUsersStat(): Stat

--- a/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentBookedListener.php
+++ b/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentBookedListener.php
@@ -27,7 +27,7 @@ class NotifyAdminsOfAppointmentBookedListener implements ShouldQueue
         $admins->each(
             fn (Model|Authenticatable|Collection|array $admin): Notification => Notification::make()
                 ->title(__('panel-admin::notifications.appointment_booked.title'))
-                ->body(__('panel-admin::notifications.appointment_booked.body', ['name' => $event->appointment->user?->name ?? __('panel-admin::notifications.unknown_user')]))
+                ->body(__('panel-admin::notifications.appointment_booked.body', ['name' => $event->appointment->user->name ?? __('panel-admin::notifications.unknown_user')]))
                 ->success()
                 ->sendToDatabase($admin),
         );

--- a/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentCancelledListener.php
+++ b/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentCancelledListener.php
@@ -27,7 +27,7 @@ class NotifyAdminsOfAppointmentCancelledListener implements ShouldQueue
         $admins->each(
             fn (Model|Authenticatable|Collection|array $admin): Notification => Notification::make()
                 ->title(__('panel-admin::notifications.appointment_cancelled.title'))
-                ->body(__('panel-admin::notifications.appointment_cancelled.body', ['name' => $event->appointment->user?->name ?? __('panel-admin::notifications.unknown_user')]))
+                ->body(__('panel-admin::notifications.appointment_cancelled.body', ['name' => $event->appointment->user->name ?? __('panel-admin::notifications.unknown_user')]))
                 ->warning()
                 ->sendToDatabase($admin),
         );

--- a/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentCompletedListener.php
+++ b/app-modules/panel-admin/src/Listeners/NotifyAdminsOfAppointmentCompletedListener.php
@@ -27,7 +27,7 @@ class NotifyAdminsOfAppointmentCompletedListener implements ShouldQueue
         $admins->each(
             fn (Model|Authenticatable|Collection|array $admin): Notification => Notification::make()
                 ->title(__('panel-admin::notifications.appointment_completed.title'))
-                ->body(__('panel-admin::notifications.appointment_completed.body', ['name' => $event->appointment->user?->name ?? __('panel-admin::notifications.unknown_user')]))
+                ->body(__('panel-admin::notifications.appointment_completed.body', ['name' => $event->appointment->user->name ?? __('panel-admin::notifications.unknown_user')]))
                 ->success()
                 ->sendToDatabase($admin),
         );

--- a/app-modules/panel-admin/src/Models/ImpersonationLog.php
+++ b/app-modules/panel-admin/src/Models/ImpersonationLog.php
@@ -7,7 +7,18 @@ namespace TresPontosTech\Admin\Models;
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $admin_id
+ * @property string $impersonated_user_id
+ * @property string|null $ip_address
+ * @property Carbon $started_at
+ * @property Carbon|null $ended_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class ImpersonationLog extends Model
 {
     protected $fillable = [

--- a/app-modules/panel-app/src/Filament/Actions/CancelAppointmentAction.php
+++ b/app-modules/panel-app/src/Filament/Actions/CancelAppointmentAction.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\App\Filament\Actions;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Support\Icons\Heroicon;
+use Livewire\Component;
 use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Enums\CancellationActor;
@@ -52,7 +53,10 @@ class CancelAppointmentAction extends Action
                 cancelledBy: auth()->user(),
             ));
 
-            $this->getLivewire()->dispatch('appointment-cancelled');
+            $livewire = $this->getLivewire();
+            if ($livewire instanceof Component) {
+                $livewire->dispatch('appointment-cancelled');
+            }
 
             Notification::make()
                 ->title(__('panel-app::resources.appointments.cancel.success'))

--- a/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
@@ -118,7 +118,15 @@ class AnamneseWizardPage extends Page
 
     public function submit(): void
     {
-        $data = $this->form->getState();
+        $state = $this->form->getState();
+
+        $data = [
+            'life_moment' => (string) $state['life_moment'],
+            'main_motivation' => (string) $state['main_motivation'],
+            'money_relationship' => (string) $state['money_relationship'],
+            'plans_monthly_expenses' => (string) $state['plans_monthly_expenses'],
+            'tried_financial_strategies' => (string) $state['tried_financial_strategies'],
+        ];
 
         /** @var User $user */
         $user = auth()->user();

--- a/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
@@ -38,6 +38,9 @@ class AnamneseWizardPage extends Page
         return false;
     }
 
+    /**
+     * @var array<string, mixed>
+     */
     public array $data = [];
 
     public function mount(): void

--- a/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
@@ -18,6 +18,9 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\HtmlString;
 use TresPontosTech\User\Actions\SaveAnamneseAction;
 
+/**
+ * @property-read Schema $form
+ */
 class AnamneseWizardPage extends Page
 {
     protected static ?string $slug = 'anamnese';

--- a/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
@@ -110,6 +110,7 @@ class EditUserProfile extends BaseEditUserProfile
             $anamneseData = Arr::only($data, self::ANAMNESE_FIELDS);
             $profileData = Arr::except($data, self::ANAMNESE_FIELDS);
 
+            /** @var User $updatedRecord */
             $updatedRecord = parent::handleRecordUpdate($record, $profileData);
 
             resolve(SaveAnamneseAction::class)->handle($updatedRecord, $anamneseData);

--- a/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TresPontosTech\App\Filament\Pages;
 
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Schemas\Components\Tabs;
@@ -90,7 +91,9 @@ class EditUserProfile extends BaseEditUserProfile
     {
         $data = parent::mutateFormDataBeforeFill($data);
 
-        $anamnese = $this->getUser()->anamnese;
+        /** @var User $user */
+        $user = $this->getUser();
+        $anamnese = $user->anamnese;
 
         $data['life_moment'] = $anamnese?->getRawOriginal('life_moment');
         $data['main_motivation'] = $anamnese?->main_motivation;

--- a/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
@@ -107,7 +107,13 @@ class EditUserProfile extends BaseEditUserProfile
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         return DB::transaction(function () use ($record, $data): Model {
-            $anamneseData = Arr::only($data, self::ANAMNESE_FIELDS);
+            $anamneseData = [
+                'life_moment' => (string) $data['life_moment'],
+                'main_motivation' => (string) $data['main_motivation'],
+                'money_relationship' => (string) $data['money_relationship'],
+                'plans_monthly_expenses' => (string) $data['plans_monthly_expenses'],
+                'tried_financial_strategies' => (string) $data['tried_financial_strategies'],
+            ];
             $profileData = Arr::except($data, self::ANAMNESE_FIELDS);
 
             /** @var User $updatedRecord */

--- a/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
@@ -29,7 +29,7 @@ class UserSubscriptionPage extends Page
     public function mount(): void
     {
         $plans = resolve(PlanRepository::class)->getCheckoutPlansFor('user');
-        $this->selectedPlanSlug = $plans->first()?->slug ?? '';
+        $this->selectedPlanSlug = $plans->first()->slug ?? '';
     }
 
     protected function getViewData(): array

--- a/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
@@ -10,6 +10,7 @@ use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
 use TresPontosTech\Billing\Core\Entities\PriceEntity;
 use TresPontosTech\Billing\Core\Repositories\PlanRepository;
+use TresPontosTech\Company\Models\Company;
 
 class UserSubscriptionPage extends Page
 {
@@ -33,7 +34,9 @@ class UserSubscriptionPage extends Page
 
     protected function getViewData(): array
     {
-        $isFlamma = filament()->getTenant()?->slug === 'flamma-company';
+        /** @var Company|null $tenant */
+        $tenant = filament()->getTenant();
+        $isFlamma = $tenant?->slug === 'flamma-company';
         $plans = resolve(PlanRepository::class)->getCheckoutPlansFor('user');
 
         if ($isFlamma) {
@@ -116,7 +119,9 @@ class UserSubscriptionPage extends Page
     /** @param PriceEntity[] $prices */
     private function resolvePriceForTenant(array $prices): PriceEntity
     {
-        $isFlamma = filament()->getTenant()?->slug === 'flamma-company';
+        /** @var Company|null $tenant */
+        $tenant = filament()->getTenant();
+        $isFlamma = $tenant?->slug === 'flamma-company';
         $prices = collect($prices);
 
         if ($isFlamma) {

--- a/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
@@ -74,7 +74,7 @@ class UserSubscriptionPage extends Page
             collectTaxIds: $plan->collectTaxIds,
             successUrl: UserDashboard::getUrl(),
             cancelUrl: UserDashboard::getUrl(),
-            metadata: ['model' => Relation::getMorphAlias(User::class)],
+            metadata: ['model' => (string) Relation::getMorphAlias(User::class)],
         );
 
         $driver = resolve(BillingManager::class)->getDriver($plan->provider);

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/CreateAppointment.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/CreateAppointment.php
@@ -28,7 +28,7 @@ class CreateAppointment extends CreateRecord
 
         /** @var User $user */
         $user = auth()->user();
-        if ($user && ! $user->canCreateAppointment()) {
+        if (! $user->canCreateAppointment()) {
             Notification::make()
                 ->title(__('panel-app::resources.appointments.pages.create.cannot_book_now'))
                 ->body(__('panel-app::resources.appointments.pages.create.no_appointments_available'))

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/CreateAppointment.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/CreateAppointment.php
@@ -8,6 +8,7 @@ use Filament\Notifications\Notification;
 use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
+use Illuminate\Contracts\Support\Arrayable;
 use Throwable;
 use TresPontosTech\App\Filament\Resources\Appointments\AppointmentResource;
 use TresPontosTech\App\Filament\Resources\Appointments\Schemas\AppointmentWizard;
@@ -57,7 +58,13 @@ class CreateAppointment extends CreateRecord
 
     public function submit(): void
     {
-        $appointmentDTO = BookAppointmentDTO::make(auth()->user()->getKey(), $this->form->getRawState());
+        $rawState = $this->form->getRawState();
+        $payload = $rawState instanceof Arrayable ? $rawState->toArray() : $rawState;
+
+        /** @var User $user */
+        $user = auth()->user();
+
+        $appointmentDTO = BookAppointmentDTO::make($user->getKey(), $payload);
 
         try {
             resolve(BookAppointmentAction::class)->handle($appointmentDTO);

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Schemas/AppointmentWizard.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Schemas/AppointmentWizard.php
@@ -74,6 +74,9 @@ class AppointmentWizard
                 ->action('start'));
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function availableSlots(?string $date): array
     {
         if (is_null($date)) {
@@ -89,6 +92,9 @@ class AppointmentWizard
         return self::getAvailableTimeSlots($startDate);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function getAvailableTimeSlots(Carbon $startDate): array
     {
         return resolve(GetAvailableSlotsAction::class)->handle($startDate);

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
@@ -58,12 +58,12 @@ class SharedDocumentResource extends Resource
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->with(['consultant']);
+        return parent::getGlobalSearchEloquentQuery()->with(['documentable']);
     }
 
     public static function getGloballySearchableAttributes(): array
     {
-        return ['title', 'consultant.name'];
+        return ['title', 'documentable.name'];
     }
 
     /**
@@ -73,8 +73,8 @@ class SharedDocumentResource extends Resource
     {
         $details = [];
 
-        if ($record->consultant) {
-            $details['Consultant'] = $record->consultant->name;
+        if ($record->documentable) {
+            $details['Consultant'] = $record->documentable->name;
         }
 
         return $details;

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
@@ -54,11 +54,11 @@ class SharedDocumentResource extends Resource
     }
 
     /**
-     * @return Builder<Document>
+     * @return Builder<Model>
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->with(['documentable']);
+        return static::getEloquentQuery()->with(['documentable']);
     }
 
     public static function getGloballySearchableAttributes(): array

--- a/app-modules/panel-app/src/Filament/Widgets/UserCurrentPlanWidget.php
+++ b/app-modules/panel-app/src/Filament/Widgets/UserCurrentPlanWidget.php
@@ -59,9 +59,9 @@ class UserCurrentPlanWidget extends Widget
             'description' => $plan->description,
             'status' => $subscription->ends_at ? 'expired' : ($subscription->stripe_status === 'active' ? 'active' : 'inactive'),
             'features' => [
-                'appointments' => $price->monthlyAppointments,
-                'whatsapp_access' => $price->whatsappEnabled,
-                'exclusive_materials' => $price->materialsEnabled,
+                'appointments' => $price->monthly_appointments,
+                'whatsapp_access' => $price->whatsapp_enabled,
+                'exclusive_materials' => $price->materials_enabled,
             ],
             'availableAppointments' => $user->monthly_appointments_left,
             'canCreateAppointment' => $user->canCreateAppointment(),

--- a/app-modules/panel-app/src/Http/Middleware/RedirectIfAnamneseNotCompleted.php
+++ b/app-modules/panel-app/src/Http/Middleware/RedirectIfAnamneseNotCompleted.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use TresPontosTech\Company\Models\Company;
 
 class RedirectIfAnamneseNotCompleted
 {
@@ -22,6 +23,7 @@ class RedirectIfAnamneseNotCompleted
         }
 
         $user = auth()->user();
+        /** @var Company|null $tenant */
         $tenant = filament()->getTenant();
 
         if ($user === null || $user->anamnese !== null) {

--- a/app-modules/panel-company/phpstan.ignore.neon
+++ b/app-modules/panel-company/phpstan.ignore.neon
@@ -1,2 +1,11 @@
 parameters:
     ignoreErrors:
+        # role/active são colunas de company_employees trazidas no select do join (users.* + company_employees.*).
+        - message: '#^Access to an undefined property App\\Models\\Users\\User::\$active\.$#'
+          identifier: property.notFound
+          count: 2
+          path: src/Filament/Pages/Tenancy/EditTenantProfile.php
+        - message: '#^Access to an undefined property App\\Models\\Users\\User::\$role\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Filament/Pages/Tenancy/EditTenantProfile.php

--- a/app-modules/panel-company/src/Filament/Actions/CancelSubscriptionAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CancelSubscriptionAction.php
@@ -31,8 +31,8 @@ class CancelSubscriptionAction extends Action
                 return;
             }
 
-            $provider = $subscription->price?->plan?->provider
-                ?? $subscription->plan?->provider
+            $provider = $subscription->price?->plan->provider
+                ?? $subscription->plan->provider
                 ?? BillingCustomer::getActiveProvider($billable)
                 ?? BillingProviderEnum::Barte;
 

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -11,8 +11,8 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
-use Laravel\Cashier\Subscription;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Rules\UniqueAtCompany;
 use TresPontosTech\Permissions\Roles;
@@ -54,7 +54,9 @@ class CreateAndAttachAction extends CreateAction
 
         $this->after(
             function (User $record): void {
-                filament()->getTenant()->employees()->syncWithoutDetaching($record);
+                /** @var Company $tenant */
+                $tenant = filament()->getTenant();
+                $tenant->employees()->syncWithoutDetaching($record);
                 $record->assignRole(Roles::Employee);
                 event(new UserRegistered($record, Roles::Employee, $this->plainPassword));
             }

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -9,6 +9,7 @@ use Filament\Actions\CreateAction;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
@@ -66,6 +67,9 @@ class CreateAndAttachAction extends CreateAction
 
     }
 
+    /**
+     * @return array<Component>
+     */
     private function buildFormSchema(): array
     {
         return [

--- a/app-modules/panel-company/src/Filament/Actions/TenantSeatsCounterAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/TenantSeatsCounterAction.php
@@ -3,8 +3,8 @@
 namespace TresPontosTech\PanelCompany\Filament\Actions;
 
 use Filament\Actions\Action;
-use Laravel\Cashier\Subscription;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Company\Models\Company;
 
 class TenantSeatsCounterAction extends Action

--- a/app-modules/panel-company/src/Filament/Actions/TenantSecretKeyRotationPanelAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/TenantSecretKeyRotationPanelAction.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Support\Icons\Heroicon;
 use TresPontosTech\Company\Models\Company;
+use TresPontosTech\PanelCompany\Filament\Pages\Tenancy\EditTenantProfile;
 use TresPontosTech\Tenant\Actions\TenantSecretKeyRotationAction;
 
 class TenantSecretKeyRotationPanelAction extends Action
@@ -30,7 +31,11 @@ class TenantSecretKeyRotationPanelAction extends Action
         $company = filament()->getTenant();
         $key = resolve(TenantSecretKeyRotationAction::class)->generate($company);
 
-        $this->getLivewire()->data['integration_access_key'] = $key;
+        $livewire = $this->getLivewire();
+
+        if ($livewire instanceof EditTenantProfile) {
+            $livewire->data['integration_access_key'] = $key;
+        }
 
         Notification::make('rotateKey')
             ->success()

--- a/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
+++ b/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
@@ -13,8 +13,8 @@ trait HasMetricsDateRange
 {
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),
@@ -24,13 +24,13 @@ trait HasMetricsDateRange
 
     private function filteredUserIds(): ?Collection
     {
-        $userId = data_get($this->filters, 'userId');
+        $userId = data_get($this->pageFilters, 'userId');
 
         if (filled($userId)) {
             return collect([$userId]);
         }
 
-        $departmentId = data_get($this->filters, 'departmentId');
+        $departmentId = data_get($this->pageFilters, 'departmentId');
 
         if (blank($departmentId)) {
             return null;

--- a/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
+++ b/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace TresPontosTech\PanelCompany\Filament\Concerns;
 
 use Filament\Facades\Filament;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use TresPontosTech\Company\Models\Company;
 
 trait HasMetricsDateRange
 {
+    /**
+     * @return array{start: Carbon, end: Carbon}
+     */
     private function dateRange(): array
     {
         $startDate = data_get($this->pageFilters, 'startDate');
@@ -22,6 +26,9 @@ trait HasMetricsDateRange
         ];
     }
 
+    /**
+     * @return Collection<int, string>|null
+     */
     private function filteredUserIds(): ?Collection
     {
         $userId = data_get($this->pageFilters, 'userId');

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -137,7 +137,9 @@ class CompanyCreditPage extends Page implements HasTable
                         ? null
                         : __('panel-company::resources.actions.revoke_all_credits.disabled_tooltip'))
                     ->action(function (): void {
-                        dispatch(new RevokeCreditsFromEmployeesJob(filament()->getTenant()));
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        dispatch(new RevokeCreditsFromEmployeesJob($tenant));
 
                         Notification::make()
                             ->title(__('panel-company::resources.actions.revoke_all_credits.queued_notification'))
@@ -153,7 +155,9 @@ class CompanyCreditPage extends Page implements HasTable
                         ? null
                         : __('panel-company::resources.actions.distribute_equally.disabled_tooltip'))
                     ->action(function (): void {
-                        dispatch(new DistributeCreditsEquallyJob(filament()->getTenant()));
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        dispatch(new DistributeCreditsEquallyJob($tenant));
 
                         Notification::make()
                             ->title(__('panel-company::resources.actions.distribute_equally.queued_notification'))
@@ -192,8 +196,10 @@ class CompanyCreditPage extends Page implements HasTable
                     ->successNotificationTitle(__('panel-company::resources.actions.distribute_manually.success_notification'))
                     ->action(function (array $data, Action $action): void {
                         $employee = User::query()->findOrFail($data['employee_id']);
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
                         resolve(AllocateCreditToEmployee::class)->handle(
-                            filament()->getTenant(),
+                            $tenant,
                             $employee,
                             (int) $data['quantity'],
                         );

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -25,6 +25,7 @@ use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Jobs\DistributeCreditsEquallyJob;
 use TresPontosTech\Billing\Core\Jobs\RevokeCreditsFromEmployeesJob;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
 use TresPontosTech\PanelCompany\Filament\Widgets\CompanyCreditStatsWidget;
 
@@ -74,6 +75,7 @@ class CompanyCreditPage extends Page implements HasTable
 
     public function table(Table $table): Table
     {
+        /** @var Company $tenant */
         $tenant = filament()->getTenant();
         $records = UserCredit::query()
             ->where('company_id', $tenant->getKey())
@@ -203,6 +205,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function ownerAvailableCreditsCount(): int
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         return UserCredit::query()
@@ -221,6 +224,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function hasDistributedCredits(): bool
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         return UserCredit::query()
@@ -233,6 +237,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function canDistributeEqually(): bool
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         $availableCredits = UserCredit::query()
@@ -249,7 +254,10 @@ class CompanyCreditPage extends Page implements HasTable
     /** @return array<string, string> */
     private function getActiveEmployeeOptions(): array
     {
-        return filament()->getTenant()
+        /** @var Company $tenant */
+        $tenant = filament()->getTenant();
+
+        return $tenant
             ->onlyEmployees()
             ->get()
             ->pluck('name', 'id')

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -121,7 +121,7 @@ class CompanyCreditPage extends Page implements HasTable
                             ->required(),
                     ])
                     ->action(function (array $data, UserCredit $record): void {
-                        $employee = User::query()->findOrFail($data['employee_id']);
+                        $employee = User::query()->findOrFail((string) $data['employee_id']);
                         resolve(TransferCreditBetweenEmployees::class)->handle($record, $employee);
                     }),
             ])
@@ -135,7 +135,7 @@ class CompanyCreditPage extends Page implements HasTable
                     ->disabled(fn (): bool => ! $this->hasDistributedCredits())
                     ->tooltip(fn (): ?string => $this->hasDistributedCredits()
                         ? null
-                        : __('panel-company::resources.actions.revoke_all_credits.disabled_tooltip'))
+                        : (string) __('panel-company::resources.actions.revoke_all_credits.disabled_tooltip'))
                     ->action(function (): void {
                         /** @var Company $tenant */
                         $tenant = filament()->getTenant();
@@ -153,7 +153,7 @@ class CompanyCreditPage extends Page implements HasTable
                     ->disabled(fn (): bool => ! $this->canDistributeEqually())
                     ->tooltip(fn (): ?string => $this->canDistributeEqually()
                         ? null
-                        : __('panel-company::resources.actions.distribute_equally.disabled_tooltip'))
+                        : (string) __('panel-company::resources.actions.distribute_equally.disabled_tooltip'))
                     ->action(function (): void {
                         /** @var Company $tenant */
                         $tenant = filament()->getTenant();
@@ -171,7 +171,7 @@ class CompanyCreditPage extends Page implements HasTable
                     ->disabled(fn (): bool => ! $this->hasOwnerAvailableCredits())
                     ->tooltip(fn (): ?string => $this->hasOwnerAvailableCredits()
                         ? null
-                        : __('panel-company::resources.actions.distribute_manually.disabled_tooltip'))
+                        : (string) __('panel-company::resources.actions.distribute_manually.disabled_tooltip'))
                     ->schema(fn (): array => [
                         TextEntry::make('notice')
                             ->label('')
@@ -195,7 +195,7 @@ class CompanyCreditPage extends Page implements HasTable
                     ])
                     ->successNotificationTitle(__('panel-company::resources.actions.distribute_manually.success_notification'))
                     ->action(function (array $data, Action $action): void {
-                        $employee = User::query()->findOrFail($data['employee_id']);
+                        $employee = User::query()->findOrFail((string) $data['employee_id']);
                         /** @var Company $tenant */
                         $tenant = filament()->getTenant();
                         resolve(AllocateCreditToEmployee::class)->handle(

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -28,6 +28,10 @@ use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
 use TresPontosTech\PanelCompany\Filament\Widgets\CompanyCreditStatsWidget;
 
+/**
+ * @property-read int $ownerAvailableCreditsCount
+ * @property-read bool $hasOwnerAvailableCredits
+ */
 class CompanyCreditPage extends Page implements HasTable
 {
     use InteractsWithTable;

--- a/app-modules/panel-company/src/Filament/Pages/Metrics.php
+++ b/app-modules/panel-company/src/Filament/Pages/Metrics.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Widgets\Metrics\AppointmentsByCategoryChart;
 use TresPontosTech\PanelCompany\Filament\Widgets\Metrics\AppointmentsByDepartmentChart;
 use TresPontosTech\PanelCompany\Filament\Widgets\Metrics\AppointmentStatsWidget;
@@ -56,23 +57,31 @@ class Metrics extends BaseDashboard
             Select::make('userId')
                 ->label(__('panel-company::resources.pages.metrics.filter_user'))
                 ->placeholder(__('panel-company::resources.pages.metrics.filter_user_placeholder'))
-                ->options(fn (): array => Filament::getTenant()
-                    ->employees()
-                    ->orderBy('users.name')
-                    ->pluck('users.name', 'users.id')
-                    ->toArray()
-                )
+                ->options(function (): array {
+                    /** @var Company $tenant */
+                    $tenant = Filament::getTenant();
+
+                    return $tenant
+                        ->employees()
+                        ->orderBy('users.name')
+                        ->pluck('users.name', 'users.id')
+                        ->toArray();
+                })
                 ->searchable()
                 ->native(false),
             Select::make('departmentId')
                 ->label(__('panel-company::resources.pages.metrics.filter_department'))
                 ->placeholder(__('panel-company::resources.pages.metrics.filter_department_placeholder'))
-                ->options(fn (): array => Filament::getTenant()
-                    ->departments()
-                    ->orderBy('name')
-                    ->pluck('name', 'id')
-                    ->toArray()
-                )
+                ->options(function (): array {
+                    /** @var Company $tenant */
+                    $tenant = Filament::getTenant();
+
+                    return $tenant
+                        ->departments()
+                        ->orderBy('name')
+                        ->pluck('name', 'id')
+                        ->toArray();
+                })
                 ->searchable()
                 ->native(false),
         ]);

--- a/app-modules/panel-company/src/Filament/Pages/Tenancy/EditTenantProfile.php
+++ b/app-modules/panel-company/src/Filament/Pages/Tenancy/EditTenantProfile.php
@@ -90,9 +90,12 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
 
     public function table(Table $table): Table
     {
+        /** @var Company $tenant */
+        $tenant = filament()->getTenant();
+
         return $table
             ->query(
-                filament()->getTenant()
+                $tenant
                     ->employees()
                     ->getQuery()
                     ->select([
@@ -181,17 +184,23 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
                     ->schema([
                         Select::make('department_id')
                             ->label(__('panel-company::resources.pages.edit_tenant.department'))
-                            ->options(fn (): array => filament()->getTenant()
-                                ->departments()
-                                ->orderBy('name')
-                                ->pluck('name', 'id')
-                                ->toArray()
-                            )
+                            ->options(function (): array {
+                                /** @var Company $tenant */
+                                $tenant = filament()->getTenant();
+
+                                return $tenant
+                                    ->departments()
+                                    ->orderBy('name')
+                                    ->pluck('name', 'id')
+                                    ->toArray();
+                            })
                             ->nullable()
                             ->native(false),
                     ])
                     ->action(function (User $record, array $data): void {
-                        filament()->getTenant()->employees()->updateExistingPivot($record, [
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        $tenant->employees()->updateExistingPivot($record, [
                             'department_id' => $data['department_id'],
                         ]);
 
@@ -207,7 +216,11 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
 
                         return $record->getKey() !== $company->user_id;
                     })
-                    ->action(fn ($record) => filament()->getTenant()->employees()->detach($record)),
+                    ->action(function ($record): void {
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        $tenant->employees()->detach($record);
+                    }),
             ])
             ->columns([
                 TextColumn::make('active')

--- a/app-modules/panel-company/src/Filament/Pages/Tenancy/RegisterTenant.php
+++ b/app-modules/panel-company/src/Filament/Pages/Tenancy/RegisterTenant.php
@@ -17,7 +17,7 @@ class RegisterTenant extends BaseRegisterTenant
 {
     public static function canView(): bool
     {
-        /** @var Company $tenant */
+        /** @var Company|null $tenant */
         $tenant = filament()->getTenant();
 
         if (is_null($tenant)) {

--- a/app-modules/panel-company/src/Filament/Resources/Departments/DepartmentResource.php
+++ b/app-modules/panel-company/src/Filament/Resources/Departments/DepartmentResource.php
@@ -109,6 +109,10 @@ class DepartmentResource extends Resource
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
     public static function mutateFormDataBeforeCreate(array $data): array
     {
         $data['company_id'] = Filament::getTenant()?->getKey();

--- a/app-modules/panel-company/src/Filament/Widgets/CompanyCreditStatsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/CompanyCreditStatsWidget.php
@@ -9,6 +9,7 @@ use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 
 class CompanyCreditStatsWidget extends StatsOverviewWidget
 {
@@ -22,6 +23,7 @@ class CompanyCreditStatsWidget extends StatsOverviewWidget
 
     protected function getStats(): array
     {
+        /** @var Company $company */
         $company = Filament::getTenant();
 
         $stats = UserCredit::query()

--- a/app-modules/panel-company/src/Filament/Widgets/LatestScheduledSessionsTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/LatestScheduledSessionsTableWidget.php
@@ -8,6 +8,7 @@ use Filament\Tables\Table;
 use Filament\Widgets\TableWidget;
 use Illuminate\Database\Eloquent\Builder;
 use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Company\Models\Company;
 
 class LatestScheduledSessionsTableWidget extends TableWidget
 {
@@ -20,8 +21,13 @@ class LatestScheduledSessionsTableWidget extends TableWidget
         return $table
             ->searchable(true)
             ->heading(__('panel-company::widgets.latest_sessions.heading'))
-            ->query(fn (): Builder => Appointment::query()
-                ->where('company_id', Filament::getTenant()->id)->latest())
+            ->query(function (): Builder {
+                /** @var Company $tenant */
+                $tenant = Filament::getTenant();
+
+                return Appointment::query()
+                    ->where('company_id', $tenant->id)->latest();
+            })
             ->columns([
                 TextColumn::make('consultant.name')
                     ->label(__('panel-company::widgets.latest_sessions.consultant'))

--- a/app-modules/panel-company/src/Filament/Widgets/LatestTenantAdoptorsTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/LatestTenantAdoptorsTableWidget.php
@@ -7,6 +7,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget;
 use Illuminate\Database\Eloquent\Builder;
+use TresPontosTech\Company\Models\Company;
 
 class LatestTenantAdoptorsTableWidget extends TableWidget
 {
@@ -19,10 +20,15 @@ class LatestTenantAdoptorsTableWidget extends TableWidget
         return $table
             ->searchable(false)
             ->heading(__('panel-company::widgets.latest_adoptors.heading'))
-            ->query(fn (): Builder => Filament::getTenant()
-                ->employees()
-                ->take(5)
-                ->getQuery())
+            ->query(function (): Builder {
+                /** @var Company $tenant */
+                $tenant = Filament::getTenant();
+
+                return $tenant
+                    ->employees()
+                    ->take(5)
+                    ->getQuery();
+            })
             ->paginated(false)
             ->columns([
                 TextColumn::make('name')

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentStatsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentStatsWidget.php
@@ -11,6 +11,7 @@ use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Collection;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class AppointmentStatsWidget extends StatsOverviewWidget
@@ -28,7 +29,9 @@ class AppointmentStatsWidget extends StatsOverviewWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $tenantId = Filament::getTenant()->id;
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant->id;
 
         $userIds = $this->filteredUserIds();
 

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentVolumeChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentVolumeChart.php
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class AppointmentVolumeChart extends ChartWidget
@@ -33,7 +34,9 @@ class AppointmentVolumeChart extends ChartWidget
 
     protected function getData(): array
     {
-        $tenantId = Filament::getTenant()->id;
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant->id;
         $userIds = $this->filteredUserIds();
 
         $startDate = data_get($this->pageFilters, 'startDate');

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentVolumeChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentVolumeChart.php
@@ -36,8 +36,8 @@ class AppointmentVolumeChart extends ChartWidget
         $tenantId = Filament::getTenant()->id;
         $userIds = $this->filteredUserIds();
 
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         if (filled($startDate) && filled($endDate)) {
             $start = now()->parse($startDate)->startOfDay();

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByCategoryChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByCategoryChart.php
@@ -10,6 +10,7 @@ use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Illuminate\Support\Collection;
 use TresPontosTech\Appointments\Enums\AppointmentCategoryEnum;
 use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class AppointmentsByCategoryChart extends ChartWidget
@@ -34,8 +35,11 @@ class AppointmentsByCategoryChart extends ChartWidget
 
         $userIds = $this->filteredUserIds();
 
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+
         $results = Appointment::query()
-            ->where('company_id', Filament::getTenant()->id)
+            ->where('company_id', $tenant->id)
             ->whereBetween('appointment_at', [$start, $end])
             ->when($userIds instanceof Collection, fn ($q) => $q->whereIn('user_id', $userIds))
             ->whereNotNull('category_type')

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
@@ -33,7 +33,7 @@ class AppointmentsByDepartmentChart extends ChartWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $selectedDepartmentId = data_get($this->filters, 'departmentId');
+        $selectedDepartmentId = data_get($this->pageFilters, 'departmentId');
 
         $counts = Department::query()
             ->where('departments.company_id', Filament::getTenant()->id)

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
@@ -8,6 +8,7 @@ use Filament\Facades\Filament;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Illuminate\Support\Facades\DB;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Company\Models\Department;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
@@ -35,8 +36,11 @@ class AppointmentsByDepartmentChart extends ChartWidget
 
         $selectedDepartmentId = data_get($this->pageFilters, 'departmentId');
 
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+
         $counts = Department::query()
-            ->where('departments.company_id', Filament::getTenant()->id)
+            ->where('departments.company_id', $tenant->id)
             ->leftJoin('company_employees', 'company_employees.department_id', '=', 'departments.id')
             ->leftJoin('appointments', function ($join) use ($start, $end): void {
                 $join->on('appointments.user_id', '=', 'company_employees.user_id')

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditStatsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditStatsWidget.php
@@ -11,6 +11,7 @@ use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Collection;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class CreditStatsWidget extends StatsOverviewWidget
@@ -28,7 +29,9 @@ class CreditStatsWidget extends StatsOverviewWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $tenantId = Filament::getTenant()->id;
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant->id;
         $userIds = $this->filteredUserIds();
 
         $base = UserCredit::query()

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
@@ -65,6 +65,9 @@ class CreditUsageTableWidget extends TableWidget
             ]);
     }
 
+    /**
+     * @return Builder<UserCredit>
+     */
     private function tableQuery(): Builder
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class CreditUsageTableWidget extends TableWidget
@@ -68,7 +69,9 @@ class CreditUsageTableWidget extends TableWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $tenantId = Filament::getTenant()->id;
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant->id;
         $userIds = $this->filteredUserIds();
 
         return UserCredit::query()

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
@@ -55,7 +55,7 @@ class CreditUsageTableWidget extends TableWidget
                 TextColumn::make('status')
                     ->label(__('panel-company::widgets.credit_usage.status'))
                     ->badge()
-                    ->color(fn (UserCreditStatusEnum $state): string|array => $state->getColor()),
+                    ->color(fn (UserCreditStatusEnum $state): array => $state->getColor()),
 
                 TextColumn::make('transferred_at')
                     ->label(__('panel-company::widgets.credit_usage.transferred_at'))

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
@@ -30,7 +30,7 @@ class InsightsWidget extends StatsOverviewWidget
         $tenant = Filament::getTenant();
 
         $userIds = $this->filteredUserIds();
-        $userId = data_get($this->filters, 'userId');
+        $userId = data_get($this->pageFilters, 'userId');
 
         if ($tenant->employees()->count() === 0) {
             return [$this->noDataStat()];

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TresPontosTech\PanelCompany\Filament\Widgets\Metrics;
 
+use App\Models\Users\User;
 use Filament\Facades\Filament;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
@@ -158,7 +159,11 @@ class InsightsWidget extends StatsOverviewWidget
             return null;
         }
 
-        $topUser = $tenant->employees()->find($topData->user_id);
+        $topUser = $tenant->employees()->find((string) $topData->user_id);
+
+        if (! $topUser instanceof User) {
+            return null;
+        }
 
         return Stat::make(__('panel-company::widgets.insights.top_user'), $topUser->name)
             ->description(__('panel-company::widgets.insights.top_user_description', [

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
@@ -43,6 +43,9 @@ class InsightsWidget extends StatsOverviewWidget
         ]);
     }
 
+    /**
+     * @param  Collection<int, string>|null  $userIds
+     */
     private function neverUsedStat(Company $tenant, ?Collection $userIds): ?Stat
     {
         $employeesQuery = $tenant->employees()
@@ -76,6 +79,9 @@ class InsightsWidget extends StatsOverviewWidget
             ->color($neverUsedRate > 50 ? 'danger' : ($neverUsedRate > 20 ? 'warning' : 'success'));
     }
 
+    /**
+     * @param  Collection<int, string>|null  $userIds
+     */
     private function volumeVariationStat(string $tenantId, ?Collection $userIds): ?Stat
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
@@ -129,6 +135,9 @@ class InsightsWidget extends StatsOverviewWidget
             ->color($color);
     }
 
+    /**
+     * @param  Collection<int, string>|null  $userIds
+     */
     private function topUserStat(Company $tenant, ?Collection $userIds = null): ?Stat
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();

--- a/app-modules/panel-company/src/Filament/Widgets/TenantAdoptionStatsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/TenantAdoptionStatsWidget.php
@@ -35,6 +35,7 @@ class TenantAdoptionStatsWidget extends StatsOverviewWidget
 
     private function getEmployeesWithAccessCount(): Stat
     {
+        /** @var Company $tenant */
         $tenant = Filament::getTenant();
         $totalEmployees = $tenant->onlyEmployees()->count();
 
@@ -53,6 +54,7 @@ class TenantAdoptionStatsWidget extends StatsOverviewWidget
 
     private function getEmployeesWithPlansCount(): Stat
     {
+        /** @var Company $tenant */
         $tenant = Filament::getTenant();
 
         $employeesWithAccess = $tenant->onlyEmployees()
@@ -75,6 +77,7 @@ class TenantAdoptionStatsWidget extends StatsOverviewWidget
 
     private function getAdoptionRate(): Stat
     {
+        /** @var Company $tenant */
         $tenant = Filament::getTenant();
         $totalEmployees = $tenant->onlyEmployees()->count();
 

--- a/app-modules/panel-consultant/src/Filament/Actions/ReviewAppointmentRecordAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/ReviewAppointmentRecordAction.php
@@ -38,7 +38,7 @@ class ReviewAppointmentRecordAction extends Action
             && Gate::allows('update', $record->record));
 
         $this->fillForm(fn (Appointment $record): array => [
-            'content' => $record->record?->content ?? '',
+            'content' => $record->record->content ?? '',
         ]);
 
         $this->schema([

--- a/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
@@ -6,6 +6,7 @@ use App\Models\Users\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Mail;
 use TresPontosTech\Consultants\Actions\UpsertDocumentShareAction;
@@ -35,6 +36,9 @@ class ShareDocumentFilamentAction extends Action
             });
     }
 
+    /**
+     * @return array<Component>
+     */
     public static function getCustomForm(): array
     {
         return [
@@ -57,7 +61,10 @@ class ShareDocumentFilamentAction extends Action
         ];
     }
 
-    public static function handleExecution(Document $record, array $data, $action): void
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function handleExecution(Document $record, array $data, Action $action): void
     {
         $consultantId = auth()->user()->consultant->getKey();
 

--- a/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
@@ -89,7 +89,7 @@ class ShareDocumentFilamentAction extends Action
             ])
         );
 
-        $employee = User::query()->find($data['employee_id']);
+        $employee = User::query()->whereKey($data['employee_id'])->first();
 
         if ($employee) {
             Mail::to($employee->email)->queue(new DocumentSharedMail($record, $employee));

--- a/app-modules/panel-consultant/src/Filament/Pages/EditConsultantProfile.php
+++ b/app-modules/panel-consultant/src/Filament/Pages/EditConsultantProfile.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Consultants\Filament\Pages;
 use App\Filament\Shared\Fields\DocumentIdInput;
 use App\Filament\Shared\Fields\TaxIdInput;
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Schemas\Components\Component;
 
 class EditConsultantProfile extends BaseEditUserProfile
@@ -14,6 +15,9 @@ class EditConsultantProfile extends BaseEditUserProfile
      */
     protected function getExtraDetailFormComponents(): array
     {
+        /** @var User $user */
+        $user = $this->getUser();
+
         return [
             TaxIdInput::make()
                 ->label(__('panel-admin::resources.pages.edit_profile.cpf')),
@@ -24,7 +28,7 @@ class EditConsultantProfile extends BaseEditUserProfile
                 ->unique(
                     table: 'user_details',
                     column: 'document_id',
-                    ignorable: $this->getUser()->detail,
+                    ignorable: $user->detail,
                     ignoreRecord: false
                 ),
         ];

--- a/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -38,6 +38,9 @@ class AppointmentsTable
 
     }
 
+    /**
+     * @return array<int, TextColumn>
+     */
     public static function columns(): array
     {
         return [

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/DocumentResource.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/DocumentResource.php
@@ -70,11 +70,11 @@ class DocumentResource extends Resource
     }
 
     /**
-     * @return Builder<Document>
+     * @return Builder<Model>
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->with(['documentable']);
+        return static::getEloquentQuery()->with(['documentable']);
     }
 
     public static function getGloballySearchableAttributes(): array

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/CreateDocument.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/CreateDocument.php
@@ -7,7 +7,11 @@ namespace TresPontosTech\Consultants\Filament\Resources\Documents\Pages;
 use Filament\Resources\Pages\CreateRecord;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Filament\Resources\Documents\DocumentResource;
+use TresPontosTech\Consultants\Models\Document;
 
+/**
+ * @property-read Document $record
+ */
 class CreateDocument extends CreateRecord
 {
     protected static string $resource = DocumentResource::class;

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/EditDocument.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/EditDocument.php
@@ -10,7 +10,11 @@ use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\EditRecord;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Filament\Resources\Documents\DocumentResource;
+use TresPontosTech\Consultants\Models\Document;
 
+/**
+ * @property-read Document $record
+ */
 class EditDocument extends EditRecord
 {
     protected static string $resource = DocumentResource::class;

--- a/app-modules/permissions/src/Commands/SyncPermissions/SyncPermissionsCommand.php
+++ b/app-modules/permissions/src/Commands/SyncPermissions/SyncPermissionsCommand.php
@@ -226,8 +226,8 @@ class SyncPermissionsCommand extends Command
         note('Models and RBAC Status:');
         table(['Name', 'Resource', 'Group', 'Has RBAC'], $tableData);
 
-        return collect($rbacConfigs)->map(fn (array $resources, string $role): RolePermissions => new RolePermissions(
-            role: $role,
+        return collect($rbacConfigs)->map(fn (array $resources, int|string $role): RolePermissions => new RolePermissions(
+            role: (string) $role,
             resources: $resources
         ))->values();
     }

--- a/app-modules/permissions/src/PermissionsEnum.php
+++ b/app-modules/permissions/src/PermissionsEnum.php
@@ -19,6 +19,10 @@ enum PermissionsEnum: string
 
     public function buildPermissionFor(string $classPath): string
     {
-        return $this->value . '_' . Str::snake(Relation::getMorphAlias($classPath));
+        $morphAlias = array_search($classPath, Relation::morphMap(), strict: true);
+
+        $resource = $morphAlias === false ? $classPath : $morphAlias;
+
+        return $this->value . '_' . Str::snake($resource);
     }
 }

--- a/app-modules/permissions/src/Roles.php
+++ b/app-modules/permissions/src/Roles.php
@@ -22,7 +22,7 @@ enum Roles: string implements HasColor, HasLabel
 
     case Consultant = 'consultant';
 
-    public function getColor(): string|array|null
+    public function getColor(): array
     {
         return match ($this) {
             self::CompanyOwner => Color::Red,

--- a/app-modules/tenant/src/Models/TenantMember.php
+++ b/app-modules/tenant/src/Models/TenantMember.php
@@ -7,10 +7,21 @@ namespace TresPontosTech\Tenant\Models;
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Company\Models\Department;
 use TresPontosTech\Permissions\Roles;
 
+/**
+ * @property string $user_id
+ * @property string $company_id
+ * @property string|null $department_id
+ * @property Roles|null $role
+ * @property bool $active
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class TenantMember extends Pivot
 {
     public $timestamps = true;
@@ -26,16 +37,19 @@ class TenantMember extends Pivot
         'active' => 'boolean',
     ];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<Company, $this> */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /** @return BelongsTo<Department, $this> */
     public function department(): BelongsTo
     {
         return $this->belongsTo(Department::class);

--- a/app-modules/user/src/Actions/ParseUsersFromFileAction.php
+++ b/app-modules/user/src/Actions/ParseUsersFromFileAction.php
@@ -7,6 +7,9 @@ use Spatie\SimpleExcel\SimpleExcelReader;
 
 class ParseUsersFromFileAction
 {
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
     public function execute(string $filePath, string $fileExtension): Collection
     {
         return SimpleExcelReader::create($filePath, $fileExtension)
@@ -18,6 +21,10 @@ class ParseUsersFromFileAction
             ->values();
     }
 
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
     private function sanitizeRow(array $row): array
     {
         foreach (['phone_number', 'tax_id'] as $field) {

--- a/app-modules/user/src/Actions/PersistImportedUsersAction.php
+++ b/app-modules/user/src/Actions/PersistImportedUsersAction.php
@@ -19,6 +19,9 @@ class PersistImportedUsersAction
 {
     private const int CHUNK_SIZE = 100;
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     public function execute(Collection $rows, Company $company): ImportUsersResultDTO
     {
         $imported = 0;

--- a/app-modules/user/src/Actions/ValidateUserImportAction.php
+++ b/app-modules/user/src/Actions/ValidateUserImportAction.php
@@ -16,7 +16,10 @@ class ValidateUserImportAction
     /** @var list<ImportErrorDTO> */
     private array $errors = [];
 
-    /** @return list<ImportErrorDTO> */
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     * @return list<ImportErrorDTO>
+     */
     public function execute(Collection $rows, Company $company): array
     {
         $this->errors = [];
@@ -191,6 +194,9 @@ class ValidateUserImportAction
         }
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicateEmails(Collection $rows): void
     {
         $emails = $rows->map(fn (array $row): string => strtolower(trim((string) ($row['email'] ?? ''))));
@@ -206,6 +212,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateExistingEmails(Collection $rows): void
     {
         $emails = $rows->map(fn (array $row): string => strtolower(trim((string) ($row['email'] ?? ''))));
@@ -227,6 +236,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicateTaxIds(Collection $rows): void
     {
         $taxIds = $rows->map(fn (array $row): string => trim((string) ($row['tax_id'] ?? '')));
@@ -242,6 +254,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateExistingTaxIds(Collection $rows): void
     {
         $taxIds = $rows->map(fn (array $row): string => trim((string) ($row['tax_id'] ?? '')));
@@ -263,6 +278,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicatePhoneNumbers(Collection $rows): void
     {
         $phoneNumbers = $rows->map(fn (array $row): string => trim((string) ($row['phone_number'] ?? '')));

--- a/app-modules/user/src/DTOs/UserDTO.php
+++ b/app-modules/user/src/DTOs/UserDTO.php
@@ -13,6 +13,9 @@ final readonly class UserDTO
         public ?string $tenant_id = null,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/user/src/Enums/LifeMoment.php
+++ b/app-modules/user/src/Enums/LifeMoment.php
@@ -6,7 +6,6 @@ use Filament\Support\Contracts\HasDescription;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
-use Illuminate\Contracts\Support\Htmlable;
 
 enum LifeMoment: string implements HasDescription, HasIcon, HasLabel
 {
@@ -20,12 +19,12 @@ enum LifeMoment: string implements HasDescription, HasIcon, HasLabel
 
     case Investor = 'investor';
 
-    public function getLabel(): string|Htmlable|null
+    public function getLabel(): string
     {
         return __('user::enums.life_moment.' . $this->value . '.label');
     }
 
-    public function getDescription(): string|Htmlable|null
+    public function getDescription(): string
     {
         return __('user::enums.life_moment.' . $this->value . '.description');
     }

--- a/app-modules/user/src/Filament/Actions/ImportUsersAction.php
+++ b/app-modules/user/src/Filament/Actions/ImportUsersAction.php
@@ -8,6 +8,7 @@ use Filament\Forms\Components\FileUpload;
 use Filament\Notifications\Notification;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\HtmlString;
+use Livewire\Component;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\User\Actions\ParseUsersFromFileAction;
@@ -74,6 +75,7 @@ class ImportUsersAction extends Action
             /** @var TemporaryUploadedFile $file */
             $file = $data['file'];
             $company = $this->resolveCompany();
+            $livewire = $this->getLivewire();
 
             $rows = resolve(ParseUsersFromFileAction::class)->execute(
                 $file->getRealPath(),
@@ -93,27 +95,35 @@ class ImportUsersAction extends Action
             $errors = resolve(ValidateUserImportAction::class)->execute($rows, $company);
 
             if ($errors !== []) {
-                $this->getLivewire()->dispatch('import-errors', errors: collect($errors)
-                    ->map(fn (ImportErrorDTO $e): array => [
-                        'row' => $e->row,
-                        'email' => $e->email,
-                        'message' => $e->message,
-                    ])
-                    ->values()
-                    ->all()
-                );
+                if ($livewire instanceof Component) {
+                    $livewire->dispatch('import-errors', errors: collect($errors)
+                        ->map(fn (ImportErrorDTO $e): array => [
+                            'row' => $e->row,
+                            'email' => $e->email,
+                            'message' => $e->message,
+                        ])
+                        ->values()
+                        ->all()
+                    );
+                }
 
                 return;
             }
 
+            $userId = auth()->id();
+
+            throw_if($userId === null, \RuntimeException::class, 'Cannot import users without an authenticated user.');
+
             dispatch(new ImportUsersJob(
                 rows: $rows,
-                companyId: $company->getKey(),
-                userId: auth()->id()
+                companyId: (string) $company->getKey(),
+                userId: (string) $userId
             ))
                 ->onQueue('users-import');
 
-            $this->getLivewire()->dispatch('import-started');
+            if ($livewire instanceof Component) {
+                $livewire->dispatch('import-started');
+            }
 
             Notification::make()
                 ->info()

--- a/app-modules/user/src/Jobs/ImportUsersJob.php
+++ b/app-modules/user/src/Jobs/ImportUsersJob.php
@@ -17,6 +17,9 @@ class ImportUsersJob implements ShouldQueue
 
     public int $timeout = 600;
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     public function __construct(
         public readonly Collection $rows,
         public readonly string $companyId,

--- a/app-modules/user/src/Models/UserAnamnese.php
+++ b/app-modules/user/src/Models/UserAnamnese.php
@@ -46,6 +46,7 @@ class UserAnamnese extends Model
         ];
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Users/Detail.php
+++ b/app/Models/Users/Detail.php
@@ -9,7 +9,21 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $user_id
+ * @property string $company_id
+ * @property string|null $phone_number
+ * @property string|null $integration_id
+ * @property string $document_id
+ * @property string $tax_id
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ */
 #[UsePolicy(DetailPolicy::class)]
 class Detail extends Model
 {

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Cashier\Billable;
 use Spatie\Image\Enums\Fit;
@@ -52,6 +53,21 @@ use TresPontosTech\Tenant\Models\Traits\HasTenant;
 use TresPontosTech\User\Models\UserAnamnese;
 
 /**
+ * @property string $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $crm_id
+ * @property string|null $external_id
+ * @property string|null $stripe_id
+ * @property string|null $pm_type
+ * @property string|null $pm_last_four
+ * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property string|null $remember_token
  * @property-read int $monthly_appointments_left
  */
 #[UsePolicy(UserPolicy::class)]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 4
+    level: 5
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 5
+    level: 6
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 3
+    level: 4
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 2
+    level: 3
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 1
+    level: 2
 
     paths:
         - app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
+    level: 1
 
     paths:
         - app


### PR DESCRIPTION
## Problema

Após a Fase 1 (#200) deixar a análise modular do PHPStan verde no **level 0**, faltava subir o rigor até o **level 7** corrigindo os erros reais — sem afrouxar `level` nem suprimir com baseline.

## Solução

Subida incremental **level 1 → 7**, um commit por nível (revisável separadamente). Política: **corrigir de verdade**; `phpstan.ignore.neon` por módulo só para false positives genuínos.

| Level | Foco | Principais correções |
|---|---|---|
| 1 | `property.notFound` | Filament v4 `$filters`→`$pageFilters`; `@property` em models; `@property-read` p/ computed/schema |
| 2 | typing de Model | **Anotação completa de todos os models** (colunas + genéricos de relação) — colapsou ~100 erros; tipagem de `$this->record`/`getTenant()`/`auth()->user()` |
| 3 | by-ref / return | `&$lines` (PHPWord null), `getGlobalSearchEloquentQuery()` |
| 4 | código morto / tipos não usados | retorno de enums Filament estreitado; `?->`→`->` redundante; método morto removido |
| 5 | tipos de argumento | `str_starts_with`/keys, `throw_unless` posicional, jobs recebendo `Company` tipado |
| 6 | tipos faltantes | `array<...>`, genéricos (`HasFactory<>`, `Collection<>`, `Builder<>`), return/param types |
| 7 | nullabilidade / uniões | narrowing com `instanceof`, tratamento de `false`/`null`, shapes de `object`/array |

### Bugs reais encontrados e corrigidos no caminho
- `UserBillingProvider`/`CompanyBillingProvider`: usavam `getDefaultDriver()` (retorna o **nome** do driver, string) onde precisavam da **instância** → `getDriver()`.
- `ConsultantForm`: `str(...)->slug` (propriedade inexistente) → `->slug()`.
- `UserCurrentPlanWidget`: acesso camelCase (`monthlyAppointments`) a colunas snake_case → corrigido.
- `SharedDocumentResource`: relação inexistente `consultant` → `documentable`.

## Configuração

- Único arquivo que mudou de nível: a linha `level:` no `phpstan.neon` da raiz (0 → 7).
- `phpstan.ignore.neon` por módulo: apenas false positives reais documentados (magic `__get` do Cashier Checkout, generic model da medialibrary).

## Verificação (cada nível)

- `vendor/bin/phpstan analyse` → `[OK] No errors` no **level 7** (cobrindo `app` + 13 módulos).
- Suíte completa a cada nível: **782 passed, 2 skipped, 0 falhas**.
- `pint` e `rector --dry-run` limpos a cada commit.

> Nota: cada commit corresponde a um nível e mantém PHPStan/Pint/Rector/testes verdes — dá para revisar incrementalmente.