### PR TITLE
ci(phpstan): sobe análise estática modular para o level 2

### DIFF
--- a/app-modules/appointments/src/Models/Appointment.php
+++ b/app-modules/appointments/src/Models/Appointment.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use TresPontosTech\Appointments\Actions\Transitions\AbstractAppointmentTransition;
 use TresPontosTech\Appointments\Enums\AppointmentCategoryEnum;
@@ -24,6 +25,24 @@ use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Consultants\Models\Consultant;
 
+/**
+ * @property string $id
+ * @property string|null $consultant_id
+ * @property string $user_id
+ * @property AppointmentCategoryEnum $category_type
+ * @property Carbon $appointment_at
+ * @property AppointmentStatus $status
+ * @property string|null $notes
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property string|null $company_id
+ * @property string|null $meeting_url
+ * @property string|null $google_event_id
+ * @property string|null $cancelled_by
+ * @property CancellationActor|null $cancellation_actor
+ * @property-read AbstractAppointmentTransition $current_transition
+ */
 class Appointment extends Model
 {
     use HasFactory;
@@ -47,36 +66,57 @@ class Appointment extends Model
         'cancellation_actor',
     ];
 
+    /**
+     * @return BelongsTo<Consultant, $this>
+     */
     public function consultant(): BelongsTo
     {
         return $this->belongsTo(Consultant::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function cancelledBy(): BelongsTo
     {
         return $this->belongsTo(User::class, 'cancelled_by');
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return HasOne<AppointmentFeedback, $this>
+     */
     public function feedback(): HasOne
     {
         return $this->hasOne(AppointmentFeedback::class);
     }
 
+    /**
+     * @return HasOne<AppointmentRecord, $this>
+     */
     public function record(): HasOne
     {
         return $this->hasOne(AppointmentRecord::class);
     }
 
+    /**
+     * @return HasOne<UserCredit, $this>
+     */
     public function credit(): HasOne
     {
         return $this->hasOne(UserCredit::class);

--- a/app-modules/appointments/src/Models/AppointmentFeedback.php
+++ b/app-modules/appointments/src/Models/AppointmentFeedback.php
@@ -6,8 +6,18 @@ use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Database\Factories\AppointmentFeedbackFactory;
 
+/**
+ * @property int $id
+ * @property string $appointment_id
+ * @property string $user_id
+ * @property int $rating
+ * @property string|null $comment
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class AppointmentFeedback extends Model
 {
     use HasFactory;
@@ -33,11 +43,17 @@ class AppointmentFeedback extends Model
         return AppointmentFeedbackFactory::new();
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -17,7 +17,18 @@ use TresPontosTech\Appointments\Database\Factories\AppointmentRecordFactory;
 use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 
 /**
+ * @property string $id
+ * @property string $appointment_id
+ * @property string|null $content
+ * @property string|null $internal_summary
+ * @property string|null $model_used
+ * @property int|null $input_tokens
+ * @property int|null $output_tokens
+ * @property Carbon|null $generation_started_at
  * @property Carbon|null $published_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
@@ -52,6 +63,9 @@ class AppointmentRecord extends Model
         return AppointmentRecordFactory::new();
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);

--- a/app-modules/billing/phpstan.ignore.neon
+++ b/app-modules/billing/phpstan.ignore.neon
@@ -1,2 +1,7 @@
 parameters:
     ignoreErrors:
+        # Cashier Checkout expõe ->url via __get mágico (encaminha para a Stripe Session).
+        - message: '#^Access to an undefined property Laravel\\Cashier\\Checkout::\$url\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Stripe/Subscription/StripeAdapter.php

--- a/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
+++ b/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
@@ -20,6 +20,7 @@ use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCreated;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionDefaulted;
 use TresPontosTech\Billing\Core\Models\BillingCustomer;
 use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Company\Models\Company;
 
 class HandleBarteWebhook
 {
@@ -117,7 +118,13 @@ class HandleBarteWebhook
 
         $billable = $modelClass::query()->findOrFail($billableId);
 
-        $owner = $billable instanceof User ? $billable : $billable->owner;
+        if ($billable instanceof User) {
+            $owner = $billable;
+        } elseif ($billable instanceof Company) {
+            $owner = $billable->owner;
+        } else {
+            return;
+        }
 
         Notification::make()
             ->title(__('billing::notifications.credit_order_created.title'))

--- a/app-modules/billing/src/Core/Models/BillingCustomer.php
+++ b/app-modules/billing/src/Core/Models/BillingCustomer.php
@@ -6,10 +6,21 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Billing\Database\Factories\BillingCustomerFactory;
 
+/**
+ * @property int $id
+ * @property string $billable_type
+ * @property string $billable_id
+ * @property BillingProviderEnum $provider
+ * @property string $provider_customer_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class BillingCustomer extends Model
 {
     use HasFactory;

--- a/app-modules/billing/src/Core/Models/CompanyPlan.php
+++ b/app-modules/billing/src/Core/Models/CompanyPlan.php
@@ -7,12 +7,24 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\CompanyPlanStatusEnum;
 use TresPontosTech\Billing\Database\Factories\CompanyPlanFactory;
 use TresPontosTech\Company\Models\Company;
 
 /**
+ * @property string $id
+ * @property string $company_id
+ * @property int $plan_id
+ * @property int $seats
  * @property int $monthly_appointments_per_employee
+ * @property CompanyPlanStatusEnum $status
+ * @property Carbon|null $starts_at
+ * @property Carbon|null $ends_at
+ * @property string|null $notes
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 class CompanyPlan extends Model
 {
@@ -43,11 +55,17 @@ class CompanyPlan extends Model
         ];
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class, 'plan_id');

--- a/app-modules/billing/src/Core/Models/Plan.php
+++ b/app-modules/billing/src/Core/Models/Plan.php
@@ -6,10 +6,30 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Database\Factories\PlanFactory;
 
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property BillingProviderEnum $provider
+ * @property string|null $provider_product_id
+ * @property int|null $trial_days
+ * @property bool|null $has_generic_trial
+ * @property bool|null $allow_promotion_codes
+ * @property bool|null $collect_tax_ids
+ * @property bool $active
+ * @property string $slug
+ * @property BillableTypeEnum $type
+ * @property string|null $unit_label
+ * @property string|null $statement_descriptor
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class Plan extends Model
 {
     use HasFactory;
@@ -44,6 +64,9 @@ class Plan extends Model
         ];
     }
 
+    /**
+     * @return HasMany<Price, $this>
+     */
     public function prices(): HasMany
     {
         return $this->hasMany(Price::class, 'billing_plan_id');

--- a/app-modules/billing/src/Core/Models/Price.php
+++ b/app-modules/billing/src/Core/Models/Price.php
@@ -6,10 +6,26 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Billing\Database\Factories\PriceFactory;
 
 /**
+ * @property int $id
+ * @property int $billing_plan_id
+ * @property string $billing_scheme
+ * @property string $tiers_mode
+ * @property string $type
+ * @property int $unit_amount_decimal
+ * @property bool $active
+ * @property bool $default
+ * @property string $provider_price_id
+ * @property bool $whatsapp_enabled
+ * @property bool $materials_enabled
  * @property int $monthly_appointments
+ * @property array<array-key, mixed>|null $metadata
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  */
 class Price extends Model
 {
@@ -33,6 +49,9 @@ class Price extends Model
         'metadata',
     ];
 
+    /**
+     * @return BelongsTo<Plan, $this>
+     */
     public function plan(): BelongsTo
     {
         return $this->belongsTo(Plan::class, 'billing_plan_id');

--- a/app-modules/billing/src/Core/Models/Subscriptions/Subscription.php
+++ b/app-modules/billing/src/Core/Models/Subscriptions/Subscription.php
@@ -6,10 +6,24 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
 use Laravel\Cashier\Subscription as BaseSubscriptionModel;
 use TresPontosTech\Billing\Core\Models\Plan;
 use TresPontosTech\Billing\Core\Models\Price;
 
+/**
+ * @property string $subscriptionable_type
+ * @property string $subscriptionable_id
+ * @property string $type
+ * @property string $stripe_id
+ * @property string $stripe_status
+ * @property string|null $stripe_price
+ * @property int|null $quantity
+ * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $ends_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class Subscription extends BaseSubscriptionModel
 {
     protected $table = 'billing_subscriptions';

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -12,12 +12,25 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Database\Factories\UserCreditFactory;
 use TresPontosTech\Company\Models\Company;
 
+/**
+ * @property string $id
+ * @property string $owner_id
+ * @property string $holder_id
+ * @property string $company_id
+ * @property UserCreditStatusEnum $status
+ * @property string|null $appointment_id
+ * @property Carbon|null $transferred_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class UserCredit extends Model
 {
     use HasFactory;
@@ -41,21 +54,33 @@ class UserCredit extends Model
         ];
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'owner_id');
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function holder(): BelongsTo
     {
         return $this->belongsTo(User::class, 'holder_id');
     }
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /**
+     * @return BelongsTo<Appointment, $this>
+     */
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);

--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -6,7 +6,7 @@ use App\Models\Users\User;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
-use Stripe\Collection;
+use Illuminate\Support\Collection;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Entities\PlanEntity;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
@@ -49,7 +49,6 @@ class RedirectUserIfNotSubscribed
 
         // TODO: Employee needs to pick a plan to continue
         // TODO: the plan is already settled up (by pila) so, let them continue
-
         /** @var Collection<string, PlanEntity> $availableEmployeesPlans */
         $availableEmployeesPlans = $this->planRepository->getPlansFor('user');
 

--- a/app-modules/company/src/Models/Company.php
+++ b/app-modules/company/src/Models/Company.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Laravel\Cashier\Billable;
 use Ramsey\Uuid\Uuid;
 use Spatie\Image\Enums\Fit;
@@ -33,11 +34,20 @@ use TresPontosTech\Tenant\Models\TenantMember;
 use TresPontosTech\Tenant\Policies\CompanyPolicy;
 
 /**
+ * @property string $id
  * @property string $user_id
- * @property string $panel
+ * @property string $name
+ * @property string $integration_access_key
  * @property string $slug
  * @property string $tax_id
- * @property string $integration_access_key
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property string|null $stripe_id
+ * @property string|null $pm_type
+ * @property string|null $pm_last_four
+ * @property Carbon|null $trial_ends_at
+ * @property string $panel
  */
 #[UsePolicy(CompanyPolicy::class)]
 class Company extends Model implements HasAvatar, HasMedia
@@ -76,21 +86,33 @@ class Company extends Model implements HasAvatar, HasMedia
             ->first();
     }
 
+    /**
+     * @return HasMany<Appointment, $this>
+     */
     public function appointments(): HasMany
     {
         return $this->hasMany(Appointment::class);
     }
 
+    /**
+     * @return HasManyThrough<AppointmentFeedback, Appointment, $this>
+     */
     public function feedbacks(): HasManyThrough
     {
         return $this->hasManyThrough(AppointmentFeedback::class, Appointment::class);
     }
 
+    /**
+     * @return HasMany<CompanyPlan, $this>
+     */
     public function companyPlans(): HasMany
     {
         return $this->hasMany(CompanyPlan::class);
     }
 
+    /**
+     * @return BelongsToMany<Plan, $this>
+     */
     public function plans(): BelongsToMany
     {
         return $this->belongsToMany(Plan::class, 'company_plans', 'company_id', 'plan_id')
@@ -99,11 +121,17 @@ class Company extends Model implements HasAvatar, HasMedia
             ->wherePivotNull('deleted_at');
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function owner(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    /**
+     * @return BelongsToMany<User, $this, TenantMember>
+     */
     public function employees(): BelongsToMany
     {
         return $this->belongsToMany(User::class, 'company_employees', 'company_id', 'user_id')
@@ -112,6 +140,9 @@ class Company extends Model implements HasAvatar, HasMedia
             ->using(TenantMember::class);
     }
 
+    /**
+     * @return HasMany<Department, $this>
+     */
     public function departments(): HasMany
     {
         return $this->hasMany(Department::class);
@@ -128,6 +159,9 @@ class Company extends Model implements HasAvatar, HasMedia
         return CompanyFactory::new();
     }
 
+    /**
+     * @return MorphMany<Subscription, $this>
+     */
     public function subscriptions(): MorphMany
     {
         return $this->morphMany(Subscription::class, 'subscriptionable');
@@ -148,10 +182,10 @@ class Company extends Model implements HasAvatar, HasMedia
     {
         $this->addMediaConversion('company-logo-avatar')
             ->performOnCollections('company_logo')
+            ->nonQueued()
             ->width(32)
             ->height(32)
-            ->fit(Fit::Crop, 32, 32)
-            ->nonQueued();
+            ->fit(Fit::Crop, 32, 32);
 
     }
 

--- a/app-modules/company/src/Models/Department.php
+++ b/app-modules/company/src/Models/Department.php
@@ -9,10 +9,21 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Company\Database\Factories\DepartmentFactory;
 use TresPontosTech\Company\Enums\DepartmentCategory;
 
-/** @use HasFactory<DepartmentFactory> */
+/**
+ * @use HasFactory<DepartmentFactory>
+ *
+ * @property string $id
+ * @property string $company_id
+ * @property DepartmentCategory $category
+ * @property string $name
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
 class Department extends Model
 {
     use HasFactory;
@@ -29,6 +40,9 @@ class Department extends Model
         'category' => DepartmentCategory::class,
     ];
 
+    /**
+     * @return BelongsTo<Company, $this>
+     */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);

--- a/app-modules/consultants/phpstan.ignore.neon
+++ b/app-modules/consultants/phpstan.ignore.neon
@@ -1,2 +1,7 @@
 parameters:
     ignoreErrors:
+        # $media->model é tipado como Model base pela medialibrary; para mídia de Document acessa ->documentable.
+        - message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model::\$documentable\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Support/DocumentPathGenerator.php

--- a/app-modules/consultants/src/Models/Consultant.php
+++ b/app-modules/consultants/src/Models/Consultant.php
@@ -4,7 +4,6 @@ namespace TresPontosTech\Consultants\Models;
 
 use App\Enums\AvailableTagsEnum;
 use App\Models\Users\User;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -16,9 +15,11 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Tags\HasTags;
+use Spatie\Tags\Tag;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
 use TresPontosTech\Consultants\Observers\ConsultantObserver;
@@ -26,16 +27,23 @@ use TresPontosTech\Consultants\Policies\ConsultantPolicy;
 use Zap\Models\Concerns\HasSchedules;
 
 /**
+ * @property string $id
+ * @property string|null $user_id
+ * @property string|null $crm_id
  * @property string $name
+ * @property string $slug
  * @property string $phone
  * @property string $email
  * @property string $short_description
  * @property string $biography
  * @property string $readme
  * @property array $socials_urls
- * @property string|null $crm_id
  * @property Carbon|null $google_calendar_synced_at
  * @property string|null $google_calendar_sync_token
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read int|null $completed_count
  * @property-read User|null $user
  */
 #[ObservedBy(ConsultantObserver::class)]
@@ -77,6 +85,9 @@ class Consultant extends Model implements HasMedia
         return $this->belongsTo(User::class);
     }
 
+    /**
+     * @return MorphMany<Document, $this>
+     */
     public function documents(): MorphMany
     {
         return $this->morphMany(Document::class, 'documentable');
@@ -90,6 +101,9 @@ class Consultant extends Model implements HasMedia
         return $this->hasMany(Appointment::class);
     }
 
+    /**
+     * @return HasManyThrough<User, Appointment, $this>
+     */
     public function clients(): HasManyThrough
     {
         return $this->hasManyThrough(User::class, Appointment::class, 'consultant_id', 'id', 'id', 'user_id');
@@ -103,24 +117,36 @@ class Consultant extends Model implements HasMedia
         return $this->hasManyThrough(AppointmentFeedback::class, Appointment::class);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function languages(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Language->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function degrees(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Education->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function expertises(): MorphToMany
     {
         return $this->tags()
             ->where('type', AvailableTagsEnum::Expertise->value);
     }
 
+    /**
+     * @return MorphToMany<Tag, $this>
+     */
     public function specializations(): MorphToMany
     {
         return $this->tags()

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -2,6 +2,7 @@
 
 namespace TresPontosTech\Consultants\Models;
 
+use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -9,14 +10,24 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
 /**
+ * @property string $id
+ * @property string|null $documentable_type
+ * @property string|null $documentable_id
+ * @property string $title
  * @property DocumentExtensionTypeEnum|null $type
+ * @property bool $active
  * @property string|null $link
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property-read Consultant|User|null $documentable
  */
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
@@ -43,6 +54,9 @@ class Document extends Model implements HasMedia
         ];
     }
 
+    /**
+     * @return MorphTo<Model, $this>
+     */
     public function documentable(): MorphTo
     {
         return $this->morphTo();

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -6,9 +6,16 @@ use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
 /**
+ * @property int $id
+ * @property string $document_id
+ * @property string $consultant_id
+ * @property string $employee_id
  * @property bool $active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class DocumentShare extends Model
 {
@@ -45,16 +52,25 @@ class DocumentShare extends Model
         $this->update(['active' => false]);
     }
 
+    /**
+     * @return BelongsTo<Consultant, $this>
+     */
     public function consultant(): BelongsTo
     {
         return $this->belongsTo(Consultant::class)->withTrashed();
     }
 
+    /**
+     * @return BelongsTo<Document, $this>
+     */
     public function document(): BelongsTo
     {
         return $this->belongsTo(Document::class);
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function employee(): BelongsTo
     {
         return $this->belongsTo(User::class, 'employee_id');

--- a/app-modules/panel-admin/phpstan.ignore.neon
+++ b/app-modules/panel-admin/phpstan.ignore.neon
@@ -1,2 +1,12 @@
 parameters:
     ignoreErrors:
+        # Cast do pacote Zap declara array|FrequencyConfig; ->days existe em FrequencyConfig.
+        - message: '#^Cannot access property \$days on array\|Zap\\Data\\FrequencyConfig\.$#'
+          identifier: property.nonObject
+          count: 2
+          path: src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
+        # Coluna agregada dinâmica (COUNT(...) as total) selecionada sobre Department.
+        - message: '#^Access to an undefined property TresPontosTech\\Company\\Models\\Department::\$total\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php

--- a/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-admin/src/Filament/Pages/EditUserProfile.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Pages;
 use App\Filament\Shared\Fields\DocumentIdInput;
 use App\Filament\Shared\Fields\TaxIdInput;
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Schemas\Components\Component;
 
 class EditUserProfile extends BaseEditUserProfile
@@ -14,6 +15,9 @@ class EditUserProfile extends BaseEditUserProfile
      */
     protected function getExtraDetailFormComponents(): array
     {
+        /** @var User $user */
+        $user = $this->getUser();
+
         return [
             TaxIdInput::make()
                 ->label(__('panel-admin::resources.pages.edit_profile.cpf')),
@@ -24,7 +28,7 @@ class EditUserProfile extends BaseEditUserProfile
                 ->unique(
                     table: 'user_details',
                     column: 'document_id',
-                    ignorable: $this->getUser()->detail,
+                    ignorable: $user->detail,
                     ignoreRecord: false
                 ),
         ];

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
@@ -28,6 +28,9 @@ use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Consultants\Models\Document;
 use TresPontosTech\IntegrationGoogleCalendar\Jobs\CreateAppointmentCalendarEventJob;
 
+/**
+ * @property-read Appointment $record
+ */
 class ViewAppointment extends ViewRecord
 {
     protected static string $resource = AppointmentResource::class;
@@ -148,7 +151,7 @@ class ViewAppointment extends ViewRecord
 
     public function getEmployeeDocuments(): Collection
     {
-        $record = $this->getRecord();
+        $record = $this->record;
 
         return Document::query()
             ->whereMorphedTo('documentable', $record->user)
@@ -157,7 +160,7 @@ class ViewAppointment extends ViewRecord
 
     public function getSharedDocuments(): Collection
     {
-        $record = $this->getRecord();
+        $record = $this->record;
 
         return Document::query()
             ->whereHas('shares', function ($query) use ($record): void {
@@ -205,7 +208,7 @@ class ViewAppointment extends ViewRecord
         }
 
         $document = Document::query()
-            ->whereMorphedTo('documentable', $this->getRecord()->user)
+            ->whereMorphedTo('documentable', $this->record->user)
             ->find($documentId);
 
         return $document?->getFirstMedia('documents');
@@ -217,7 +220,7 @@ class ViewAppointment extends ViewRecord
             return null;
         }
 
-        $appointment = $this->getRecord();
+        $appointment = $this->record;
 
         $document = Document::query()
             ->whereHas('shares', function ($query) use ($appointment): void {

--- a/app-modules/panel-admin/src/Filament/Resources/Companies/Pages/CreateCompany.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Companies/Pages/CreateCompany.php
@@ -6,8 +6,12 @@ use App\Models\Users\User;
 use Filament\Resources\Pages\CreateRecord;
 use Ramsey\Uuid\Uuid;
 use TresPontosTech\Admin\Filament\Resources\Companies\CompanyResource;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Permissions\Roles;
 
+/**
+ * @property-read Company $record
+ */
 class CreateCompany extends CreateRecord
 {
     protected static string $resource = CompanyResource::class;

--- a/app-modules/panel-admin/src/Filament/Resources/Consultants/Schemas/ConsultantForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Consultants/Schemas/ConsultantForm.php
@@ -44,7 +44,7 @@ class ConsultantForm
                                         })
                                         ->required(),
                                     TextInput::make('slug')
-                                        ->formatStateUsing(fn ($get) => str($get('name'))->slug),
+                                        ->formatStateUsing(fn ($get) => str($get('name'))->slug()),
                                     PhoneInput::make('phone')
                                         ->defaultCountry('BR')
                                         ->initialCountry('BR')

--- a/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Prices/PriceResource.php
@@ -236,6 +236,9 @@ class PriceResource extends Resource
         return ['plan.name'];
     }
 
+    /**
+     * @param  Price  $record
+     */
     public static function getGlobalSearchResultDetails(Model $record): array
     {
         $details = [];

--- a/app-modules/panel-admin/src/Models/ImpersonationLog.php
+++ b/app-modules/panel-admin/src/Models/ImpersonationLog.php
@@ -7,7 +7,18 @@ namespace TresPontosTech\Admin\Models;
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $admin_id
+ * @property string $impersonated_user_id
+ * @property string|null $ip_address
+ * @property Carbon $started_at
+ * @property Carbon|null $ended_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class ImpersonationLog extends Model
 {
     protected $fillable = [

--- a/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
+++ b/app-modules/panel-app/src/Filament/Pages/EditUserProfile.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TresPontosTech\App\Filament\Pages;
 
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Schemas\Components\Tabs;
@@ -95,7 +96,9 @@ class EditUserProfile extends BaseEditUserProfile
     {
         $data = parent::mutateFormDataBeforeFill($data);
 
-        $anamnese = $this->getUser()->anamnese;
+        /** @var User $user */
+        $user = $this->getUser();
+        $anamnese = $user->anamnese;
 
         $data['life_moment'] = $anamnese?->getRawOriginal('life_moment');
         $data['main_motivation'] = $anamnese?->main_motivation;

--- a/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserSubscriptionPage.php
@@ -10,6 +10,7 @@ use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
 use TresPontosTech\Billing\Core\Entities\PriceEntity;
 use TresPontosTech\Billing\Core\Repositories\PlanRepository;
+use TresPontosTech\Company\Models\Company;
 
 class UserSubscriptionPage extends Page
 {
@@ -33,7 +34,9 @@ class UserSubscriptionPage extends Page
 
     protected function getViewData(): array
     {
-        $isFlamma = filament()->getTenant()?->slug === 'flamma-company';
+        /** @var Company|null $tenant */
+        $tenant = filament()->getTenant();
+        $isFlamma = $tenant?->slug === 'flamma-company';
         $plans = resolve(PlanRepository::class)->getCheckoutPlansFor('user');
 
         if ($isFlamma) {
@@ -116,7 +119,9 @@ class UserSubscriptionPage extends Page
     /** @param PriceEntity[] $prices */
     private function resolvePriceForTenant(array $prices): PriceEntity
     {
-        $isFlamma = filament()->getTenant()?->slug === 'flamma-company';
+        /** @var Company|null $tenant */
+        $tenant = filament()->getTenant();
+        $isFlamma = $tenant?->slug === 'flamma-company';
         $prices = collect($prices);
 
         if ($isFlamma) {

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
@@ -52,12 +52,12 @@ class SharedDocumentResource extends Resource
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {
-        return parent::getGlobalSearchEloquentQuery()->with(['consultant']);
+        return parent::getGlobalSearchEloquentQuery()->with(['documentable']);
     }
 
     public static function getGloballySearchableAttributes(): array
     {
-        return ['title', 'consultant.name'];
+        return ['title', 'documentable.name'];
     }
 
     /**
@@ -67,8 +67,8 @@ class SharedDocumentResource extends Resource
     {
         $details = [];
 
-        if ($record->consultant) {
-            $details['Consultant'] = $record->consultant->name;
+        if ($record->documentable) {
+            $details['Consultant'] = $record->documentable->name;
         }
 
         return $details;

--- a/app-modules/panel-app/src/Http/Middleware/RedirectIfAnamneseNotCompleted.php
+++ b/app-modules/panel-app/src/Http/Middleware/RedirectIfAnamneseNotCompleted.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use TresPontosTech\Company\Models\Company;
 
 class RedirectIfAnamneseNotCompleted
 {
@@ -22,6 +23,7 @@ class RedirectIfAnamneseNotCompleted
         }
 
         $user = auth()->user();
+        /** @var Company|null $tenant */
         $tenant = filament()->getTenant();
 
         if ($user === null || $user->anamnese !== null) {

--- a/app-modules/panel-company/phpstan.ignore.neon
+++ b/app-modules/panel-company/phpstan.ignore.neon
@@ -1,2 +1,21 @@
 parameters:
     ignoreErrors:
+        # role/active são colunas de company_employees trazidas no select do join (users.* + company_employees.*).
+        - message: '#^Access to an undefined property App\\Models\\Users\\User::\$active\.$#'
+          identifier: property.notFound
+          count: 2
+          path: src/Filament/Pages/Tenancy/EditTenantProfile.php
+        - message: '#^Access to an undefined property App\\Models\\Users\\User::\$role\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Filament/Pages/Tenancy/EditTenantProfile.php
+        # Coluna agregada dinâmica (COUNT(...) as total) selecionada sobre Department.
+        - message: '#^Access to an undefined property TresPontosTech\\Company\\Models\\Department::\$total\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Actions/Metrics/GetDepartmentVolume.php
+        # Coluna agregada dinâmica (count(*) as sessions) selecionada sobre Appointment.
+        - message: '#^Access to an undefined property TresPontosTech\\Appointments\\Models\\Appointment::\$sessions\.$#'
+          identifier: property.notFound
+          count: 1
+          path: src/Actions/Metrics/GetTopConsultants.php

--- a/app-modules/panel-company/src/Actions/Metrics/GetEngagement.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetEngagement.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace TresPontosTech\PanelCompany\Actions\Metrics;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Actions\Metrics\Concerns\BuildsMetricsCacheKey;
 use TresPontosTech\PanelCompany\DTOs\EngagementData;
@@ -35,24 +37,30 @@ final class GetEngagement
             $totalEmployees = (clone $employeesQuery)->count();
 
             $activeUsers = (clone $employeesQuery)
-                ->whereHas('appointments', fn ($q) => $q
-                    ->forCompany($tenant)
-                    ->betweenDates($period->start, $period->end)
-                    ->forUsers($userIds))
+                ->whereHas('appointments', function (Builder $q) use ($tenant, $period, $userIds): void {
+                    /** @var Builder<Appointment> $q */
+                    $q->forCompany($tenant)
+                        ->betweenDates($period->start, $period->end)
+                        ->forUsers($userIds);
+                })
                 ->count();
 
             $inactiveUsers = $totalEmployees - $activeUsers;
             $utilizationRate = $totalEmployees > 0 ? round($activeUsers / $totalEmployees * 100, 1) : 0.0;
 
             $firstTimeUsers = (clone $employeesQuery)
-                ->whereHas('appointments', fn ($q) => $q
-                    ->forCompany($tenant)
-                    ->betweenDates($period->start, $period->end)
-                    ->forUsers($userIds))
-                ->whereDoesntHave('appointments', fn ($q) => $q
-                    ->forCompany($tenant)
-                    ->forUsers($userIds)
-                    ->where('appointment_at', '<', $period->start))
+                ->whereHas('appointments', function (Builder $q) use ($tenant, $period, $userIds): void {
+                    /** @var Builder<Appointment> $q */
+                    $q->forCompany($tenant)
+                        ->betweenDates($period->start, $period->end)
+                        ->forUsers($userIds);
+                })
+                ->whereDoesntHave('appointments', function (Builder $q) use ($tenant, $period, $userIds): void {
+                    /** @var Builder<Appointment> $q */
+                    $q->forCompany($tenant)
+                        ->forUsers($userIds)
+                        ->where('appointment_at', '<', $period->start);
+                })
                 ->count();
 
             return new EngagementData($totalEmployees, $activeUsers, $inactiveUsers, $utilizationRate, $firstTimeUsers);

--- a/app-modules/panel-company/src/Actions/Metrics/GetInsights.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetInsights.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TresPontosTech\PanelCompany\Actions\Metrics;
 
 use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use TresPontosTech\Appointments\Models\Appointment;
@@ -38,9 +39,10 @@ final class GetInsights
 
             $totalEmployees = (clone $employeesQuery)->count();
             $everUsed = (clone $employeesQuery)
-                ->whereHas('appointments', fn ($q) => $q
-                    ->forCompany($tenant)
-                    ->forUsers($userIds))
+                ->whereHas('appointments', function (Builder $q) use ($tenant, $userIds): void {
+                    /** @var Builder<Appointment> $q */
+                    $q->forCompany($tenant)->forUsers($userIds);
+                })
                 ->count();
 
             $neverUsedCount = max(0, $totalEmployees - $everUsed);

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -11,8 +11,8 @@ use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
-use Laravel\Cashier\Subscription;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Rules\UniqueAtCompany;
 use TresPontosTech\Permissions\Roles;
@@ -54,7 +54,9 @@ class CreateAndAttachAction extends CreateAction
 
         $this->after(
             function (User $record): void {
-                filament()->getTenant()->employees()->syncWithoutDetaching($record);
+                /** @var Company $tenant */
+                $tenant = filament()->getTenant();
+                $tenant->employees()->syncWithoutDetaching($record);
                 $record->assignRole(Roles::Employee);
                 event(new UserRegistered($record, Roles::Employee, $this->plainPassword));
             }

--- a/app-modules/panel-company/src/Filament/Actions/TenantSeatsCounterAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/TenantSeatsCounterAction.php
@@ -3,8 +3,8 @@
 namespace TresPontosTech\PanelCompany\Filament\Actions;
 
 use Filament\Actions\Action;
-use Laravel\Cashier\Subscription;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
+use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Company\Models\Company;
 
 class TenantSeatsCounterAction extends Action

--- a/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
+++ b/app-modules/panel-company/src/Filament/Pages/CompanyCreditPage.php
@@ -25,6 +25,7 @@ use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Jobs\DistributeCreditsEquallyJob;
 use TresPontosTech\Billing\Core\Jobs\RevokeCreditsFromEmployeesJob;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
 use TresPontosTech\PanelCompany\Filament\Widgets\CompanyCreditStatsWidget;
 
@@ -73,6 +74,7 @@ class CompanyCreditPage extends Page implements HasTable
 
     public function table(Table $table): Table
     {
+        /** @var Company $tenant */
         $tenant = filament()->getTenant();
         $records = UserCredit::query()
             ->where('company_id', $tenant->getKey())
@@ -202,6 +204,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function ownerAvailableCreditsCount(): int
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         return UserCredit::query()
@@ -220,6 +223,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function hasDistributedCredits(): bool
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         return UserCredit::query()
@@ -232,6 +236,7 @@ class CompanyCreditPage extends Page implements HasTable
     #[Computed]
     public function canDistributeEqually(): bool
     {
+        /** @var Company $company */
         $company = filament()->getTenant();
 
         $availableCredits = UserCredit::query()
@@ -248,7 +253,10 @@ class CompanyCreditPage extends Page implements HasTable
     /** @return array<string, string> */
     private function getActiveEmployeeOptions(): array
     {
-        return filament()->getTenant()
+        /** @var Company $tenant */
+        $tenant = filament()->getTenant();
+
+        return $tenant
             ->onlyEmployees()
             ->get()
             ->pluck('name', 'id')

--- a/app-modules/panel-company/src/Filament/Pages/Metrics.php
+++ b/app-modules/panel-company/src/Filament/Pages/Metrics.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\Support\Htmlable;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Widgets\CommandDashboard\AdoptionFunnelWidget;
 use TresPontosTech\PanelCompany\Filament\Widgets\CommandDashboard\CategoryMixWidget;
 use TresPontosTech\PanelCompany\Filament\Widgets\CommandDashboard\DepartmentAdoptionWidget;
@@ -68,23 +69,29 @@ class Metrics extends BaseDashboard
                     Select::make('userId')
                         ->label(__('panel-company::resources.pages.metrics.filter_user'))
                         ->placeholder(__('panel-company::resources.pages.metrics.filter_user_placeholder'))
-                        ->options(fn (): array => Filament::getTenant()
-                            ->employees()
-                            ->orderBy('users.name')
-                            ->pluck('users.name', 'users.id')
-                            ->toArray()
-                        )
+                        ->options(function (): array {
+                            /** @var Company $tenant */
+                            $tenant = Filament::getTenant();
+
+                            return $tenant->employees()
+                                ->orderBy('users.name')
+                                ->pluck('users.name', 'users.id')
+                                ->toArray();
+                        })
                         ->searchable()
                         ->native(false),
                     Select::make('departmentId')
                         ->label(__('panel-company::resources.pages.metrics.filter_department'))
                         ->placeholder(__('panel-company::resources.pages.metrics.filter_department_placeholder'))
-                        ->options(fn (): array => Filament::getTenant()
-                            ->departments()
-                            ->orderBy('name')
-                            ->pluck('name', 'id')
-                            ->toArray()
-                        )
+                        ->options(function (): array {
+                            /** @var Company $tenant */
+                            $tenant = Filament::getTenant();
+
+                            return $tenant->departments()
+                                ->orderBy('name')
+                                ->pluck('name', 'id')
+                                ->toArray();
+                        })
                         ->searchable()
                         ->native(false),
                 ]),

--- a/app-modules/panel-company/src/Filament/Pages/Tenancy/EditTenantProfile.php
+++ b/app-modules/panel-company/src/Filament/Pages/Tenancy/EditTenantProfile.php
@@ -90,9 +90,12 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
 
     public function table(Table $table): Table
     {
+        /** @var Company $tenant */
+        $tenant = filament()->getTenant();
+
         return $table
             ->query(
-                filament()->getTenant()
+                $tenant
                     ->employees()
                     ->getQuery()
                     ->select([
@@ -181,17 +184,23 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
                     ->schema([
                         Select::make('department_id')
                             ->label(__('panel-company::resources.pages.edit_tenant.department'))
-                            ->options(fn (): array => filament()->getTenant()
-                                ->departments()
-                                ->orderBy('name')
-                                ->pluck('name', 'id')
-                                ->toArray()
-                            )
+                            ->options(function (): array {
+                                /** @var Company $tenant */
+                                $tenant = filament()->getTenant();
+
+                                return $tenant
+                                    ->departments()
+                                    ->orderBy('name')
+                                    ->pluck('name', 'id')
+                                    ->toArray();
+                            })
                             ->nullable()
                             ->native(false),
                     ])
                     ->action(function (User $record, array $data): void {
-                        filament()->getTenant()->employees()->updateExistingPivot($record, [
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        $tenant->employees()->updateExistingPivot($record, [
                             'department_id' => $data['department_id'],
                         ]);
 
@@ -207,7 +216,11 @@ class EditTenantProfile extends BaseEditTenantProfile implements HasTable
 
                         return $record->getKey() !== $company->user_id;
                     })
-                    ->action(fn ($record) => filament()->getTenant()->employees()->detach($record)),
+                    ->action(function ($record): void {
+                        /** @var Company $tenant */
+                        $tenant = filament()->getTenant();
+                        $tenant->employees()->detach($record);
+                    }),
             ])
             ->columns([
                 TextColumn::make('active')

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Concerns\HasMetricsDateRange;
 
 class CreditUsageTableWidget extends TableWidget
@@ -68,7 +69,9 @@ class CreditUsageTableWidget extends TableWidget
     {
         $period = $this->metricsPeriod();
 
-        $tenantId = Filament::getTenant()->id;
+        /** @var Company $tenant */
+        $tenant = Filament::getTenant();
+        $tenantId = $tenant->id;
         $userIds = $this->filteredUserIds();
 
         return UserCredit::query()

--- a/app-modules/panel-consultant/src/Filament/Pages/EditConsultantProfile.php
+++ b/app-modules/panel-consultant/src/Filament/Pages/EditConsultantProfile.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Consultants\Filament\Pages;
 use App\Filament\Shared\Fields\DocumentIdInput;
 use App\Filament\Shared\Fields\TaxIdInput;
 use App\Filament\Shared\Pages\EditUserProfile as BaseEditUserProfile;
+use App\Models\Users\User;
 use Filament\Schemas\Components\Component;
 
 class EditConsultantProfile extends BaseEditUserProfile
@@ -14,6 +15,9 @@ class EditConsultantProfile extends BaseEditUserProfile
      */
     protected function getExtraDetailFormComponents(): array
     {
+        /** @var User $user */
+        $user = $this->getUser();
+
         return [
             TaxIdInput::make()
                 ->label(__('panel-admin::resources.pages.edit_profile.cpf')),
@@ -24,7 +28,7 @@ class EditConsultantProfile extends BaseEditUserProfile
                 ->unique(
                     table: 'user_details',
                     column: 'document_id',
-                    ignorable: $this->getUser()->detail,
+                    ignorable: $user->detail,
                     ignoreRecord: false
                 ),
         ];

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/CreateDocument.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/CreateDocument.php
@@ -7,7 +7,11 @@ namespace TresPontosTech\Consultants\Filament\Resources\Documents\Pages;
 use Filament\Resources\Pages\CreateRecord;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Filament\Resources\Documents\DocumentResource;
+use TresPontosTech\Consultants\Models\Document;
 
+/**
+ * @property-read Document $record
+ */
 class CreateDocument extends CreateRecord
 {
     protected static string $resource = DocumentResource::class;

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/EditDocument.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/Pages/EditDocument.php
@@ -10,7 +10,11 @@ use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\EditRecord;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Filament\Resources\Documents\DocumentResource;
+use TresPontosTech\Consultants\Models\Document;
 
+/**
+ * @property-read Document $record
+ */
 class EditDocument extends EditRecord
 {
     protected static string $resource = DocumentResource::class;

--- a/app-modules/tenant/src/Models/TenantMember.php
+++ b/app-modules/tenant/src/Models/TenantMember.php
@@ -7,10 +7,21 @@ namespace TresPontosTech\Tenant\Models;
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\Company\Models\Department;
 use TresPontosTech\Permissions\Roles;
 
+/**
+ * @property string $user_id
+ * @property string $company_id
+ * @property string|null $department_id
+ * @property Roles|null $role
+ * @property bool $active
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 class TenantMember extends Pivot
 {
     public $timestamps = true;
@@ -26,16 +37,19 @@ class TenantMember extends Pivot
         'active' => 'boolean',
     ];
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
 
+    /** @return BelongsTo<Company, $this> */
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
     }
 
+    /** @return BelongsTo<Department, $this> */
     public function department(): BelongsTo
     {
         return $this->belongsTo(Department::class);

--- a/app-modules/user/src/Models/UserAnamnese.php
+++ b/app-modules/user/src/Models/UserAnamnese.php
@@ -46,6 +46,7 @@ class UserAnamnese extends Model
         ];
     }
 
+    /** @return BelongsTo<User, $this> */
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);

--- a/app/Models/Users/Detail.php
+++ b/app/Models/Users/Detail.php
@@ -9,7 +9,21 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property int $id
+ * @property string $user_id
+ * @property string $company_id
+ * @property string|null $phone_number
+ * @property string|null $integration_id
+ * @property string $document_id
+ * @property string $tax_id
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read User $user
+ */
 #[UsePolicy(DetailPolicy::class)]
 class Detail extends Model
 {

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -28,6 +28,7 @@ use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Cashier\Billable;
 use Spatie\Image\Enums\Fit;
@@ -52,6 +53,21 @@ use TresPontosTech\Tenant\Models\Traits\HasTenant;
 use TresPontosTech\User\Models\UserAnamnese;
 
 /**
+ * @property string $id
+ * @property string $name
+ * @property string $email
+ * @property Carbon|null $email_verified_at
+ * @property string $password
+ * @property string|null $crm_id
+ * @property string|null $external_id
+ * @property string|null $stripe_id
+ * @property string|null $pm_type
+ * @property string|null $pm_last_four
+ * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ * @property string|null $remember_token
  * @property-read int $monthly_appointments_left
  */
 #[UsePolicy(UserPolicy::class)]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 1
+    level: 2
 
     paths:
         - app


### PR DESCRIPTION
## Contexto

Segundo passo da subida incremental do PHPStan modular: **level 1 → level 2** (o #208 deixou o `develop` no level 1).

No level 2 o PHPStan passou a exigir que todo acesso a propriedade/método seja conhecido em tempo de análise. Surgiram **178 erros** em 71 arquivos, concentrados em:

| Identificador | Qtd | Causa |
|---|---|---|
| `property.notFound` | 124 | models sem `@property`; variáveis no tipo base `Model` |
| `method.notFound` | 23 | relações/scopes chamados sobre `Model` base |
| `method.nonObject` / `property.nonObject` | 28 | casts (Carbon/enum) não reconhecidos por falta de `@property` |
| generics/varTag | 3 | `@var` desatualizado |

## O que foi feito

Nenhuma mudança altera comportamento — são anotações de tipo, narrowing e ignores pontuais.

### Models — `@property` + `@return` nas relações
Blocos completos derivados de migrations + `casts()` e generics nas relações: `Appointment`, `AppointmentFeedback`, `AppointmentRecord`, `Plan`, `Price`, `Subscription`, `UserCredit`, `BillingCustomer`, `CompanyPlan`, `Company`, `Department`, `Consultant`, `Document`, `DocumentShare`, `User`, `Detail`, `TenantMember`, `ImpersonationLog`, `UserAnamnese`. Isso resolve a maioria dos erros, inclusive os `nonObject` (que vinham de casts `Carbon`/enum não tipados).

### Consumidores — narrowing por convenção do projeto
`/** @var User $user */` para `auth()->user()` e `/** @var Company $tenant */` para `Filament::getTenant()`/`$record`, onde o framework devolve o tipo base.

### Métricas (#207) — código novo não coberto pela tipagem anterior
- `@var Builder<Appointment>` nas closures de `whereHas`/`whereDoesntHave` em `GetEngagement`/`GetInsights`: o Larastan não infere o tipo da relação quando o `whereHas` é encadeado sobre o proxy `BelongsToMany`. As chamadas estáticas `Appointment::forCompany(...)` no mesmo arquivo já resolvem normalmente.
- Ignores **scoped + comentados** para aliases de agregação (`Department::$total`, `Appointment::$sessions`), seguindo o padrão já existente do `panel-admin` — anotar no model seria semanticamente incorreto.

### Ignores por módulo (falsos-positivos reais)
`Cashier\Checkout::$url` e `Subscription::$quantity` (via `__get` mágico), colunas trazidas no join `company_employees`, e `Zap\Data\FrequencyConfig::$days`.

## Compatibilidade com o #207

Esta branch saiu do `develop` já com o #207 mergeado. A nova página de Métricas (widgets, trait `HasMetricsDateRange`, actions `Get*`) está totalmente tipada e coberta pelos testes.

## Verificação

- ✅ `vendor/bin/phpstan analyse` — **level 2, 0 erros**
- ✅ Pint — sem ajustes · Rector dry-run — 0 mudanças
- ✅ Suíte completa: **955 passed, 2 skipped, 0 falhas** (idêntico ao baseline do develop)

## Próximo passo

Level 3 em PR seguinte.