### PR TITLE
docs(boost): adiciona guidelines de domínio, apresentação e workflow

### DIFF
--- a/.ai/guidelines/domain/model-phpdoc-sync.blade.php
+++ b/.ai/guidelines/domain/model-phpdoc-sync.blade.php
@@ -1,0 +1,97 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+
+# Model PHPDoc Sync — Mandatory on Schema Changes
+
+**Priority: HIGH** — This rule is non-negotiable. Every schema change MUST update the
+corresponding model PHPDoc.
+
+## Rule
+
+When you **add, remove, rename, or change the type** of any database column (via
+migration, manual SQL, or schema dump), the `@property` PHPDoc block on the affected
+Model class **MUST be updated in the same commit**.
+
+## What triggers this rule
+
+- `{{ $assist->artisanCommand('make:migration') }}` that adds/removes/alters columns
+- Any edit to an existing migration file
+- Any raw SQL that changes table structure
+- Renaming a column
+- Changing a column type (e.g. `string` → `text`, `timestamp` → `timestampTz`)
+- Adding/removing nullable
+- Adding/removing a default value that changes the PHPDoc type
+
+## PHPDoc format
+
+@verbatim
+<code-snippet name="Model PHPDoc block" lang="php">
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $name
+ * @property string $slug
+ * @property string|null $stripe_id
+ * @property Carbon|null $trial_ends_at
+ * @property Carbon|null $deleted_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
+#[UseFactory(CompanyFactory::class)]
+#[Table(name: 'companies')]
+final class Company extends Model
+</code-snippet>
+@endverbatim
+
+## Type mapping
+
+| Column type | PHPDoc type |
+|-------------|-------------|
+| `uuid` | `string` |
+| `string`, `text` | `string` |
+| `integer`, `bigInteger` | `int` |
+| `boolean` | `bool` |
+| `timestamp`, `datetime`, `timestampTz` | `Carbon\|null` |
+| `json`, `jsonb` | `array<string, mixed>\|null` |
+| `decimal`, `float` | `float` |
+| `enum` (backed) | `EnumClass` |
+
+- Add `|null` when the column is nullable.
+- Use the cast type for enums and custom casts, not the raw DB type.
+- This project uses UUID primary keys (`HasUuids`) on most models, so `id` is `string`.
+- `created_at` and `updated_at` are always `Carbon|null`.
+
+## Explicit class-level attributes
+
+Prefer declaring these attributes explicitly, even when the values match Laravel's
+convention. This is the standard for new and refactored models:
+
+- `#[Table(name: '...')]` — explicit table name.
+- `#[UseFactory(XxxFactory::class)]` — explicit factory binding, instead of a
+  `newFactory()` override. The `HasFactory` trait is still required.
+
+@verbatim
+<code-snippet name="Explicit model attributes" lang="php">
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+
+#[UseFactory(CompanyFactory::class)]
+#[Table(name: 'companies')]
+final class Company extends Model
+{
+    /** @use HasFactory<CompanyFactory> */
+    use HasFactory;
+}
+</code-snippet>
+@endverbatim
+
+## Verification
+
+Before marking a migration task as done, confirm:
+
+1. The model file has a `/** @property ... */` block above the class.
+2. Every column in the table has a corresponding `@property` line.
+3. Types match the column definition and any explicit `casts()`.
+4. The model declares `#[Table(name: '...')]` and `#[UseFactory(XxxFactory::class)]`.
+5. PHPStan passes (`{{ $assist->binCommand('phpstan analyse') }}`).

--- a/.ai/guidelines/domain/module-architecture.blade.php
+++ b/.ai/guidelines/domain/module-architecture.blade.php
@@ -1,0 +1,136 @@
+# Module Architecture
+
+This monorepo uses `internachi/modular`. Each module lives under
+`app-modules/{kebab-case}/`, is published as `3pontos-tech/{slug}`, and uses the
+namespace `TresPontosTech\{PascalCase}\`.
+
+> The namespace does **not** always match the directory name — always confirm in the
+> module's `composer.json`. Presentation modules in particular follow the
+> `TresPontosTech\Panel{Name}` standard (see the table below).
+
+## Module types
+
+| Type             | Modules                                                                  | Contains                                       |
+| ---------------- | ------------------------------------------------------------------------ | ---------------------------------------------- |
+| **Domain**       | `appointments`, `billing`, `company`, `consultants`, `permissions`, `support`, `tenant`, `user` | Business logic: Models, Actions, DTOs, Enums   |
+| **Integration**  | `integration-google-calendar`, `integration-highlevel`                   | External APIs: Actions, Requests, Responses, Jobs, Console |
+| **Presentation** | `panel-admin`, `panel-app`, `panel-company`, `panel-consultant`          | UI: Filament Resources/Pages/Widgets, Livewire |
+
+Presentation modules own UI concerns only. Domain logic belongs in domain modules —
+see the `presentation/core` guideline.
+
+## Namespace standard for `panel-*` modules
+
+Presentation modules use `TresPontosTech\Panel{Name}` (PascalCase of the directory):
+
+| Module             | Namespace                       |
+| ------------------ | ------------------------------- |
+| `panel-admin`      | `TresPontosTech\PanelAdmin`     |
+| `panel-app`        | `TresPontosTech\PanelApp`       |
+| `panel-company`    | `TresPontosTech\PanelCompany`   |
+| `panel-consultant` | `TresPontosTech\PanelConsultant`|
+
+This matches the provider class names already in use (`PanelAdminServiceProvider`, …).
+Some panels are still being aligned to this standard — trust the `composer.json` for
+the current value, and target this standard when creating or renaming a panel.
+
+## Canonical structure
+
+```
+app-modules/{module}/
+├── composer.json
+├── phpstan.neon
+├── config/{module}.php                       (optional)
+├── database/
+│   ├── factories/
+│   ├── migrations/
+│   └── seeders/
+├── lang/{en,pt_BR}/                          (optional)
+├── routes/{topic}-routes.php                 (optional, auto-discovered)
+├── resources/views/                          (optional, presentation only)
+├── resources/boost/guidelines/              (optional, module-scoped guidelines)
+├── src/
+│   ├── Providers/{ModuleName}ServiceProvider.php
+│   ├── Actions/
+│   ├── Models/
+│   ├── DTOs/
+│   ├── Enums/
+│   ├── Exceptions/
+│   ├── Policies/
+│   └── ...
+└── tests/
+    ├── Feature/
+    └── Unit/
+```
+
+## Sub-namespace strategies
+
+**Flat layers** — most domain modules (`appointments`, `company`, `user`, `support`):
+`src/Actions/`, `src/Models/`, `src/DTOs/`, `src/Enums/`.
+
+**Sub-domain grouping** — complex modules:
+- `billing` → `Core/`, `Stripe/`, `Barte/` (each with its own Models/Actions/DTOs).
+- presentation modules → `Filament/` with `Resources/`, `Pages/`, `Widgets/`, `Clusters/`.
+
+## ServiceProvider
+
+Place the ServiceProvider at `src/Providers/{ModuleName}ServiceProvider.php` (the
+dominant convention here). A few legacy modules keep it at the `src/` root
+(`billing`, `permissions`, `integration-highlevel`) — follow `src/Providers/` for new
+modules. Register the provider in the module's `composer.json` under
+`extra.laravel.providers`.
+
+@verbatim
+<code-snippet name="Module ServiceProvider" lang="php">
+namespace TresPontosTech\{ModuleName}\Providers;
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\ServiceProvider;
+
+class {ModuleName}ServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../../config/{module}.php', '{module}');
+    }
+
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__ . '/../../database/migrations');
+        $this->loadTranslationsFrom(__DIR__ . '/../../lang', '{module}');
+
+        Relation::morphMap([
+            'some_class' => SomeClass::class,
+        ]);
+    }
+}
+</code-snippet>
+@endverbatim
+
+Check a sibling module's ServiceProvider (e.g. `appointments`, `company`) for the full
+pattern before adding `loadViewsFrom()`, `Event::listen()`, `Gate::policy()`, etc.
+
+## Module composer.json
+
+@verbatim
+<code-snippet name="Module composer.json" lang="json">
+{
+    "name": "3pontos-tech/{module-slug}",
+    "autoload": {
+        "psr-4": {
+            "TresPontosTech\\{ModuleName}\\": "src/",
+            "TresPontosTech\\{ModuleName}\\Database\\Factories\\": "database/factories/",
+            "TresPontosTech\\{ModuleName}\\Database\\Seeders\\": "database/seeders/"
+        }
+    }
+}
+</code-snippet>
+@endverbatim
+
+## Dependency rules
+
+- **Domain** modules never import from Presentation or Integration.
+- **Integration** modules may depend on Domain (e.g. resolving a `User` or `Company`).
+- **Presentation** imports from Domain and Integration, never the reverse.
+- The canonical `User` model lives in the app core (`App\Models\Users\User`), not in a
+  module; the `user` module holds related domain pieces (anamnese, events, jobs).

--- a/.ai/guidelines/domain/multi-tenancy.blade.php
+++ b/.ai/guidelines/domain/multi-tenancy.blade.php
@@ -1,0 +1,60 @@
+# Multi-Tenancy
+
+Filament-native tenancy. **The tenant is the `Company`** — there is no separate
+`Tenant` model. (The `tenant` module holds supporting pieces: the `TenantMember` pivot
+and the `HasTenant` trait, not a tenant entity.)
+
+## Resolution
+
+Filament resolves the tenant from the URL slug (`/{panel}/{company-slug}/…`). The
+**app** and **company** panels enable tenancy:
+
+@verbatim
+<code-snippet name="Panel tenancy" lang="php">
+// AppPanelProvider / CompanyPanelProvider
+$panel->tenant(Company::class, slugAttribute: 'slug');
+</code-snippet>
+@endverbatim
+
+The **admin** and **consultant** panels are **not** tenant-scoped.
+
+The `User` model uses the `TresPontosTech\Tenant\Models\Traits\HasTenant` trait and
+implements Filament's `HasTenants` + `HasDefaultTenant`. Its tenant relationship is
+`companies()` (a `BelongsToMany` through the `TenantMember` pivot on the
+`company_employees` table).
+
+## Data isolation (hybrid)
+
+There is **no** global `BelongsToTenant` trait and **no** `ApplyTenantScopes`
+middleware. Isolation comes from two places:
+
+1. **Filament automatic scoping** — any Resource registered in a tenant-enabled panel
+   is auto-scoped via `whereBelongsTo($tenant)` while `$isScopedToTenant = true`
+   (the default). Opt a resource out with `protected static bool $isScopedToTenant = false;`
+   (e.g. `SharedDocumentResource`).
+2. **Manual query scoping** — for everything outside Filament's automatic path, filter
+   explicitly in `getEloquentQuery()` (e.g. `SupportTicketResource` filters by
+   `auth()->id()`) or with `whereBelongsTo(filament()->getTenant())`.
+
+Tenant-scoped models carry a `company_id` FK with a `company()` BelongsTo relationship
+(e.g. `Appointment`, `SupportTicket`). Each model defines its own — there is no shared
+trait.
+
+## In tests
+
+@verbatim
+<code-snippet name="Tenant-scoped test setup" lang="php">
+$company = Company::factory()->create();
+$user = User::factory()->create();
+
+filament()->setCurrentPanel('app');
+filament()->setTenant($company);
+$this->actingAs($user);
+
+// Propagate the tenant through factory chains:
+Appointment::factory()->recycle($company)->recycle($consultant)->create();
+</code-snippet>
+@endverbatim
+
+Use `->recycle($company)` to reuse the same tenant across a factory chain, and
+`filament()->setTenant($company)` to activate it for the panel under test.

--- a/.ai/guidelines/domain/project-context.blade.php
+++ b/.ai/guidelines/domain/project-context.blade.php
@@ -1,0 +1,38 @@
+# Gil Benefits — Project Context
+
+Gil Benefits is a **B2B2C financial-consulting platform**. Companies subscribe to a
+plan and offer financial consulting to their employees, delivered by consultants
+through scheduled appointments.
+
+**Target audience:** companies (the tenants) and their employees (end users), served
+by financial consultants.
+**Channels:** Web only — four Filament panels (admin, app, company, consultant) plus
+external integrations (Google Calendar, HighLevel).
+
+## Business Model
+
+- **SaaS multi-tenant, B2B2C.** A company subscribes to a tiered plan (billed via
+  Laravel Cashier / Stripe and Barte) and makes financial consulting available to its
+  employees.
+- Employees consume credits / appointments according to the company plan; consultants
+  deliver the sessions and post-session feedback.
+- Plans and prices are **not** documented here — read `app-modules/billing` before
+  quoting tiers or values.
+
+## Modular Monolith (`internachi/modular`)
+
+| Layer            | Modules                                                                 |
+| ---------------- | ----------------------------------------------------------------------- |
+| **Domain**       | `appointments`, `billing`, `company`, `consultants`, `permissions`, `support`, `tenant`, `user` |
+| **Integration**  | `integration-google-calendar`, `integration-highlevel`                  |
+| **Presentation** | `panel-admin`, `panel-app`, `panel-company`, `panel-consultant`         |
+
+See the `module-architecture` guideline for the full layout and dependency rules.
+
+## Key Conventions
+
+- **Tenant = `Company`** — Filament-native tenancy, slug in the URL. See `multi-tenancy`.
+- **Namespace:** `TresPontosTech\{Module}` (presentation modules → `TresPontosTech\Panel{Name}`).
+- **Language:** PT-BR for user-facing strings, English for code.
+- **PHP:** 8.4 (strict types). **Filament:** v5. **Livewire:** v4.
+- **Testing:** Pest v4. **Quality:** PHPStan (modular, climbing levels), Rector, Pint.

--- a/.ai/guidelines/presentation/core.blade.php
+++ b/.ai/guidelines/presentation/core.blade.php
@@ -1,0 +1,62 @@
+# Presentation Layer
+
+The `panel-*` modules (`panel-admin`, `panel-app`, `panel-company`,
+`panel-consultant`) are the **presentation layer**. They own UI concerns: Filament
+Resources, Pages, Widgets, Clusters, Livewire components, and Blade views.
+
+## Rule
+
+Domain logic (Actions, Models, DTOs, business rules) belongs in domain modules
+(`appointments`, `billing`, `company`, `consultants`, `user`, …), never in
+presentation modules.
+
+Presentation modules import from domain modules.
+Domain modules never import from presentation modules.
+
+## Filament (v5)
+
+Research Filament 5.x before implementing, using the `search-docs` MCP tool (or
+`context7` if available). Always import domain classes into Pages, Resources, Widgets,
+and Livewire components with `use` statements — keep the presentation layer decoupled
+from domain internals.
+
+When a Filament Action triggers domain behaviour, wrap a domain Action in a Filament
+Action class. The Filament Action stays focused on UI; the domain Action does the work.
+
+@verbatim
+<code-snippet name="Filament Action wrapping a Domain Action" lang="php">
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
+use TresPontosTech\Company\Models\Company;
+
+class RegisterSubscriptionAction extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label(__('panel-company::subscription.actions.register.label'))
+            ->icon(Heroicon::PlusCircle)
+            ->color(Color::Sky)
+            ->action(function (array $data): void {
+                /** @var Company|null $company */
+                $company = filament()->getTenant();
+
+                resolve(RegisterSubscription::class)
+                    ->execute(RegisterSubscriptionData::fromArray($data));
+
+                Notification::make()->success()->send();
+            });
+    }
+}
+</code-snippet>
+@endverbatim
+
+## Livewire (v4)
+
+When working in the presentation layer, activate any available Livewire skill before
+building components, and follow the existing component conventions in the panel you are
+editing.

--- a/.ai/guidelines/tooling/phpstan.blade.php
+++ b/.ai/guidelines/tooling/phpstan.blade.php
@@ -1,0 +1,42 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+
+# PHPStan — ignoreErrors Conventions
+
+This project runs PHPStan modularly — each module has its own `phpstan.neon`, and the
+analysis level is climbed one step at a time. When adding entries to `ignoreErrors` in
+any `phpstan.neon`, always use the **indented block style**: a lone `-` on its own
+line, with keys indented beneath it. Never use the inline `- { ... }` style, as it
+requires horizontal scrolling and hurts readability.
+
+## Correct format
+
+@verbatim
+<code-snippet name="ignoreErrors block style" lang="neon">
+parameters:
+    ignoreErrors:
+        -
+            message: '#^Error message regex here#'
+            identifier: error.identifier
+            count: 1
+            path: src/Path/To/File.php
+</code-snippet>
+@endverbatim
+
+## Rules
+
+- `message` must be a regex wrapped in `#` delimiters.
+- Always scope errors to a specific `path` — never leave an entry without one.
+- Always include `count` so PHPStan warns if the number of occurrences changes.
+- Always include `identifier` when PHPStan provides one (e.g. `property.notFound`).
+- Do not escape spaces with `\ ` inside `#...#` regex patterns.
+- Prefer fixing the root cause over ignoring. Only ignore when:
+    - The error comes from third-party or generated code.
+    - The false positive is a known PHPStan/Larastan limitation (e.g. Livewire `$form`).
+
+## Baseline
+
+Prefer running `{{ $assist->binCommand('phpstan analyse --generate-baseline') }}` for
+bulk legacy errors. Manual `ignoreErrors` entries are reserved for intentional,
+documented suppressions only.

--- a/.ai/guidelines/workflow/documentation-authoring.blade.php
+++ b/.ai/guidelines/workflow/documentation-authoring.blade.php
@@ -1,0 +1,84 @@
+# Documentation Authoring
+
+Conventions for where domain documentation lives and how it is structured. Docs are
+plain Markdown co-located with the code — there is no docs portal or auto-discovery, so
+these conventions are what keep documents findable.
+
+## Where to save each document (co-location)
+
+A document about **one module** lives inside that module; a **system-wide /
+cross-module** document lives at the repo root.
+
+```
+app-modules/{module}/                  docs/            (system-wide / cross-module)
+├── CONTEXT.md       (glossary)         ├── adr/
+├── README.md        (entry point)      ├── specs/
+└── docs/                               ├── plans/
+    ├── adr/                            └── prd/
+    ├── specs/
+    ├── plans/
+    └── prd/
+```
+
+- ADR numbering is **per module** (`{module}/docs/adr/0001-…`, `0002-…`), not global.
+- Spec / Plan / PRD filenames are date-stamped: `AAAA-MM-DD-titulo.md` (PRDs may omit
+  the date).
+- When a spec or plan is produced, save it under the **related module's** `docs/`
+  (or `docs/` at the root if it spans modules).
+
+## Skills that produce docs (brainstorm, grill-me, writing-plans)
+
+These conventions **OVERRIDE** the superpowers skills' default save paths:
+
+- `brainstorming` defaults specs to `docs/superpowers/specs/…`; `writing-plans`
+  defaults plans to `docs/superpowers/plans/…`.
+- In this repo, **do NOT use `docs/superpowers/`**. Save the spec/plan under the owning
+  module's `docs/{specs,plans}/` (or root `docs/{specs,plans}/` if it spans modules),
+  following the co-location rule above. ADRs → `app-modules/<module>/docs/adr/`.
+- Pick the owning module before writing; if the document is genuinely cross-module, use
+  the root `docs/`.
+
+## Document types — purpose and boundaries
+
+Each type has ONE owner — don't duplicate content across them.
+
+| Type     | Lives in                               | Captures                                                        | Do NOT put here (→ owner)                                  |
+| -------- | -------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------- |
+| spec     | `…/docs/specs/AAAA-MM-DD-titulo.md`    | what & why: context, goals/non-goals, architecture, trade-offs  | step-by-step checklist (→ plan); glossary (→ CONTEXT.md)   |
+| plan     | `…/docs/plans/AAAA-MM-DD-titulo.md`    | how: goal + ref to spec, tasks in phases as testable `- [ ]`    | arch rationale (→ ADR); conceptual design (→ spec)         |
+| prd      | `…/docs/prd/titulo.md`                 | product problem & solution: problem, solution, user stories, out-of-scope (usually born from an issue) | step-by-step impl (→ plan); technical trade-offs (→ ADR)   |
+| adr      | `app-modules/<module>/docs/adr/NNNN-…` | one decision + rationale + consequences (per-module numbering)  | —                                                          |
+| README   | `app-modules/<module>/README.md`       | entry point: overview, responsibilities, entry points, flows, how to test, links | column/schema table (→ Model PHPDoc); glossary (→ CONTEXT.md); arch rationale (→ ADR) |
+| CONTEXT  | `app-modules/<module>/CONTEXT.md`      | glossary + module boundaries                                    | how-to (→ README); decisions (→ ADR)                       |
+
+The "column/schema table lives in the Model PHPDoc" boundary is the `model-phpdoc-sync`
+guideline. Write all docs in **pt_BR**.
+
+## Front-matter standard
+
+Add a YAML front-matter block on new docs. All keys optional, but prefer them:
+
+```yaml
+---
+type: spec            # spec | plan | adr | prd
+title: "..."
+module: nome-do-modulo
+status: ...            # adr: accepted|superseded|… · plan: proposed|in_progress|completed
+date: 2026-06-23
+author: seu-handle-github
+related:               # cross-links to other docs
+  spec: nome-do-modulo/AAAA-MM-DD-titulo
+---
+```
+
+## README vs CONTEXT (do not duplicate)
+
+- `CONTEXT.md` = glossary + module boundaries (conceptual).
+- `README.md` = practical entry point + roadmap (concrete), linking to CONTEXT/ADRs.
+- A module README **must not** include a column/schema table (that lives in the Model
+  PHPDoc — see `model-phpdoc-sync`), a glossary (that's CONTEXT), or architecture
+  decisions with rationale (those become ADRs).
+
+## Language
+
+Write documentation in **pt_BR**. Existing English docs stay as-is.

--- a/.ai/guidelines/workflow/domain-docs.blade.php
+++ b/.ai/guidelines/workflow/domain-docs.blade.php
@@ -1,0 +1,55 @@
+# Domain Docs
+
+How to consume this repo's domain documentation when exploring the codebase. These
+docs are plain Markdown files co-located with the code — there is no docs portal or
+auto-discovery here.
+
+## Before exploring, read these (if they exist)
+
+- **`app-modules/<module>/CONTEXT.md`** — the module glossary: vocabulary and
+  boundaries for that module.
+- **`app-modules/<module>/ARCHITECTURE.md`** — the module's structure, runtime flows,
+  and key classes (the "how it's wired"), distinct from the `CONTEXT.md` glossary.
+- **`app-modules/<module>/docs/adr/`** — ADRs are **module-scoped**: read the ones in
+  the module you're about to work in. They're numbered per-module from `0001` and
+  referenced anywhere as `module/NNNN` (e.g. `billing/0003`). There is no root
+  `docs/adr/`.
+- **Root `docs/`** — only for cross-cutting documents that span multiple modules.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence and
+don't suggest creating them upfront — they are created lazily, when a term or decision
+actually gets resolved.
+
+## File structure
+
+```
+/
+└── app-modules/
+    ├── billing/
+    │   ├── CONTEXT.md                     <- module glossary
+    │   ├── ARCHITECTURE.md                <- module structure & flows
+    │   └── docs/adr/                      <- module-scoped decisions (billing/0001…)
+    ├── appointments/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                      <- appointments/0001…
+    └── ...
+```
+
+All ADRs live under their owning module. Cross-cutting decisions live with the module
+that owns them.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (an issue title, a refactor proposal, a
+hypothesis, a test name), use the term as defined in that module's `CONTEXT.md`. Don't
+drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're
+inventing language the project doesn't use (reconsider) or there's a real gap (note it).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently
+overriding:
+
+> _Contradicts ADR billing/0001 — but worth reopening because..._

--- a/.ai/guidelines/workflow/issue-tracker.blade.php
+++ b/.ai/guidelines/workflow/issue-tracker.blade.php
@@ -1,0 +1,29 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues on `3pontos-tech/gil-benefits`.
+Use the `gh` CLI for all operations — pass `--json` for structured output and `--jq`
+for filtering.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for
+  multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`.
+- **List issues**: `gh issue list --state open --json number,title,labels --jq '[.[] | {number, title, labels: [.labels[].name]}]'`
+  with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a
+clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+See the `triage-labels` guideline for the label and title conventions.

--- a/.ai/guidelines/workflow/triage-labels.blade.php
+++ b/.ai/guidelines/workflow/triage-labels.blade.php
@@ -1,0 +1,92 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to
+the actual label strings used in this repo's issue tracker.
+
+| Label in skills   | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the
+corresponding label string from this table.
+
+---
+
+# Type Labels
+
+Issue type follows conventional commit prefixes.
+
+| Label           | Meaning                       |
+| --------------- | ----------------------------- |
+| `type:feat`     | New feature                   |
+| `type:fix`      | Bug fix                       |
+| `type:refactor` | Code refactoring              |
+| `type:docs`     | Documentation                 |
+| `type:prd`      | Product Requirements Document |
+| `type:chore`    | Maintenance / tooling         |
+| `type:ci`       | CI / build pipeline           |
+
+---
+
+# Module Labels
+
+Every issue must be tagged with the module(s) it affects. Labels follow the pattern
+`mod:<module-name>`, matching the directory name under `app-modules/`.
+
+| Label                              | Module directory               | Description               |
+| ---------------------------------- | ------------------------------ | ------------------------- |
+| `mod:appointments`                 | `appointments`                 | Scheduling & appointments |
+| `mod:billing`                      | `billing`                      | Subscriptions & billing   |
+| `mod:company`                      | `company`                      | Companies (tenants)       |
+| `mod:consultants`                  | `consultants`                  | Consultants & documents   |
+| `mod:integration-google-calendar` | `integration-google-calendar`  | Google Calendar sync      |
+| `mod:integration-highlevel`        | `integration-highlevel`        | HighLevel integration     |
+| `mod:panel-admin`                  | `panel-admin`                  | Admin Filament panel      |
+| `mod:panel-app`                    | `panel-app`                    | End-user Filament panel   |
+| `mod:panel-company`                | `panel-company`                | Company Filament panel    |
+| `mod:panel-consultant`             | `panel-consultant`             | Consultant Filament panel |
+| `mod:permissions`                  | `permissions`                  | RBAC & permissions        |
+| `mod:support`                      | `support`                      | Support tickets           |
+| `mod:tenant`                       | `tenant`                       | Tenancy scaffolding       |
+| `mod:user`                         | `user`                         | Users & anamnese          |
+
+When creating an issue for a new module that has no label yet, create the label first
+(`gh label create "mod:<name>" --description "<short description>" --color "c2e0c6"`)
+and add a row to this table.
+
+---
+
+# Difficulty Labels
+
+Every implementable issue should be tagged with a difficulty estimate.
+
+| Label                | Estimate  | Meaning                                          |
+| -------------------- | --------- | ------------------------------------------------ |
+| `difficulty:trivial` | < 1 day   | Deletion, config changes, scripts                |
+| `difficulty:easy`    | 1-2 days  | Single model/action, well-defined scope          |
+| `difficulty:medium`  | 3-5 days  | Multiple files, Filament UI, moderate complexity |
+| `difficulty:hard`    | 1-2 weeks | Cross-module, complex logic, multiple panels     |
+| `difficulty:epic`    | 2+ weeks  | Entire new system, major refactors               |
+
+Issues tagged `difficulty:trivial` or `difficulty:easy` should also receive the
+`good first issue` label.
+
+---
+
+# Title Convention
+
+Issue titles follow **conventional commits** with the module as scope:
+
+```
+<type>(<module>): <short description in English>
+```
+
+Examples:
+- `feat(appointments): reschedule flow with Google Calendar sync`
+- `refactor(billing): consolidate plan tier resolution`
+- `fix(panel-company): tenant slug not resolved on invite link`
+- `prd(consultants): document sharing MVP`

--- a/app-modules/permissions/resources/boost/guidelines/core.blade.php
+++ b/app-modules/permissions/resources/boost/guidelines/core.blade.php
@@ -1,5 +1,5 @@
 ## Permissions - RBAC system built on Spatie/laravel-permission with custom table names and sync commands. - Namespace:
-`He4rt\Permissions\`. No translation namespace (uses config-driven labels). ### Models - **Permission** (extends
+`TresPontosTech\Permissions\`. No translation namespace (uses config-driven labels). ### Models - **Permission** (extends
 `Spatie\Permission\Models\Permission`) — Custom permission model using `rbac_permissions` table. - Extra fields:
 `resource`, `action`, `resource_group`. - Computed attributes: `formatted_name`, `resource_model`. - **Role** (extends
 `Spatie\Permission\Models\Role`) — Custom role model using `rbac_roles` table. - Uses UUID primary key. Relationships:

--- a/boost.json
+++ b/boost.json
@@ -3,6 +3,7 @@
         "opencode",
         "claude_code"
     ],
+    "cloud": false,
     "guidelines": true,
     "mcp": true,
     "nightwatch_mcp": false,
@@ -15,7 +16,9 @@
     ],
     "sail": false,
     "skills": [
+        "cashier-stripe-development",
         "laravel-best-practices",
+        "configure-nightwatch",
         "pest-testing",
         "tailwindcss-development",
         "modular",


### PR DESCRIPTION
## Problema

As guidelines do Boost foram trazidas de outro projeto (he4rt) e estavam acopladas àquela realidade: namespace `He4rt\`, `APP_TIMEZONE=UTC`, módulo `docs`/portal e tracker `he4rt-bot-api`. Faltava um conjunto adaptado ao gil-benefits.

## Solução

Adiciona 10 guidelines em `.ai/guidelines/` (descobertas recursivamente pelo Boost), adaptadas aos fatos reais do projeto:

- **Namespace** `TresPontosTech\{Module}` e pacotes `3pontos-tech/*`; padrão **alvo** `TresPontosTech\Panel{Name}` para os módulos `panel-*`.
- **Multi-tenancy**: tenant = `Company` (Filament-native, panels `app`/`company`); sem model `Tenant` nem `ApplyTenantScopes` — isolamento híbrido.
- **ServiceProvider** em `src/Providers/` (padrão dominante, 11/14 módulos).
- **Tracker** = `3pontos-tech/gil-benefits` + labels `mod:*` dos 14 módulos reais.
- **Docs/ADR** como convenção co-localizada por módulo, **sem portal**, com matriz de tipos de doc e suas fronteiras (spec/plan/prd/adr/README/CONTEXT) e override explícito do path default das skills `brainstorm`/`grill-me`/`writing-plans`.

Também corrige o namespace `He4rt\Permissions\` → `TresPontosTech\Permissions\` na guideline já existente do módulo `permissions`.

> Nota: a guideline de arquitetura crava o **alvo** `Panel{Name}` para os panels; o código (`Admin`, `App`, `Consultants`) será alinhado em PR futuro.

## Arquivos Alterados

- `.ai/guidelines/{domain,presentation,tooling,workflow}/*.blade.php` — 10 guidelines novas
- `app-modules/permissions/resources/boost/guidelines/core.blade.php` — fix de namespace
- `boost.json` — sync gerado pelo `boost:update`

O gate de pre-push (rector, pint, phpstan, pest) passou. `CLAUDE.md` é gerado pelo Boost e gitignored — não entra no diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project guidelines covering module architecture, multi-tenancy patterns, and documentation standards.
  * Introduced workflow guidance for issue tracking, triage labeling, and documentation authoring conventions.
  * Added domain architecture and presentation layer guidelines.

* **Chores**
  * Updated project configuration with new settings and expanded development skills.
  * Updated namespace references in permissions module documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->