### PR TITLE
ci(phpstan): sobe análise estática modular para o level 1

### DIFF
--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -12,9 +12,13 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Database\Factories\AppointmentRecordFactory;
 use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 
+/**
+ * @property Carbon|null $published_at
+ */
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
 {

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -14,6 +14,10 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
+/**
+ * @property DocumentExtensionTypeEnum|null $type
+ * @property string|null $link
+ */
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
 {

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -7,6 +7,9 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property bool $active
+ */
 class DocumentShare extends Model
 {
     use HasFactory;

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByCategory.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByCategory.php
@@ -22,8 +22,8 @@ class AppointmentsByCategory extends ChartWidget
 
     protected function getData(): array
     {
-        $start = $this->filters['startDate'] ? now()->parse($this->filters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
-        $end = $this->filters['endDate'] ? now()->parse($this->filters['endDate'])->endOfDay() : now()->endOfDay();
+        $start = $this->pageFilters['startDate'] ? now()->parse($this->pageFilters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
+        $end = $this->pageFilters['endDate'] ? now()->parse($this->pageFilters['endDate'])->endOfDay() : now()->endOfDay();
 
         $results = Appointment::query()
             ->whereBetween('created_at', [$start, $end])

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
@@ -21,7 +21,7 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
 
     public function getHeading(): ?string
     {
-        $category = data_get($this->filters, 'departmentCategory');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         if (filled($category)) {
             $enum = DepartmentCategory::tryFrom($category);
@@ -36,9 +36,9 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
 
     protected function getData(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
-        $category = data_get($this->filters, 'departmentCategory');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         $start = filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay();
         $end = filled($endDate) ? now()->parse($endDate)->endOfDay() : now()->endOfDay();

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
@@ -22,8 +22,8 @@ class AppointmentsByStatus extends ChartWidget
 
     protected function getData(): array
     {
-        $start = $this->filters['startDate'] ? now()->parse($this->filters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
-        $end = $this->filters['endDate'] ? now()->parse($this->filters['endDate'])->endOfDay() : now()->endOfDay();
+        $start = $this->pageFilters['startDate'] ? now()->parse($this->pageFilters['startDate'])->startOfDay() : now()->subDays(30)->startOfDay();
+        $end = $this->pageFilters['endDate'] ? now()->parse($this->pageFilters['endDate'])->endOfDay() : now()->endOfDay();
 
         $results = Appointment::query()
             ->whereBetween('created_at', [$start, $end])

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
@@ -22,7 +22,7 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $category = data_get($this->filters, 'departmentCategory');
+        $category = data_get($this->pageFilters, 'departmentCategory');
 
         $base = Appointment::query()
             ->whereBetween('appointment_at', [$start, $end])
@@ -86,8 +86,8 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
 
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
@@ -28,8 +28,8 @@ class KPIsOverview extends StatsOverviewWidget
 
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
@@ -31,8 +31,8 @@ class RankingsWidget extends TableWidget
 
     public function table(Table $table): Table
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         $start = filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay();
         $end = filled($endDate) ? now()->parse($endDate)->endOfDay() : now()->endOfDay();

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketStatsWidget.php
@@ -73,8 +73,8 @@ class SupportTicketStatsWidget extends StatsOverviewWidget
      */
     private function dateRange(): array
     {
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsByCategory.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsByCategory.php
@@ -24,11 +24,11 @@ class SupportTicketsByCategory extends ChartWidget
 
     protected function getData(): array
     {
-        $start = filled($this->filters['startDate'] ?? null)
-            ? now()->parse($this->filters['startDate'])->startOfDay()
+        $start = filled($this->pageFilters['startDate'] ?? null)
+            ? now()->parse($this->pageFilters['startDate'])->startOfDay()
             : now()->subDays(30)->startOfDay();
-        $end = filled($this->filters['endDate'] ?? null)
-            ? now()->parse($this->filters['endDate'])->endOfDay()
+        $end = filled($this->pageFilters['endDate'] ?? null)
+            ? now()->parse($this->pageFilters['endDate'])->endOfDay()
             : now()->endOfDay();
 
         $results = SupportTicket::query()

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsBySector.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsBySector.php
@@ -25,11 +25,11 @@ class SupportTicketsBySector extends ChartWidget
 
     protected function getData(): array
     {
-        $start = filled($this->filters['startDate'] ?? null)
-            ? now()->parse($this->filters['startDate'])->startOfDay()
+        $start = filled($this->pageFilters['startDate'] ?? null)
+            ? now()->parse($this->pageFilters['startDate'])->startOfDay()
             : now()->subDays(30)->startOfDay();
-        $end = filled($this->filters['endDate'] ?? null)
-            ? now()->parse($this->filters['endDate'])->endOfDay()
+        $end = filled($this->pageFilters['endDate'] ?? null)
+            ? now()->parse($this->pageFilters['endDate'])->endOfDay()
             : now()->endOfDay();
 
         $byCategory = SupportTicket::query()

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsByStatus.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/SupportTicketsByStatus.php
@@ -24,11 +24,11 @@ class SupportTicketsByStatus extends ChartWidget
 
     protected function getData(): array
     {
-        $start = filled($this->filters['startDate'] ?? null)
-            ? now()->parse($this->filters['startDate'])->startOfDay()
+        $start = filled($this->pageFilters['startDate'] ?? null)
+            ? now()->parse($this->pageFilters['startDate'])->startOfDay()
             : now()->subDays(30)->startOfDay();
-        $end = filled($this->filters['endDate'] ?? null)
-            ? now()->parse($this->filters['endDate'])->endOfDay()
+        $end = filled($this->pageFilters['endDate'] ?? null)
+            ? now()->parse($this->pageFilters['endDate'])->endOfDay()
             : now()->endOfDay();
 
         $results = SupportTicket::query()

--- a/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
@@ -18,6 +18,9 @@ use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\HtmlString;
 use TresPontosTech\User\Actions\SaveAnamneseAction;
 
+/**
+ * @property-read Schema $form
+ */
 class AnamneseWizardPage extends Page
 {
     protected static ?string $slug = 'anamnese';

--- a/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
+++ b/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
@@ -26,8 +26,8 @@ trait HasMetricsDateRange
             ];
         }
 
-        $startDate = data_get($this->filters, 'startDate');
-        $endDate = data_get($this->filters, 'endDate');
+        $startDate = data_get($this->pageFilters, 'startDate');
+        $endDate = data_get($this->pageFilters, 'endDate');
 
         return [
             'start' => filled($startDate) ? now()->parse($startDate)->startOfDay() : now()->subDays(30)->startOfDay(),
@@ -56,7 +56,7 @@ trait HasMetricsDateRange
      */
     private function parsedMonthFilter(): ?array
     {
-        $month = data_get($this->filters, 'month');
+        $month = data_get($this->pageFilters, 'month');
 
         if (blank($month) || preg_match('/^\d{4}-\d{1,2}$/', (string) $month) !== 1) {
             return null;
@@ -74,8 +74,8 @@ trait HasMetricsDateRange
 
     private function metricsFilters(): MetricsFilters
     {
-        $userId = data_get($this->filters, 'userId');
-        $departmentId = data_get($this->filters, 'departmentId');
+        $userId = data_get($this->pageFilters, 'userId');
+        $departmentId = data_get($this->pageFilters, 'departmentId');
 
         return new MetricsFilters(
             userId: filled($userId) ? (string) $userId : null,

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -28,6 +28,9 @@ use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
 use TresPontosTech\PanelCompany\Filament\Widgets\CompanyCreditStatsWidget;
 
+/**
+ * @property-read int $ownerAvailableCreditsCount
+ */
 class CompanyCreditPage extends Page implements HasTable
 {
     use InteractsWithTable;

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentsByDepartmentChart.php
@@ -33,7 +33,7 @@ class AppointmentsByDepartmentChart extends ChartWidget
     {
         ['start' => $start, 'end' => $end] = $this->dateRange();
 
-        $selectedDepartmentId = data_get($this->filters, 'departmentId');
+        $selectedDepartmentId = data_get($this->pageFilters, 'departmentId');
 
         $counts = Department::query()
             ->where('departments.company_id', Filament::getTenant()->id)

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/InsightsWidget.php
@@ -30,7 +30,7 @@ class InsightsWidget extends StatsOverviewWidget
         $tenant = Filament::getTenant();
 
         $userIds = $this->filteredUserIds();
-        $userId = data_get($this->filters, 'userId');
+        $userId = data_get($this->pageFilters, 'userId');
 
         if ($tenant->employees()->count() === 0) {
             return [$this->noDataStat()];

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 0
+    level: 1
 
     paths:
         - app


### PR DESCRIPTION
## Contexto

O PHPStan modular foi configurado no **level 0** no PR #200 (já mergeado no `develop`). Este PR dá o primeiro passo da subida incremental: **level 0 → level 1**.

Ao subir para o level 1, o PHPStan passou a acusar **77 erros**, todos do mesmo identificador `property.notFound` (acesso a propriedade não declarada). Eles se concentram em três pontos:

| # | Origem | Qtd |
|---|--------|-----|
| A | Models sem `@property` para colunas/casts | 4 |
| B | `$this->filters` em widgets/trait de métricas | 69 |
| C | Properties mágicas de Page (`$form`, `#[Computed]`) | 4 |

Nenhuma mudança altera comportamento — são anotações de tipo e a troca de um alias deprecado pelo nome real da property.

## O que foi feito

### A) Models — `@property` com os tipos reais
Tipos derivados das migrations + `casts()`:
- `AppointmentRecord::$published_at` → `Carbon|null` (timestamp nullable, cast `datetime`)
- `Document::$type` → `DocumentExtensionTypeEnum|null` (coluna nullable + cast enum) e `Document::$link` → `string|null`
- `DocumentShare::$active` → `bool` (cast `bool`, default `true`)

### B) Métricas — `$this->filters` → `$this->pageFilters`
No Filament v4 o trait `InteractsWithPageFilters` declara `public ?array $pageFilters` e mantém um `__get` de **backwards-compat**:

```php
public function __get($property): mixed
{
    if ($property === 'filters') {
        return $this->pageFilters; // alias deprecado
    }
    return parent::__get($property);
}
```

Ou seja, `$this->filters` já resolvia para `$this->pageFilters` em runtime — o PHPStan apenas acusava o acesso ao alias mágico. A troca para a property real é **comportamentalmente idêntica** e remove a dependência do shim deprecado.

Afetou 10 widgets do `panel-admin`, o trait `HasMetricsDateRange` e 2 widgets do `panel-company` (os demais widgets do `panel-company` herdam o acesso pelo trait).

### C) Pages — `@property-read` para properties mágicas
- `AnamneseWizardPage::$form` → `@property-read Schema $form` (resolvida pelo método `form()`)
- `CompanyCreditPage::$ownerAvailableCreditsCount` → `@property-read int` (property `#[Computed]` do Livewire)

## Verificação

- ✅ `vendor/bin/phpstan analyse` — **level 1, 0 erros**
- ✅ `vendor/bin/pint` — sem ajustes pendentes
- ✅ `vendor/bin/rector --dry-run` — 0 mudanças
- ✅ Suíte completa (pre-push hook): **933 passed, 2 skipped, 0 falhas**

## Próximos passos

Este é o primeiro nível de uma subida incremental; os níveis 2→7 virão em PRs seguintes (a property mágica é só level 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard metrics and statistics widgets to correctly apply page-level filters for date ranges and category selections across appointments, support tickets, and rankings views.

* **Documentation**
  * Added property documentation to key model classes for improved code clarity.

* **Chores**
  * Increased code analysis standards to enforce stricter quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->