### PR TITLE
ci(phpstan): sobe análise estática modular para o level 3

### DIFF
--- a/app-modules/appointments/src/Support/DocumentTextExtractor.php
+++ b/app-modules/appointments/src/Support/DocumentTextExtractor.php
@@ -89,7 +89,7 @@ readonly class DocumentTextExtractor
     {
         foreach ($container->getElements() as $element) {
             if ($element instanceof Text) {
-                $lines[] = $element->getText();
+                $lines[] = $element->getText() ?? '';
 
                 continue;
             }

--- a/app-modules/panel-app/phpstan.ignore.neon
+++ b/app-modules/panel-app/phpstan.ignore.neon
@@ -1,2 +1,21 @@
 parameters:
     ignoreErrors:
+        # 'full' é valor responsivo válido no array de $columnSpan (Filament resolve 'full' => '1 / -1',
+        # e o próprio columnSpanFull() faz columnSpan(['default' => 'full'])), mas o PHPDoc do Widget
+        # tipa o array como array<string, int|null>, sem prever a string. Imprecisão do pacote.
+        - message: '#^Property TresPontosTech\\App\\Filament\\Widgets\\FinancialTopicsWidget::\$columnSpan \(array<string, int\|null>\|int\|string\) does not accept default value of type array<string, int\|string>\.$#'
+          identifier: property.defaultValue
+          count: 1
+          path: src/Filament/Widgets/FinancialTopicsWidget.php
+        - message: '#^Property TresPontosTech\\App\\Filament\\Widgets\\NextAppointmentWidget::\$columnSpan \(array<string, int\|null>\|int\|string\) does not accept default value of type array<string, int\|string>\.$#'
+          identifier: property.defaultValue
+          count: 1
+          path: src/Filament/Widgets/NextAppointmentWidget.php
+        - message: '#^Property TresPontosTech\\App\\Filament\\Widgets\\PlanCreditsWidget::\$columnSpan \(array<string, int\|null>\|int\|string\) does not accept default value of type array<string, int\|string>\.$#'
+          identifier: property.defaultValue
+          count: 1
+          path: src/Filament/Widgets/PlanCreditsWidget.php
+        - message: '#^Property TresPontosTech\\App\\Filament\\Widgets\\SharedMaterialsWidget::\$columnSpan \(array<string, int\|null>\|int\|string\) does not accept default value of type array<string, int\|string>\.$#'
+          identifier: property.defaultValue
+          count: 1
+          path: src/Filament/Widgets/SharedMaterialsWidget.php

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
@@ -48,7 +48,7 @@ class SharedDocumentResource extends Resource
     }
 
     /**
-     * @return Builder<Document>
+     * @return Builder<Model>
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {

--- a/app-modules/panel-consultant/src/Filament/Resources/Documents/DocumentResource.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Documents/DocumentResource.php
@@ -70,7 +70,7 @@ class DocumentResource extends Resource
     }
 
     /**
-     * @return Builder<Document>
+     * @return Builder<Model>
      */
     public static function getGlobalSearchEloquentQuery(): Builder
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 2
+    level: 3
 
     paths:
         - app


### PR DESCRIPTION
## Problema

Continuação da subida incremental do PHPStan modular (1 PR por nível): `develop` está no level 2 (#211). Este PR sobe para o **level 3**, que passa a verificar return types e null-safety de forma mais estrita.

## Solução

Sobe `level: 2 → 3` no `phpstan.neon` e resolve os erros **sem alterar comportamento**:

- **`DocumentTextExtractor`** — `PhpOffice\…\Text::getText()` é `?string`; ao montar o array de linhas, usa `?? ''` para cobrir o `null` (caminho feliz inalterado).
- **`SharedDocumentResource` / `DocumentResource` (busca global)** — alinha o docblock `@return Builder<Document>` → `Builder<Model>`. Os resources estendem `Resource` sem parametrizar o generic, então `TModel` resolve para `Model` e o método de fato devolve `Builder<Model>`. Mantém o `parent::getGlobalSearchEloquentQuery()` da [documentação oficial do Filament](https://filamentphp.com/docs/5.x/resources/global-search) — só o docblock muda.
- **`panel-app/phpstan.ignore.neon`** — ignores scoped+comentados para `$columnSpan = ['default' => 'full', 'md' => 3]` em 4 widgets. `'full'` é valor responsivo válido (o Filament resolve `'full' => '1 / -1'` e o próprio `columnSpanFull()` usa `columnSpan(['default' => 'full'])`), mas o PHPDoc do `Widget` tipa o array como `array<string, int|null>`, sem prever a string. Imprecisão do pacote — mesmo padrão dos ignores de Zap/Cashier já existentes.

## Arquivos Alterados

- `phpstan.neon` — level 2 → 3
- `app-modules/appointments/src/Support/DocumentTextExtractor.php` — null-safety
- `app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php` — docblock
- `app-modules/panel-consultant/src/Filament/Resources/Documents/DocumentResource.php` — docblock
- `app-modules/panel-app/phpstan.ignore.neon` — falso-positivo do `$columnSpan`

## Verificação

- PHPStan level 3: **0 erros**
- Pint `--dirty`: passou · Rector dry-run: 0 mudanças
- Suíte completa: **957 passed, 2 skipped, 0 falhas**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed text extraction to ensure consistent string handling when processing documents.

* **Chores**
  * Enhanced code quality through improved type-checking strictness and updated type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->