### PR TITLE
hotfix: standalone-subscription

### DIFF
--- a/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
+++ b/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
@@ -53,6 +53,7 @@ class HandleBarteWebhook
 
         $planUuid = $dto->metadata->get('barte_plan_uuid');
         $cycleType = $dto->metadata->get('barte_cycle_type');
+        $priceId = $dto->metadata->get('barte_price_id');
 
         $quantity = $dto->metadata->get('quantity');
 
@@ -61,10 +62,10 @@ class HandleBarteWebhook
             : 'default';
 
         $event = match ($dto->event) {
-            BarteWebhookEventEnum::SubscriptionPending => new SubscriptionCreated(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'pending', $planUuid, $cycleType, $quantity, planSlug: $planSlug)),
-            BarteWebhookEventEnum::SubscriptionActive => new SubscriptionActivated(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'active', $planUuid, $cycleType, $quantity, planSlug: $planSlug)),
-            BarteWebhookEventEnum::SubscriptionDefaulter => new SubscriptionDefaulted(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'defaulter', $planUuid, $cycleType, $quantity, planSlug: $planSlug)),
-            BarteWebhookEventEnum::SubscriptionInactive => new SubscriptionCancelled(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'inactive', $planUuid, $cycleType, $quantity, Date::now(), $planSlug)),
+            BarteWebhookEventEnum::SubscriptionPending => new SubscriptionCreated(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'pending', $planUuid, $cycleType, $quantity, planSlug: $planSlug, priceId: $priceId)),
+            BarteWebhookEventEnum::SubscriptionActive => new SubscriptionActivated(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'active', $planUuid, $cycleType, $quantity, planSlug: $planSlug, priceId: $priceId)),
+            BarteWebhookEventEnum::SubscriptionDefaulter => new SubscriptionDefaulted(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'defaulter', $planUuid, $cycleType, $quantity, planSlug: $planSlug, priceId: $priceId)),
+            BarteWebhookEventEnum::SubscriptionInactive => new SubscriptionCancelled(SubscriptionDTO::make($billingCustomer, $dto->uuid, 'inactive', $planUuid, $cycleType, $quantity, Date::now(), $planSlug, priceId: $priceId)),
             default => null,
         };
 

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -110,6 +110,7 @@ final readonly class BarteAdapter implements BillingContract
                 ['key' => 'billable_type', 'value' => $billable->getMorphClass()],
                 ['key' => 'billable_id', 'value' => (string) $billable->getKey()],
                 ['key' => 'barte_plan_uuid', 'value' => $planUuid],
+                ['key' => 'barte_price_id', 'value' => $data->priceId],
                 ['key' => 'quantity', 'value' => (string) $data->quantity],
             ],
             paymentSubscription: new PaymentSubscriptionDto(

--- a/app-modules/billing/src/Core/DTOs/SubscriptionDTO.php
+++ b/app-modules/billing/src/Core/DTOs/SubscriptionDTO.php
@@ -29,13 +29,17 @@ final readonly class SubscriptionDTO
         int|string $quantity,
         ?Carbon $endsAt = null,
         string $planSlug = 'default',
+        ?string $priceId = null,
     ): self {
         return new self(
             billableType: $billingCustomer->billable_type,
             billableId: $billingCustomer->billable_id,
             subscriptionExternalId: $subscriptionExternalId,
             status: $status,
-            planExternalId: $planUuid ? ($cycleType ? sprintf('%s-%s', $planUuid, $cycleType) : $planUuid) : null,
+            // Persist the exact price the buyer checked out with (e.g. flamma's
+            // standalone-user price) so tenant-specific pricing is not collapsed onto
+            // the shared plan id. Falls back to the plan id when no price was provided.
+            planExternalId: $priceId ?? ($planUuid ? ($cycleType ? sprintf('%s-%s', $planUuid, $cycleType) : $planUuid) : null),
             planSlug: $planSlug,
             quantity: (int) $quantity,
             endsAt: $endsAt,

--- a/app-modules/billing/tests/Feature/Subscription/BarteCheckoutMetadataTest.php
+++ b/app-modules/billing/tests/Feature/Subscription/BarteCheckoutMetadataTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use TresPontosTech\Billing\Barte\BarteAdapter;
+use TresPontosTech\Billing\Barte\BarteClient;
+use TresPontosTech\Billing\Core\DTOs\CheckoutData;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Models\BillingCustomer;
+use TresPontosTech\Billing\Core\Models\Plan;
+use TresPontosTech\Billing\Core\Models\Price;
+
+// Ensures the checkout forwards the chosen price id to Barte so the webhook can persist it
+// (flamma's standalone-user price must survive the round-trip).
+
+it('sends the chosen price id to Barte as barte_price_id metadata', function (): void {
+    config(['services.barte.base_url' => 'https://api.barte.test']);
+
+    Http::fake([
+        '*' => Http::response(['url' => 'https://pay.barte.test/checkout']),
+    ]);
+
+    $user = User::factory()->create();
+    $plan = Plan::factory()->barte()->active()->create(['provider_product_id' => 'plan-uuid']);
+
+    $price = Price::factory()->for($plan, 'plan')->create([
+        'provider_price_id' => 'plan-uuid-standalone-user',
+        'unit_amount_decimal' => 25000,
+        'metadata' => ['tenant' => 'flamma-company'],
+    ]);
+
+    BillingCustomer::factory()->create([
+        'billable_type' => $user->getMorphClass(),
+        'billable_id' => $user->getKey(),
+        'provider' => BillingProviderEnum::Barte,
+        'provider_customer_id' => 'buyer-uuid',
+    ]);
+
+    $data = new CheckoutData(
+        planSlug: $plan->slug,
+        priceId: $price->provider_price_id,
+        isMetered: false,
+        quantity: 1,
+        trialDays: null,
+        allowPromotionCodes: false,
+        collectTaxIds: false,
+        successUrl: 'https://app.test/success',
+        cancelUrl: 'https://app.test/cancel',
+    );
+
+    $url = (new BarteAdapter(new BarteClient))->createCheckout($user, $data);
+
+    expect($url)->toBe('https://pay.barte.test/checkout');
+
+    Http::assertSent(function (Request $request) use ($price): bool {
+        $metadata = $request->data()['metadata'] ?? [];
+
+        return collect($metadata)->contains(
+            fn (array $entry): bool => $entry['key'] === 'barte_price_id'
+                && $entry['value'] === $price->provider_price_id
+        );
+    });
+});

--- a/app-modules/billing/tests/Feature/Webhook/HandleBarteWebhookTest.php
+++ b/app-modules/billing/tests/Feature/Webhook/HandleBarteWebhookTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Event;
+use TresPontosTech\Billing\Barte\Actions\HandleBarteWebhook;
+use TresPontosTech\Billing\Barte\DTOs\BarteWebhookDto;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionActivated;
+use TresPontosTech\Billing\Core\Models\BillingCustomer;
+use TresPontosTech\Billing\Core\Models\Plan;
+
+// These tests cover the flamma fix: the Barte webhook must persist the exact price the
+// buyer checked out with (carried in `barte_price_id`) so tenant-specific prices such as
+// `<uuid>-standalone-user` are not collapsed onto the shared plan id.
+
+function bartePayload(string $planUuid, array $extraMetadata = []): array
+{
+    $metadata = array_merge([
+        'barte_plan_uuid' => $planUuid,
+        'quantity' => '1',
+    ], $extraMetadata);
+
+    return [
+        'uuid' => 'sub_' . uniqid(),
+        'domain' => 'SUBSCRIPTION',
+        'status' => 'ACTIVE',
+        'uuidBuyer' => 'buyer-uuid',
+        'metadata' => collect($metadata)
+            ->map(fn ($value, $key): array => ['key' => $key, 'value' => $value])
+            ->values()
+            ->all(),
+    ];
+}
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->plan = Plan::factory()->barte()->active()->create(['provider_product_id' => 'plan-uuid']);
+
+    BillingCustomer::factory()->create([
+        'billable_type' => $this->user->getMorphClass(),
+        'billable_id' => $this->user->getKey(),
+        'provider' => BillingProviderEnum::Barte,
+        'provider_customer_id' => 'buyer-uuid',
+    ]);
+});
+
+it('persists the checked-out price id as the subscription external plan id', function (): void {
+    Event::fake([SubscriptionActivated::class]);
+
+    $payload = bartePayload('plan-uuid', ['barte_price_id' => 'plan-uuid-standalone-user']);
+
+    resolve(HandleBarteWebhook::class)->handle(BarteWebhookDto::fromArray($payload));
+
+    Event::assertDispatched(
+        SubscriptionActivated::class,
+        fn (SubscriptionActivated $event): bool => $event->dto->planExternalId === 'plan-uuid-standalone-user'
+    );
+});
+
+it('falls back to the plan uuid when the webhook carries no price id', function (): void {
+    Event::fake([SubscriptionActivated::class]);
+
+    $payload = bartePayload('plan-uuid');
+
+    resolve(HandleBarteWebhook::class)->handle(BarteWebhookDto::fromArray($payload));
+
+    Event::assertDispatched(
+        SubscriptionActivated::class,
+        fn (SubscriptionActivated $event): bool => $event->dto->planExternalId === 'plan-uuid'
+    );
+});

--- a/app-modules/billing/tests/Unit/SubscriptionDTOTest.php
+++ b/app-modules/billing/tests/Unit/SubscriptionDTOTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
+use TresPontosTech\Billing\Core\Models\BillingCustomer;
+
+function fakeBillingCustomer(): BillingCustomer
+{
+    $customer = new BillingCustomer;
+    $customer->billable_type = 'user';
+    $customer->billable_id = 1;
+
+    return $customer;
+}
+
+it('uses the provided price id as the external plan id (e.g. flamma standalone-user price)', function (): void {
+    $dto = SubscriptionDTO::make(
+        fakeBillingCustomer(),
+        'sub_uuid',
+        'active',
+        'plan_uuid',
+        null,
+        1,
+        priceId: 'plan_uuid-standalone-user',
+    );
+
+    expect($dto->planExternalId)->toBe('plan_uuid-standalone-user');
+});
+
+it('falls back to the plan uuid when no price id is provided', function (): void {
+    $dto = SubscriptionDTO::make(
+        fakeBillingCustomer(),
+        'sub_uuid',
+        'active',
+        'plan_uuid',
+        null,
+        1,
+    );
+
+    expect($dto->planExternalId)->toBe('plan_uuid');
+});
+
+it('prefers the price id over the plan uuid + cycle composition', function (): void {
+    $dto = SubscriptionDTO::make(
+        fakeBillingCustomer(),
+        'sub_uuid',
+        'active',
+        'plan_uuid',
+        'MONTHLY',
+        1,
+        priceId: 'plan_uuid-standalone-user',
+    );
+
+    expect($dto->planExternalId)->toBe('plan_uuid-standalone-user');
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout requests now carry the selected provider price, helping preserve the exact pricing chosen at purchase time.
  * Subscription updates from Barte now retain that price information across lifecycle events.

* **Bug Fixes**
  * Fixed subscription handling so the correct price is used when available, with a safe fallback to the plan-based value when it isn’t.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->