### PR TITLE
ci(phpstan): sobe análise estática modular para o level 6

### DIFF
--- a/app-modules/appointments/src/Actions/GetAvailableSlotsAction.php
+++ b/app-modules/appointments/src/Actions/GetAvailableSlotsAction.php
@@ -7,6 +7,9 @@ use TresPontosTech\Consultants\Models\Consultant;
 
 readonly class GetAvailableSlotsAction
 {
+    /**
+     * @return array<string, string>
+     */
     public function handle(Carbon $date, int $durationMinutes = 60, int $bufferMinutes = 0): array
     {
         $consultants = Consultant::all();

--- a/app-modules/appointments/src/DTO/BookAppointmentDTO.php
+++ b/app-modules/appointments/src/DTO/BookAppointmentDTO.php
@@ -16,6 +16,9 @@ class BookAppointmentDTO implements JsonSerializable
         public ?string $notes = null,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(int|string $userId, array $payload): self
     {
         return new self(

--- a/app-modules/appointments/src/Models/Appointment.php
+++ b/app-modules/appointments/src/Models/Appointment.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use TresPontosTech\Appointments\Actions\Transitions\AbstractAppointmentTransition;
+use TresPontosTech\Appointments\Database\Factories\AppointmentFactory;
 use TresPontosTech\Appointments\Enums\AppointmentCategoryEnum;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Enums\CancellationActor;
@@ -45,7 +46,9 @@ use TresPontosTech\Consultants\Models\Consultant;
  */
 class Appointment extends Model
 {
+    /** @use HasFactory<AppointmentFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 
@@ -132,23 +135,39 @@ class Appointment extends Model
         ];
     }
 
+    /**
+     * @return Attribute<AbstractAppointmentTransition, never>
+     */
     protected function currentTransition(): Attribute
     {
         return Attribute::make(get: fn (): AbstractAppointmentTransition => $this->status->transition($this));
     }
 
+    /**
+     * @param  Builder<Appointment>  $query
+     * @return Builder<Appointment>
+     */
     #[Scope]
     protected function forCompany(Builder $query, Company $company): Builder
     {
         return $query->where('company_id', $company->getKey());
     }
 
+    /**
+     * @param  Builder<Appointment>  $query
+     * @return Builder<Appointment>
+     */
     #[Scope]
     protected function betweenDates(Builder $query, CarbonInterface $start, CarbonInterface $end): Builder
     {
         return $query->whereBetween('appointment_at', [$start, $end]);
     }
 
+    /**
+     * @param  Builder<Appointment>  $query
+     * @param  Collection<int, string>|null  $userIds
+     * @return Builder<Appointment>
+     */
     #[Scope]
     protected function forUsers(Builder $query, ?Collection $userIds): Builder
     {

--- a/app-modules/appointments/src/Models/AppointmentFeedback.php
+++ b/app-modules/appointments/src/Models/AppointmentFeedback.php
@@ -20,6 +20,7 @@ use TresPontosTech\Appointments\Database\Factories\AppointmentFeedbackFactory;
  */
 class AppointmentFeedback extends Model
 {
+    /** @use HasFactory<AppointmentFeedbackFactory> */
     use HasFactory;
 
     protected $table = 'appointment_feedbacks';

--- a/app-modules/appointments/src/Models/AppointmentRecord.php
+++ b/app-modules/appointments/src/Models/AppointmentRecord.php
@@ -33,7 +33,9 @@ use TresPontosTech\Appointments\Policies\AppointmentRecordPolicy;
 #[UsePolicy(AppointmentRecordPolicy::class)]
 class AppointmentRecord extends Model
 {
+    /** @use HasFactory<AppointmentRecordFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 
@@ -86,6 +88,10 @@ class AppointmentRecord extends Model
         $this->update(['generation_started_at' => null]);
     }
 
+    /**
+     * @param  Builder<AppointmentRecord>  $query
+     * @return Builder<AppointmentRecord>
+     */
     #[Scope]
     protected function published(Builder $query): Builder
     {

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -149,6 +149,9 @@ final readonly class BarteAdapter implements BillingContract
 
     }
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(User|Company $billable, string $returnUrl, array $options = []): string
     {
         if ($billable instanceof Company) {

--- a/app-modules/billing/src/Barte/BarteClient.php
+++ b/app-modules/billing/src/Barte/BarteClient.php
@@ -19,6 +19,9 @@ final class BarteClient
             ->timeout(30);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getPlans(): array
     {
         $response = $this->http->get('/v2/plans');
@@ -33,6 +36,9 @@ final class BarteClient
         return $response->json();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function createBuyer(CreateBuyerDto $dto): array
     {
         $response = $this->http->post('/v2/buyers', $dto->toArray());
@@ -47,6 +53,9 @@ final class BarteClient
         return $response->json();
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function createPaymentLink(CreatePaymentLinkDto $dto): array
     {
         $response = $this->http->post('/v2/payment-links', $dto->toArray());

--- a/app-modules/billing/src/Barte/Commands/SyncBartePlans.php
+++ b/app-modules/billing/src/Barte/Commands/SyncBartePlans.php
@@ -18,23 +18,34 @@ class SyncBartePlans extends Command
     {
         $response = $client->getPlans();
 
-        $plans = collect($response['content'] ?? $response);
+        /** @var list<array<string, mixed>> $bartePlans */
+        $bartePlans = $response['content'] ?? $response;
+
+        $plans = collect($bartePlans);
 
         $this->table(
             ['UUID', 'Título', 'Ativo', 'Métodos', 'Valores'],
-            $plans->map(fn (array $p): array => [
-                $p['uuid'],
-                $p['title'],
-                $p['active'] ? 'sim' : 'não',
-                implode(', ', $p['acceptPaymentMethods'] ?? []),
-                collect($p['values'] ?? [])->map(fn ($v): string => sprintf('%s: %s', $v['type'], $v['valuePerMonth']))->join(' | '),
-            ])
+            $plans->map(function (array $p): array {
+                /** @var list<array<string, mixed>> $values */
+                $values = $p['values'] ?? [];
+
+                return [
+                    $p['uuid'],
+                    $p['title'],
+                    $p['active'] ? 'sim' : 'não',
+                    implode(', ', $p['acceptPaymentMethods'] ?? []),
+                    collect($values)->map(fn (array $v): string => sprintf('%s: %s', $v['type'], $v['valuePerMonth']))->join(' | '),
+                ];
+            })
         );
 
         foreach ($plans as $bartePlan) {
             $plan = $this->persistPlan($bartePlan);
 
-            collect($bartePlan['values'] ?? [])
+            /** @var list<array<string, mixed>> $planValues */
+            $planValues = $bartePlan['values'] ?? [];
+
+            collect($planValues)
                 ->filter(fn (array $value): bool => $value['type'] === 'MONTHLY')
                 ->each(fn (array $value) => $plan->prices()->updateOrCreate(
                     ['provider_price_id' => $bartePlan['uuid']],
@@ -60,6 +71,9 @@ class SyncBartePlans extends Command
         'flamma-platinum-barte' => 30000,
     ];
 
+    /**
+     * @param  array<string, mixed>  $bartePlan
+     */
     private function syncFlammaPrices(Plan $plan, array $bartePlan): void
     {
         $flammaPriceInCents = self::FLAMMA_PRICES[$plan->slug] ?? null;
@@ -82,6 +96,9 @@ class SyncBartePlans extends Command
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $bartePlan
+     */
     private function persistPlan(array $bartePlan): Plan
     {
         return Plan::query()->updateOrCreate(

--- a/app-modules/billing/src/Barte/DTOs/BarteWebhookDto.php
+++ b/app-modules/billing/src/Barte/DTOs/BarteWebhookDto.php
@@ -9,6 +9,9 @@ use TresPontosTech\Billing\Barte\Enums\BarteWebhookEventEnum;
 
 readonly class BarteWebhookDto
 {
+    /**
+     * @param  Collection<string, mixed>  $metadata
+     */
     public function __construct(
         public string $uuid,
         public string $domain,
@@ -17,14 +20,20 @@ readonly class BarteWebhookDto
         public Collection $metadata,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function fromArray(array $payload): self
     {
+        /** @var list<array<string, mixed>> $metadata */
+        $metadata = $payload['metadata'] ?? [];
+
         return new self(
             uuid: $payload['uuid'],
             domain: $payload['domain'],
             event: BarteWebhookEventEnum::tryFrom($payload['status']),
             uuidBuyer: $payload['uuidBuyer'] ?? null,
-            metadata: collect($payload['metadata'] ?? [])->pluck('value', 'key'),
+            metadata: collect($metadata)->pluck('value', 'key'),
         );
     }
 }

--- a/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
+++ b/app-modules/billing/src/Barte/DTOs/CreateBuyerDto.php
@@ -27,6 +27,9 @@ readonly class CreateBuyerDto
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/DTOs/CreatePaymentLinkDto.php
+++ b/app-modules/billing/src/Barte/DTOs/CreatePaymentLinkDto.php
@@ -6,6 +6,10 @@ namespace TresPontosTech\Billing\Barte\DTOs;
 
 readonly class CreatePaymentLinkDto
 {
+    /**
+     * @param  list<array<string, mixed>>  $metadata
+     * @param  list<string>  $paymentMethods
+     */
     public function __construct(
         public string $uuidSellerClient,
         public string $scheduledDate,
@@ -16,6 +20,9 @@ readonly class CreatePaymentLinkDto
         public ?PaymentOrderDto $paymentOrder = null,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         $data = [

--- a/app-modules/billing/src/Barte/DTOs/PaymentOrderDto.php
+++ b/app-modules/billing/src/Barte/DTOs/PaymentOrderDto.php
@@ -6,6 +6,9 @@ namespace TresPontosTech\Billing\Barte\DTOs;
 
 readonly class PaymentOrderDto
 {
+    /**
+     * @param  list<array<string, mixed>>  $customInstallmentsValues
+     */
     public function __construct(
         public string $title,
         public float $value,
@@ -18,6 +21,9 @@ readonly class PaymentOrderDto
         public bool $requiresLiabilityShift = false,
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/DTOs/PaymentSubscriptionDto.php
+++ b/app-modules/billing/src/Barte/DTOs/PaymentSubscriptionDto.php
@@ -12,6 +12,9 @@ readonly class PaymentSubscriptionDto
         public string $type = 'MONTHLY',
     ) {}
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(): array
     {
         return [

--- a/app-modules/billing/src/Barte/Jobs/HandleBarteWebhookJob.php
+++ b/app-modules/billing/src/Barte/Jobs/HandleBarteWebhookJob.php
@@ -24,6 +24,9 @@ class HandleBarteWebhookJob implements ShouldQueue
 
     public int $timeout = 60;
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public function __construct(public readonly array $payload) {}
 
     public function handle(HandleBarteWebhook $action): void

--- a/app-modules/billing/src/Core/Commands/SyncBillingCustomersCommand.php
+++ b/app-modules/billing/src/Core/Commands/SyncBillingCustomersCommand.php
@@ -29,6 +29,9 @@ class SyncBillingCustomersCommand extends Command
         $this->info('Done.');
     }
 
+    /**
+     * @param  iterable<int, Company|User>  $billables
+     */
     private function syncBillables(iterable $billables, string $label): void
     {
         $created = 0;

--- a/app-modules/billing/src/Core/Contracts/BillingContract.php
+++ b/app-modules/billing/src/Core/Contracts/BillingContract.php
@@ -20,6 +20,9 @@ interface BillingContract
 
     public function checkoutOpensInNewTab(): bool;
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(Company|User $billable, string $returnUrl, array $options = []): string;
 
     public function hasActiveSubscription(Company|User $billable): bool;

--- a/app-modules/billing/src/Core/DTOs/CheckoutData.php
+++ b/app-modules/billing/src/Core/DTOs/CheckoutData.php
@@ -6,6 +6,9 @@ namespace TresPontosTech\Billing\Core\DTOs;
 
 final readonly class CheckoutData
 {
+    /**
+     * @param  array<string, string>  $metadata
+     */
     public function __construct(
         public string $planSlug,
         public string $priceId,

--- a/app-modules/billing/src/Core/Entities/PriceEntity.php
+++ b/app-modules/billing/src/Core/Entities/PriceEntity.php
@@ -4,6 +4,9 @@ namespace TresPontosTech\Billing\Core\Entities;
 
 class PriceEntity implements \JsonSerializable
 {
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
     public function __construct(
         public string $type,
         public string $priceId,
@@ -14,6 +17,9 @@ class PriceEntity implements \JsonSerializable
         public array $metadata = []
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(
@@ -23,6 +29,9 @@ class PriceEntity implements \JsonSerializable
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function fromEloquent(array $payload): self
     {
         return new self(

--- a/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
+++ b/app-modules/billing/src/Core/Enums/BillingProviderEnum.php
@@ -38,6 +38,8 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
     /**
      * Providers whose existing subscriptions are considered valid for access.
      * Includes legacy providers while their plans have not yet expired.
+     *
+     * @return list<self>
      */
     public static function activeCases(): array
     {
@@ -46,6 +48,8 @@ enum BillingProviderEnum: string implements HasColor, HasIcon, HasLabel
 
     /**
      * Available Providers for NEW Subscriptions.
+     *
+     * @return list<self>
      */
     public static function checkoutCases(): array
     {

--- a/app-modules/billing/src/Core/Models/BillingCustomer.php
+++ b/app-modules/billing/src/Core/Models/BillingCustomer.php
@@ -23,11 +23,16 @@ use TresPontosTech\Billing\Database\Factories\BillingCustomerFactory;
  */
 class BillingCustomer extends Model
 {
+    /** @use HasFactory<BillingCustomerFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_customers';
 
+    /**
+     * @return BillingCustomerFactory
+     */
     protected static function newFactory(): Factory
     {
         return BillingCustomerFactory::new();

--- a/app-modules/billing/src/Core/Models/CompanyPlan.php
+++ b/app-modules/billing/src/Core/Models/CompanyPlan.php
@@ -28,7 +28,9 @@ use TresPontosTech\Company\Models\Company;
  */
 class CompanyPlan extends Model
 {
+    /** @use HasFactory<CompanyPlanFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 

--- a/app-modules/billing/src/Core/Models/Plan.php
+++ b/app-modules/billing/src/Core/Models/Plan.php
@@ -32,7 +32,9 @@ use TresPontosTech\Billing\Database\Factories\PlanFactory;
  */
 class Plan extends Model
 {
+    /** @use HasFactory<PlanFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_plans';

--- a/app-modules/billing/src/Core/Models/Price.php
+++ b/app-modules/billing/src/Core/Models/Price.php
@@ -29,7 +29,9 @@ use TresPontosTech\Billing\Database\Factories\PriceFactory;
  */
 class Price extends Model
 {
+    /** @use HasFactory<PriceFactory> */
     use HasFactory;
+
     use SoftDeletes;
 
     protected $table = 'billing_plan_prices';

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -33,7 +33,9 @@ use TresPontosTech\Company\Models\Company;
  */
 class UserCredit extends Model
 {
+    /** @use HasFactory<UserCreditFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 
@@ -86,12 +88,21 @@ class UserCredit extends Model
         return $this->belongsTo(Appointment::class);
     }
 
+    /**
+     * @param  Builder<UserCredit>  $query
+     * @return Builder<UserCredit>
+     */
     #[Scope]
     protected function forCompany(Builder $query, Company $company): Builder
     {
         return $query->where('company_id', $company->getKey());
     }
 
+    /**
+     * @param  Builder<UserCredit>  $query
+     * @param  Collection<int, string>|null  $userIds
+     * @return Builder<UserCredit>
+     */
     #[Scope]
     protected function heldBy(Builder $query, ?Collection $userIds): Builder
     {
@@ -102,6 +113,10 @@ class UserCredit extends Model
         return $query->whereIn('holder_id', $userIds);
     }
 
+    /**
+     * @param  Builder<UserCredit>  $query
+     * @return Builder<UserCredit>
+     */
     #[Scope]
     protected function ownedBy(Builder $query, Company $company): Builder
     {

--- a/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/ConfigPlanRepository.php
@@ -37,9 +37,15 @@ final readonly class ConfigPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @param  array<string, mixed>  $plan
+     */
     private function createPlanFromArray(array $plan, string $name): PlanEntity
     {
-        $prices = collect(Arr::get($plan, key: 'prices', default: []))
+        /** @var list<array<string, mixed>> $pricesConfig */
+        $pricesConfig = Arr::get($plan, key: 'prices', default: []);
+
+        $prices = collect($pricesConfig)
             ->map(fn (array $price): PriceEntity => PriceEntity::make($price));
 
         return new PlanEntity(
@@ -56,12 +62,18 @@ final readonly class ConfigPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @return Collection<string, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection
     {
         return collect($this->all())
             ->filter(fn ($plan, $key): bool => str_starts_with($key, $name));
     }
 
+    /**
+     * @return Collection<string, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection
     {
         return $this->getPlansFor($name);

--- a/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/EloquentPlanRepository.php
@@ -31,6 +31,9 @@ class EloquentPlanRepository implements PlanRepository
         return collect($this->all())->firstOrFail(fn (PlanEntity $plan): bool => $plan->slug === $name);
     }
 
+    /**
+     * @return Collection<int, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection
     {
         return Cache::remember('active_user_plans', 15, fn () => Plan::query()
@@ -42,6 +45,9 @@ class EloquentPlanRepository implements PlanRepository
         );
     }
 
+    /**
+     * @return Collection<int, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection
     {
         return Cache::remember('checkout_user_plans', 15, fn () => Plan::query()

--- a/app-modules/billing/src/Core/Repositories/PlanRepository.php
+++ b/app-modules/billing/src/Core/Repositories/PlanRepository.php
@@ -17,9 +17,16 @@ interface PlanRepository
 
     public function get(string $name): PlanEntity;
 
+    /**
+     * @return Collection<array-key, PlanEntity>
+     */
     public function getPlansFor(string $name = 'user_'): Collection;
 
-    /** Planos disponíveis para NOVAS assinaturas (usa checkoutCases). */
+    /**
+     * Planos disponíveis para NOVAS assinaturas (usa checkoutCases).
+     *
+     * @return Collection<array-key, PlanEntity>
+     */
     public function getCheckoutPlansFor(string $name): Collection;
 
     public function getActiveTenantPlan(BillingProviderEnum $provider): PlanEntity;

--- a/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/Company/RedirectCompanyIfNotSubscribed.php
@@ -5,18 +5,19 @@ namespace TresPontosTech\Billing\Stripe\Subscription\Company;
 use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Repositories\PlanRepository;
 use TresPontosTech\Company\Models\Company;
 
-class RedirectCompanyIfNotSubscribed
+readonly class RedirectCompanyIfNotSubscribed
 {
     public function __construct(
-        private readonly BillingManager $billingManager,
+        private BillingManager $billingManager,
     ) {}
 
-    public function handle(Request $request, Closure $next, string ...$plans)
+    public function handle(Request $request, Closure $next, string ...$plans): Response
     {
         /** @var Company|Filament $tenant */
         $tenant = Filament::getTenant();

--- a/app-modules/billing/src/Stripe/Subscription/StripeAdapter.php
+++ b/app-modules/billing/src/Stripe/Subscription/StripeAdapter.php
@@ -72,6 +72,9 @@ class StripeAdapter implements BillingContract
         return $session->asStripeCheckoutSession()->url;
     }
 
+    /**
+     * @param  array<string, mixed>  $options
+     */
     public function getBillingPortalUrl(Company|User $billable, string $returnUrl, array $options = []): string
     {
         return $billable

--- a/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
+++ b/app-modules/billing/src/Stripe/Subscription/SubscriptionWebhookController.php
@@ -34,6 +34,9 @@ class SubscriptionWebhookController extends WebhookController
         return parent::handleWebhook($request);
     }
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     protected function handleCheckoutSessionCompleted(array $payload): Response
     {
         $session = $payload['data']['object'];

--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -7,6 +7,7 @@ use Closure;
 use Filament\Facades\Filament;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Symfony\Component\HttpFoundation\Response;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Entities\PlanEntity;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
@@ -15,14 +16,14 @@ use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\Billing\Core\Repositories\PlanRepository;
 use TresPontosTech\Company\Models\Company;
 
-class RedirectUserIfNotSubscribed
+readonly class RedirectUserIfNotSubscribed
 {
     public function __construct(
-        private readonly PlanRepository $planRepository,
-        private readonly BillingManager $billingManager,
+        private PlanRepository $planRepository,
+        private BillingManager $billingManager,
     ) {}
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
         /** @var Company|Filament $tenant */
         $tenant = Filament::getTenant();

--- a/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
+++ b/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
@@ -224,7 +224,7 @@ describe('user access during gateway migration', function (): void {
             barte: new FakeBillingContract(isSubscribed: false, hasActiveSubscription: false),
         );
 
-        expect(fn () => $middleware->handle(fakeRequest(), passThrough()))
+        expect(fn (): Symfony\Component\HttpFoundation\Response => $middleware->handle(fakeRequest(), passThrough()))
             ->toThrow(HttpException::class);
     });
 

--- a/app-modules/company/src/DTOs/CompanyDTO.php
+++ b/app-modules/company/src/DTOs/CompanyDTO.php
@@ -14,6 +14,9 @@ final readonly class CompanyDTO implements JsonSerializable
         public string $userId,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data): self
     {
         return new self(
@@ -25,6 +28,9 @@ final readonly class CompanyDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/company/src/Models/Company.php
+++ b/app-modules/company/src/Models/Company.php
@@ -53,7 +53,10 @@ use TresPontosTech\Tenant\Policies\CompanyPolicy;
 class Company extends Model implements HasAvatar, HasMedia
 {
     use Billable;
+
+    /** @use HasFactory<CompanyFactory> */
     use HasFactory;
+
     use HasUuids;
     use InteractsWithMedia;
     use SoftDeletes;
@@ -148,8 +151,11 @@ class Company extends Model implements HasAvatar, HasMedia
         return $this->hasMany(Department::class);
     }
 
+    /**
+     * @return BelongsToMany<User, $this, TenantMember>
+     */
     #[Scope]
-    protected function onlyEmployees()
+    protected function onlyEmployees(): BelongsToMany
     {
         return $this->employees()->wherePivot('active', true)->whereNot('id', $this->user_id);
     }

--- a/app-modules/company/src/Models/Department.php
+++ b/app-modules/company/src/Models/Department.php
@@ -14,8 +14,6 @@ use TresPontosTech\Company\Database\Factories\DepartmentFactory;
 use TresPontosTech\Company\Enums\DepartmentCategory;
 
 /**
- * @use HasFactory<DepartmentFactory>
- *
  * @property string $id
  * @property string $company_id
  * @property DepartmentCategory $category
@@ -26,7 +24,9 @@ use TresPontosTech\Company\Enums\DepartmentCategory;
  */
 class Department extends Model
 {
+    /** @use HasFactory<DepartmentFactory> */
     use HasFactory;
+
     use HasUuids;
     use SoftDeletes;
 

--- a/app-modules/consultants/src/DTOs/DocumentShareDTO.php
+++ b/app-modules/consultants/src/DTOs/DocumentShareDTO.php
@@ -10,6 +10,9 @@ final readonly class DocumentShareDTO
         public string|int $consultantId,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $data
+     */
     public static function make(array $data): self
     {
         return new self(

--- a/app-modules/consultants/src/Models/Consultant.php
+++ b/app-modules/consultants/src/Models/Consultant.php
@@ -22,6 +22,7 @@ use Spatie\Tags\HasTags;
 use Spatie\Tags\Tag;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
+use TresPontosTech\Consultants\Database\Factories\ConsultantFactory;
 use TresPontosTech\Consultants\Observers\ConsultantObserver;
 use TresPontosTech\Consultants\Policies\ConsultantPolicy;
 use Zap\Models\Concerns\HasSchedules;
@@ -37,7 +38,7 @@ use Zap\Models\Concerns\HasSchedules;
  * @property string $short_description
  * @property string $biography
  * @property string $readme
- * @property array $socials_urls
+ * @property array<string, string> $socials_urls
  * @property Carbon|null $google_calendar_synced_at
  * @property string|null $google_calendar_sync_token
  * @property Carbon|null $created_at
@@ -50,7 +51,9 @@ use Zap\Models\Concerns\HasSchedules;
 #[UsePolicy(ConsultantPolicy::class)]
 class Consultant extends Model implements HasMedia
 {
+    /** @use HasFactory<ConsultantFactory> */
     use HasFactory;
+
     use HasSchedules;
     use HasTags;
     use HasUuids;

--- a/app-modules/consultants/src/Models/Document.php
+++ b/app-modules/consultants/src/Models/Document.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use TresPontosTech\Consultants\Database\Factories\DocumentFactory;
 use TresPontosTech\Consultants\Enums\DocumentExtensionTypeEnum;
 use TresPontosTech\Consultants\Policies\DocumentPolicy;
 
@@ -32,7 +33,9 @@ use TresPontosTech\Consultants\Policies\DocumentPolicy;
 #[UsePolicy(DocumentPolicy::class)]
 class Document extends Model implements HasMedia
 {
+    /** @use HasFactory<DocumentFactory> */
     use HasFactory;
+
     use HasUuids;
     use InteractsWithMedia;
     use SoftDeletes;

--- a/app-modules/consultants/src/Models/DocumentShare.php
+++ b/app-modules/consultants/src/Models/DocumentShare.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use TresPontosTech\Consultants\Database\Factories\DocumentShareFactory;
 
 /**
  * @property int $id
@@ -19,6 +20,7 @@ use Illuminate\Support\Carbon;
  */
 class DocumentShare extends Model
 {
+    /** @use HasFactory<DocumentShareFactory> */
     use HasFactory;
 
     protected $table = 'document_shares';

--- a/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
+++ b/app-modules/integration-google-calendar/src/Actions/RemoveStaleBlockedSchedulesAction.php
@@ -12,6 +12,9 @@ use Zap\Models\Schedule;
 
 readonly class RemoveStaleBlockedSchedulesAction
 {
+    /**
+     * @param  array<int, string>  $syncedEventIds
+     */
     public function handle(Consultant $consultant, array $syncedEventIds): void
     {
         DB::transaction(function () use ($consultant, $syncedEventIds): void {

--- a/app-modules/integration-google-calendar/src/DTO/GoogleEventDTO.php
+++ b/app-modules/integration-google-calendar/src/DTO/GoogleEventDTO.php
@@ -18,6 +18,9 @@ readonly class GoogleEventDTO
         public ?Carbon $updated,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $event
+     */
     public static function fromApiPayload(array $event): self
     {
         $isCancelled = ($event['status'] ?? '') === 'cancelled';

--- a/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
+++ b/app-modules/integration-google-calendar/src/GoogleCalendarClient.php
@@ -10,6 +10,9 @@ use TresPontosTech\IntegrationGoogleCalendar\Responses\CreateEventResponse;
 
 class GoogleCalendarClient
 {
+    /**
+     * @var array<string, mixed>
+     */
     private array $credentials;
 
     public function __construct()

--- a/app-modules/integration-google-calendar/src/Jobs/CreateAppointmentCalendarEventJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/CreateAppointmentCalendarEventJob.php
@@ -19,6 +19,9 @@ class CreateAppointmentCalendarEventJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Jobs/DeleteAppointmentCalendarEventJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/DeleteAppointmentCalendarEventJob.php
@@ -19,6 +19,9 @@ class DeleteAppointmentCalendarEventJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Jobs/SyncConsultantCalendarJob.php
+++ b/app-modules/integration-google-calendar/src/Jobs/SyncConsultantCalendarJob.php
@@ -15,6 +15,9 @@ class SyncConsultantCalendarJob implements ShouldQueue
 
     public int $tries = 3;
 
+    /**
+     * @var array<int, int>
+     */
     public array $backoff = [10, 60, 300];
 
     public function __construct(

--- a/app-modules/integration-google-calendar/src/Responses/CalendarEventsResponse.php
+++ b/app-modules/integration-google-calendar/src/Responses/CalendarEventsResponse.php
@@ -7,12 +7,18 @@ use TresPontosTech\IntegrationGoogleCalendar\DTO\GoogleEventDTO;
 
 readonly class CalendarEventsResponse
 {
+    /**
+     * @param  Collection<int, GoogleEventDTO>  $events
+     */
     public function __construct(
         public Collection $events,
         public ?string $nextPageToken,
         public ?string $nextSyncToken,
     ) {}
 
+    /**
+     * @param  array{items?: array<int, array<string, mixed>>, nextPageToken?: string|null, nextSyncToken?: string|null}  $payload
+     */
     public static function make(array $payload): self
     {
         $events = collect($payload['items'] ?? [])

--- a/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
@@ -15,14 +15,8 @@ final readonly class FetchConsultants
      */
     public function populateAction(): array
     {
-        sprintf(
-            '%s_company_employees',
-            config('services.highlevel.company')
-        );
-
         return collect($this->client->getCompanyEmployees()['users'])
             ->mapWithKeys(fn (array $employee): array => [$employee['id'] => $employee['name']])
             ->toArray();
-
     }
 }

--- a/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchConsultants.php
@@ -10,6 +10,9 @@ final readonly class FetchConsultants
         private HighLevelClient $client,
     ) {}
 
+    /**
+     * @return array<array-key, mixed>
+     */
     public function populateAction(): array
     {
         sprintf(
@@ -17,10 +20,9 @@ final readonly class FetchConsultants
             config('services.highlevel.company')
         );
 
-        //        return Cache::flexible($cacheKey, [$baseTtl, $baseTtl * 2], function () {
         return collect($this->client->getCompanyEmployees()['users'])
-            ->mapWithKeys(fn ($employee): array => [$employee['id'] => $employee['name']])
+            ->mapWithKeys(fn (array $employee): array => [$employee['id'] => $employee['name']])
             ->toArray();
-        //        });
+
     }
 }

--- a/app-modules/integration-highlevel/src/Actions/FetchOpportunityPipelines.php
+++ b/app-modules/integration-highlevel/src/Actions/FetchOpportunityPipelines.php
@@ -7,7 +7,10 @@ use TresPontosTech\IntegrationHighlevel\HighLevelClient;
 
 final readonly class FetchOpportunityPipelines
 {
-    public function populateAction()
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function populateAction(): array
     {
         $baseTtl = 60 * 60;
         $cacheKey = sprintf(

--- a/app-modules/integration-highlevel/src/HighLevelClient.php
+++ b/app-modules/integration-highlevel/src/HighLevelClient.php
@@ -2,6 +2,7 @@
 
 namespace TresPontosTech\IntegrationHighlevel;
 
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
 use TresPontosTech\IntegrationHighlevel\Requests\CreateAppointmentDTO;
 use TresPontosTech\IntegrationHighlevel\Requests\FetchCalendarSlotsDTO;
@@ -13,7 +14,7 @@ use TresPontosTech\IntegrationHighlevel\Responses\UpsertOpportunityResponse;
 
 class HighLevelClient
 {
-    public function searchContacts(string $query = '')
+    public function searchContacts(string $query = ''): Response
     {
         return Http::withToken(config('highlevel.secret'))
             ->withLocation()
@@ -33,6 +34,9 @@ class HighLevelClient
         return ContactResponse::make($response->json());
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getLocationPipelines(): array
     {
         return Http::withToken(config('highlevel.secret'))
@@ -42,7 +46,10 @@ class HighLevelClient
             ->json();
     }
 
-    public function getCompanyEmployees()
+    /**
+     * @return array{users?: array<int, array<string, mixed>>}
+     */
+    public function getCompanyEmployees(): array
     {
         return Http::withToken(config('highlevel.secret'))
             ->withLocation()
@@ -67,7 +74,10 @@ class HighLevelClient
         return UpsertOpportunityResponse::make($response->json());
     }
 
-    public function getCalendarFreeSlots(FetchCalendarSlotsDTO $dto)
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCalendarFreeSlots(FetchCalendarSlotsDTO $dto): array
     {
         $url = sprintf('https://services.leadconnectorhq.com/calendars/%s/free-slots', $dto->calendarId);
 

--- a/app-modules/integration-highlevel/src/Requests/CreateAppointmentDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/CreateAppointmentDTO.php
@@ -41,6 +41,9 @@ class CreateAppointmentDTO implements \JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return get_object_vars($this);

--- a/app-modules/integration-highlevel/src/Requests/FetchCalendarSlotsDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/FetchCalendarSlotsDTO.php
@@ -26,6 +26,9 @@ class FetchCalendarSlotsDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array{startDate: int, endDate: int, timezone: string|null}
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/integration-highlevel/src/Requests/UpsertContactDTO.php
+++ b/app-modules/integration-highlevel/src/Requests/UpsertContactDTO.php
@@ -35,6 +35,9 @@ class UpsertContactDTO implements JsonSerializable
         );
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function jsonSerialize(): array
     {
         return [

--- a/app-modules/integration-highlevel/src/Responses/ContactResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/ContactResponse.php
@@ -9,6 +9,9 @@ readonly class ContactResponse
         public bool $isNewContact
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $json
+     */
     public static function make(array $json): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/OpportunityResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/OpportunityResponse.php
@@ -22,6 +22,9 @@ class OpportunityResponse
         public ?string $lastActionDate,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/ScheduledAppointmentResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/ScheduledAppointmentResponse.php
@@ -16,6 +16,9 @@ class ScheduledAppointmentResponse
         public string $traceId
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/integration-highlevel/src/Responses/UpsertOpportunityResponse.php
+++ b/app-modules/integration-highlevel/src/Responses/UpsertOpportunityResponse.php
@@ -9,6 +9,9 @@ class UpsertOpportunityResponse
         public OpportunityResponse $opportunity,
     ) {}
 
+    /**
+     * @param  array{new: bool, opportunity: array<string, mixed>}  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/panel-admin/src/Filament/Pages/Dashboard.php
+++ b/app-modules/panel-admin/src/Filament/Pages/Dashboard.php
@@ -11,6 +11,9 @@ use TresPontosTech\Admin\Filament\Widgets\StatsOverview;
 
 class Dashboard extends BaseDashboard
 {
+    /**
+     * @var int|string|array<string, int|string>
+     */
     protected int|string|array $columnSpan = 'full';
 
     public function getColumns(): int|array

--- a/app-modules/panel-admin/src/Filament/Pages/DepartmentCategories.php
+++ b/app-modules/panel-admin/src/Filament/Pages/DepartmentCategories.php
@@ -61,6 +61,9 @@ class DepartmentCategories extends Page implements HasTable
             ->paginated(false);
     }
 
+    /**
+     * @return array<int, array{case: DepartmentCategory, total: mixed}>
+     */
     private function getCategoryData(): array
     {
         $counts = Department::query()

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/Pages/ViewAppointment.php
@@ -149,6 +149,9 @@ class ViewAppointment extends ViewRecord
         ];
     }
 
+    /**
+     * @return Collection<int, Document>
+     */
     public function getEmployeeDocuments(): Collection
     {
         $record = $this->record;
@@ -158,6 +161,9 @@ class ViewAppointment extends ViewRecord
             ->get();
     }
 
+    /**
+     * @return Collection<int, Document>
+     */
     public function getSharedDocuments(): Collection
     {
         $record = $this->record;

--- a/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Consultants/RelationManagers/SchedulesRelationManager.php
@@ -10,10 +10,12 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Components\Component;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Zap\Enums\Frequency;
 use Zap\Enums\ScheduleTypes;
 use Zap\Models\Schedule;
@@ -24,7 +26,7 @@ class SchedulesRelationManager extends RelationManager
 
     protected static ?string $title = null;
 
-    public static function getTitle($ownerRecord, string $pageClass): string
+    public static function getTitle(Model $ownerRecord, string $pageClass): string
     {
         return __('consultants::resources.schedules.title');
     }
@@ -40,10 +42,14 @@ class SchedulesRelationManager extends RelationManager
                     ->searchable(),
                 TextColumn::make('frequency_config')
                     ->label(__('consultants::resources.schedules.table.columns.days'))
-                    ->state(fn (Schedule $record): string => collect($record->frequency_config->days ?? [])
-                        ->map(fn (string $day): string => __('consultants::resources.schedules.days.' . $day))
-                        ->join(', ')
-                    ),
+                    ->state(function (Schedule $record): string {
+                        /** @var array<int, string> $days */
+                        $days = $record->frequency_config->days ?? [];
+
+                        return collect($days)
+                            ->map(fn (string $day): string => __('consultants::resources.schedules.days.' . $day))
+                            ->join(', ');
+                    }),
                 TextColumn::make('periods_summary')
                     ->label(__('consultants::resources.schedules.table.columns.periods'))
                     ->state(fn (Schedule $record): string => $record->periods
@@ -100,6 +106,9 @@ class SchedulesRelationManager extends RelationManager
             ]);
     }
 
+    /**
+     * @return array<Component>
+     */
     private function availabilityFormSchema(): array
     {
         return [

--- a/app-modules/panel-admin/src/Filament/Resources/Permissions/Actions/AssignRoleAction.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Permissions/Actions/AssignRoleAction.php
@@ -6,6 +6,7 @@ use App\Models\Users\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Support\Icons\Heroicon;
 use TresPontosTech\Permissions\Roles;
 
@@ -26,6 +27,9 @@ class AssignRoleAction extends Action
         return 'assign-role-action';
     }
 
+    /**
+     * @return array<Component>
+     */
     private function roleSchema(): array
     {
         return [

--- a/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
@@ -15,10 +15,16 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
 
     protected int|string|array $columnSpan = 'full';
 
+    /**
+     * @var array<string, mixed>
+     */
     public array $tableFilterState = [];
 
     private ?object $aggregates = null;
 
+    /**
+     * @param  array<string, mixed>  $filters
+     */
     #[On('appointments-table-filters-changed')]
     public function syncFilters(array $filters): void
     {

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByDepartmentCategoryChart.php
@@ -81,6 +81,10 @@ class AppointmentsByDepartmentCategoryChart extends ChartWidget
         return $this->buildChartData($counts);
     }
 
+    /**
+     * @param  Collection<int, mixed>  $counts
+     * @return array<string, mixed>
+     */
     private function buildChartData(
         Collection $counts,
         string $color = 'rgba(59, 130, 246, 0.7)',

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/GlobalAppointmentStatsWidget.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Widgets\Metrics;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
@@ -84,6 +85,9 @@ class GlobalAppointmentStatsWidget extends StatsOverviewWidget
         ]);
     }
 
+    /**
+     * @return array{start: Carbon, end: Carbon}
+     */
     private function dateRange(): array
     {
         $startDate = data_get($this->pageFilters, 'startDate');

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/KPIsOverview.php
@@ -5,6 +5,7 @@ namespace TresPontosTech\Admin\Filament\Widgets\Metrics;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Carbon;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\AppointmentFeedback;
 use TresPontosTech\Consultants\Models\Consultant;
@@ -26,6 +27,9 @@ class KPIsOverview extends StatsOverviewWidget
         ];
     }
 
+    /**
+     * @return array{start: Carbon, end: Carbon}
+     */
     private function dateRange(): array
     {
         $startDate = data_get($this->pageFilters, 'startDate');

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/RankingsWidget.php
@@ -85,6 +85,7 @@ class RankingsWidget extends TableWidget
 
     /**
      * @param  class-string<Company|Consultant>  $model
+     * @return Builder<Company>|Builder<Consultant>
      */
     private function rankingQuery(string $model, CarbonInterface $start, CarbonInterface $end): Builder
     {

--- a/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AnamneseWizardPage.php
@@ -38,6 +38,9 @@ class AnamneseWizardPage extends Page
         return false;
     }
 
+    /**
+     * @var array<string, mixed>
+     */
     public array $data = [];
 
     public function mount(): void

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Schemas/AppointmentWizard.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Schemas/AppointmentWizard.php
@@ -16,9 +16,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use TresPontosTech\Appointments\Actions\GetAvailableSlotsAction;
 
-// use TresPontosTech\IntegrationHighlevel\HighLevelClient;
-// use TresPontosTech\IntegrationHighlevel\Requests\FetchCalendarSlotsDTO;
-
 class AppointmentWizard
 {
     public static function make(): Wizard
@@ -74,6 +71,9 @@ class AppointmentWizard
                 ->action('start'));
     }
 
+    /**
+     * @return array<string, string>
+     */
     public static function availableSlots(?string $date): array
     {
         if (is_null($date)) {
@@ -89,22 +89,11 @@ class AppointmentWizard
         return self::getAvailableTimeSlots($startDate);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function getAvailableTimeSlots(Carbon $startDate): array
     {
         return resolve(GetAvailableSlotsAction::class)->handle($startDate);
-
-        // HighLevel integration (commented for Laravel Zap migration)
-        // $endDate = $startDate->clone()->endOfDay();
-        // $response = resolve(HighLevelClient::class)
-        //     ->getCalendarFreeSlots(FetchCalendarSlotsDTO::make($startDate, $endDate));
-        //
-        // $formattedDate = $startDate->format('Y-m-d');
-        //
-        // $response = $response[$formattedDate]['slots'];
-        //
-        // return collect($response)
-        //     ->mapWithKeys(fn ($slot): array => [
-        //         $slot => Date::parse($slot)->format('H:i'),
-        //     ])->all();
     }
 }

--- a/app-modules/panel-company/src/Actions/Metrics/GetInsights.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetInsights.php
@@ -86,6 +86,9 @@ final class GetInsights
         });
     }
 
+    /**
+     * @param  Collection<int, string>|null  $userIds
+     */
     private function volume(Company $tenant, ?Collection $userIds, CarbonImmutable $start, CarbonImmutable $end): int
     {
         return Appointment::forCompany($tenant)

--- a/app-modules/panel-company/src/Actions/Metrics/GetSessionsTrend.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetSessionsTrend.php
@@ -6,6 +6,7 @@ namespace TresPontosTech\PanelCompany\Actions\Metrics;
 
 use Flowframe\Trend\Trend;
 use Flowframe\Trend\TrendValue;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
@@ -38,11 +39,13 @@ final class GetSessionsTrend
         return Cache::remember($cacheKey, $this->metricsCacheTtl(), function () use ($tenant, $period, $userIds): SessionsTrendData {
             $method = $period->granularity->trendMethod();
 
+            /** @var Collection<int, TrendValue> $totalSeries */
             $totalSeries = Trend::query(
                 Appointment::forCompany($tenant)
                     ->forUsers($userIds),
             )->dateColumn('appointment_at')->between(start: $period->start, end: $period->end)->{$method}()->count();
 
+            /** @var Collection<int, TrendValue> $completedSeries */
             $completedSeries = Trend::query(
                 Appointment::forCompany($tenant)
                     ->where('status', AppointmentStatus::Completed->value)
@@ -58,7 +61,7 @@ final class GetSessionsTrend
                 ->all();
 
             $firstNonZero = collect($completedValues)->first(fn (int $v): bool => $v > 0);
-            $last = $completedValues === [] ? 0 : (int) end($completedValues);
+            $last = $completedValues === [] ? 0 : end($completedValues);
             $growthFactor = null;
 
             if (($firstNonZero ?? 0) > 0 && $last > 0) {

--- a/app-modules/panel-company/src/Actions/Metrics/ResolveScopedUserIds.php
+++ b/app-modules/panel-company/src/Actions/Metrics/ResolveScopedUserIds.php
@@ -17,6 +17,9 @@ use TresPontosTech\PanelCompany\DTOs\MetricsFilters;
  */
 final class ResolveScopedUserIds
 {
+    /**
+     * @return Collection<int, string>|null
+     */
     public function handle(Company $tenant, MetricsFilters $filters): ?Collection
     {
         if (filled($filters->userId)) {

--- a/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/CreateAndAttachAction.php
@@ -9,6 +9,7 @@ use Filament\Actions\CreateAction;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
@@ -66,6 +67,9 @@ class CreateAndAttachAction extends CreateAction
 
     }
 
+    /**
+     * @return array<Component>
+     */
     private function buildFormSchema(): array
     {
         return [

--- a/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
+++ b/app-modules/panel-company/src/Filament/Concerns/HasMetricsDateRange.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TresPontosTech\PanelCompany\Filament\Concerns;
 
+use Carbon\CarbonImmutable;
 use Filament\Facades\Filament;
 use Illuminate\Support\Collection;
 use TresPontosTech\Company\Models\Company;
@@ -13,6 +14,9 @@ use TresPontosTech\PanelCompany\Support\MetricsPeriod;
 
 trait HasMetricsDateRange
 {
+    /**
+     * @return array{start: CarbonImmutable, end: CarbonImmutable}
+     */
     private function dateRange(): array
     {
         $period = $this->metricsPeriod();
@@ -54,6 +58,9 @@ trait HasMetricsDateRange
         );
     }
 
+    /**
+     * @return Collection<int, string>|null
+     */
     private function filteredUserIds(): ?Collection
     {
         /** @var Company $tenant */

--- a/app-modules/panel-company/src/Filament/Resources/Departments/DepartmentResource.php
+++ b/app-modules/panel-company/src/Filament/Resources/Departments/DepartmentResource.php
@@ -109,6 +109,10 @@ class DepartmentResource extends Resource
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
     public static function mutateFormDataBeforeCreate(array $data): array
     {
         $data['company_id'] = Filament::getTenant()?->getKey();

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/CreditUsageTableWidget.php
@@ -65,6 +65,9 @@ class CreditUsageTableWidget extends TableWidget
             ]);
     }
 
+    /**
+     * @return Builder<UserCredit>
+     */
     private function tableQuery(): Builder
     {
         $period = $this->metricsPeriod();

--- a/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/ShareDocumentFilamentAction.php
@@ -6,6 +6,7 @@ use App\Models\Users\User;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Component;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Mail;
 use TresPontosTech\Consultants\Actions\UpsertDocumentShareAction;
@@ -35,6 +36,9 @@ class ShareDocumentFilamentAction extends Action
             });
     }
 
+    /**
+     * @return array<Component>
+     */
     public static function getCustomForm(): array
     {
         return [
@@ -57,7 +61,10 @@ class ShareDocumentFilamentAction extends Action
         ];
     }
 
-    public static function handleExecution(Document $record, array $data, $action): void
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function handleExecution(Document $record, array $data, Action $action): void
     {
         $consultantId = auth()->user()->consultant->getKey();
 

--- a/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -38,6 +38,9 @@ class AppointmentsTable
 
     }
 
+    /**
+     * @return array<int, TextColumn>
+     */
     public static function columns(): array
     {
         return [

--- a/app-modules/user/src/Actions/ParseUsersFromFileAction.php
+++ b/app-modules/user/src/Actions/ParseUsersFromFileAction.php
@@ -7,6 +7,9 @@ use Spatie\SimpleExcel\SimpleExcelReader;
 
 class ParseUsersFromFileAction
 {
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
     public function execute(string $filePath, string $fileExtension): Collection
     {
         return SimpleExcelReader::create($filePath, $fileExtension)
@@ -18,6 +21,10 @@ class ParseUsersFromFileAction
             ->values();
     }
 
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
     private function sanitizeRow(array $row): array
     {
         foreach (['phone_number', 'tax_id'] as $field) {

--- a/app-modules/user/src/Actions/PersistImportedUsersAction.php
+++ b/app-modules/user/src/Actions/PersistImportedUsersAction.php
@@ -19,6 +19,9 @@ class PersistImportedUsersAction
 {
     private const int CHUNK_SIZE = 100;
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     public function execute(Collection $rows, Company $company): ImportUsersResultDTO
     {
         $imported = 0;

--- a/app-modules/user/src/Actions/ValidateUserImportAction.php
+++ b/app-modules/user/src/Actions/ValidateUserImportAction.php
@@ -16,7 +16,10 @@ class ValidateUserImportAction
     /** @var list<ImportErrorDTO> */
     private array $errors = [];
 
-    /** @return list<ImportErrorDTO> */
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     * @return list<ImportErrorDTO>
+     */
     public function execute(Collection $rows, Company $company): array
     {
         $this->errors = [];
@@ -191,6 +194,9 @@ class ValidateUserImportAction
         }
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicateEmails(Collection $rows): void
     {
         $emails = $rows->map(fn (array $row): string => strtolower(trim((string) ($row['email'] ?? ''))));
@@ -206,6 +212,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateExistingEmails(Collection $rows): void
     {
         $emails = $rows->map(fn (array $row): string => strtolower(trim((string) ($row['email'] ?? ''))));
@@ -227,6 +236,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicateTaxIds(Collection $rows): void
     {
         $taxIds = $rows->map(fn (array $row): string => trim((string) ($row['tax_id'] ?? '')));
@@ -242,6 +254,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateExistingTaxIds(Collection $rows): void
     {
         $taxIds = $rows->map(fn (array $row): string => trim((string) ($row['tax_id'] ?? '')));
@@ -263,6 +278,9 @@ class ValidateUserImportAction
             });
     }
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     private function validateDuplicatePhoneNumbers(Collection $rows): void
     {
         $phoneNumbers = $rows->map(fn (array $row): string => trim((string) ($row['phone_number'] ?? '')));

--- a/app-modules/user/src/DTOs/UserDTO.php
+++ b/app-modules/user/src/DTOs/UserDTO.php
@@ -13,6 +13,9 @@ final readonly class UserDTO
         public ?string $tenant_id = null,
     ) {}
 
+    /**
+     * @param  array<string, mixed>  $payload
+     */
     public static function make(array $payload): self
     {
         return new self(

--- a/app-modules/user/src/Jobs/ImportUsersJob.php
+++ b/app-modules/user/src/Jobs/ImportUsersJob.php
@@ -17,6 +17,9 @@ class ImportUsersJob implements ShouldQueue
 
     public int $timeout = 600;
 
+    /**
+     * @param  Collection<int, array<string, mixed>>  $rows
+     */
     public function __construct(
         public readonly Collection $rows,
         public readonly string $companyId,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 5
+    level: 6
 
     paths:
         - app


### PR DESCRIPTION
## Problema

Continuação da subida incremental do PHPStan modular (1 PR por nível). O `develop` está no level 5 (#216); este PR sobe a análise estática para o **level 6**, que passa a exigir tipos de valor em iteráveis e parâmetros de generics (`missingType.*`).

## Solução

Subir `level: 6` expôs **177 erros**, quase todos mecânicos: `missingType.iterableValue` (82), `missingType.generics` (68), `argument.templateType` (14), `missingType.return` (7) e `missingType.parameter` (2). Correções, revisando cada mudança contra a realidade do código (sem confiar cegamente na referência da branch antiga):

- **Models / scopes Eloquent:** docblocks de generics nos scopes (`@param Builder<Model> $query` + `@return Builder<Model>`) em `Appointment` e `UserCredit`; `@return Attribute<…, never>` em `currentTransition`; `@param/@return Collection<int, string>` para os filtros de usuários.
- **Clients de API / DTOs / Actions:** tipos de retorno e array-shapes (`array<string, mixed>`, `list<…>`) em `HighLevelClient`, `SyncBartePlans`, `ValidateUserImportAction`, `BarteWebhookDto`, etc.
- **Trait `HasMetricsDateRange`:** corrigido `@return` de `dateRange()` que apontava para `Illuminate\Support\Carbon`, sendo que `MetricsPeriod` usa `Carbon\CarbonImmutable` (causava 13× `return.type`).
- **`GetSessionsTrend`:** `Trend::query()->{$method}()->count()` resolve como `mixed` (método dinâmico + `count()` sem generic no pacote `flowframe/laravel-trend`); a série foi tipada com `@var Collection<int, TrendValue>`, deixando o pipeline resolvível.

## Observações

- O widget `InsightsWidget` (removido no `develop` numa refatoração anterior) foi honrado como deleção.
- Revisei os diffs de maior porte: todas as mudanças são type-only/docblock, sem alteração de comportamento.

## Verificação

- `vendor/bin/phpstan analyse` → level 6, **0 erros**
- `vendor/bin/pint --dirty` → sem alterações · `vendor/bin/rector --dry-run` → 0 changes
- `php artisan test --parallel` → **982 passed, 2 skipped, 0 failed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded PHPDoc type annotations across modules (DTOs, models, actions, repositories, integrations) to improve IDE hints and code clarity.

* **Refactor**
  * Updated selected request handlers to use `readonly class` and added/clarified return types (notably around subscription redirection flows).
  * Improved internal processing structure for billing plan synchronization without changing expected outcomes.

* **Tests**
  * Tightened a test’s response typing for clearer assertions.

* **Chores**
  * Increased PHPStan analysis level for stricter static checking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->