### PR TITLE
fix(panel-app): validate tax_id and document_id uniqueness on registr…

### DIFF
--- a/app-modules/panel-app/src/Filament/Pages/UserRegistration.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserRegistration.php
@@ -10,6 +10,7 @@ use Closure;
 use Filament\Auth\Pages\Register;
 use Filament\Forms\Components\Field;
 use Filament\Schemas\Schema;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Override;
 use TresPontosTech\Permissions\Roles;
@@ -41,9 +42,11 @@ final class UserRegistration extends Register
      * distinct), so this application rule is what actually enforces it.
      * tax_id passes withTrashed to mirror its plain column-level constraint.
      */
-    private function uniqueDetailRule(string $column, ?string $attributeLabel, bool $withTrashed = false): Closure
+    private function uniqueDetailRule(string $column, Htmlable|string|null $attributeLabel, bool $withTrashed = false): Closure
     {
-        return static function (string $attribute, mixed $value, Closure $fail) use ($column, $attributeLabel, $withTrashed): void {
+        $label = $attributeLabel instanceof Htmlable ? $attributeLabel->toHtml() : $attributeLabel;
+
+        return static function (string $attribute, mixed $value, Closure $fail) use ($column, $label, $withTrashed): void {
             $normalized = preg_replace('/\D/', '', (string) $value);
 
             if ($normalized === null || $normalized === '') {
@@ -57,7 +60,7 @@ final class UserRegistration extends Register
             }
 
             if ($query->exists()) {
-                $fail(__('validation.unique', ['attribute' => $attributeLabel ?? $attribute]));
+                $fail(__('validation.unique', ['attribute' => $label ?? $attribute]));
             }
         };
     }

--- a/app-modules/panel-app/src/Filament/Pages/UserRegistration.php
+++ b/app-modules/panel-app/src/Filament/Pages/UserRegistration.php
@@ -4,8 +4,11 @@ namespace TresPontosTech\PanelApp\Filament\Pages;
 
 use App\Filament\Shared\Fields\DocumentIdInput;
 use App\Filament\Shared\Fields\TaxIdInput;
+use App\Models\Users\Detail;
 use App\Models\Users\User;
+use Closure;
 use Filament\Auth\Pages\Register;
+use Filament\Forms\Components\Field;
 use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Model;
 use Override;
@@ -20,11 +23,43 @@ final class UserRegistration extends Register
         return parent::form($schema)->components([
             $this->getNameFormComponent(),
             $this->getEmailFormComponent(),
-            TaxIdInput::make(),
-            DocumentIdInput::make(),
+            TaxIdInput::make()
+                ->rule(fn (Field $component): Closure => $this->uniqueDetailRule('tax_id', $component->getLabel(), withTrashed: true)),
+            DocumentIdInput::make()
+                ->rule(fn (Field $component): Closure => $this->uniqueDetailRule('document_id', $component->getLabel())),
             $this->getPasswordFormComponent(),
             $this->getPasswordConfirmationFormComponent(),
         ]);
+    }
+
+    /**
+     * Validate uniqueness against the dehydrated (unmasked) value, since the
+     * form state is masked but the column stores only digits.
+     *
+     * The database constraint on (document_id, deleted_at) does not prevent
+     * duplicates among active rows (Postgres treats NULL deleted_at as
+     * distinct), so this application rule is what actually enforces it.
+     * tax_id passes withTrashed to mirror its plain column-level constraint.
+     */
+    private function uniqueDetailRule(string $column, ?string $attributeLabel, bool $withTrashed = false): Closure
+    {
+        return static function (string $attribute, mixed $value, Closure $fail) use ($column, $attributeLabel, $withTrashed): void {
+            $normalized = preg_replace('/\D/', '', (string) $value);
+
+            if ($normalized === null || $normalized === '') {
+                return;
+            }
+
+            $query = Detail::query()->where($column, $normalized);
+
+            if ($withTrashed) {
+                $query->withTrashed();
+            }
+
+            if ($query->exists()) {
+                $fail(__('validation.unique', ['attribute' => $attributeLabel ?? $attribute]));
+            }
+        };
     }
 
     #[Override]

--- a/app-modules/panel-app/tests/Feature/Filament/UserRegistrationTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/UserRegistrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Users\Detail;
 use App\Models\Users\User;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelApp\Filament\Pages\UserRegistration;
@@ -7,6 +8,7 @@ use TresPontosTech\PanelApp\Filament\Pages\UserRegistration;
 use function Pest\Laravel\assertAuthenticatedAs;
 use function Pest\Laravel\assertDatabaseCount;
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 use function Pest\Livewire\livewire;
 
 it('should render', function (): void {
@@ -39,4 +41,43 @@ it('should register user to flamma company', function (): void {
     assertAuthenticatedAs($user);
     expect($user->companies()->first()->slug)->toBe($flammaCompany->slug)
         ->and($user->isEmployee())->toBeTrue();
+});
+
+it('should not register a user with a tax_id that already exists', function (): void {
+    Detail::factory()->create(['tax_id' => '56259004770']);
+
+    livewire(UserRegistration::class)
+        ->assertOk()
+        ->fillForm([
+            'name' => 'John',
+            'email' => 'joe@doe.com',
+            'password' => 'password123',
+            'passwordConfirmation' => 'password123',
+            'tax_id' => '562.590.047-70',
+        ])
+        ->call('register')
+        ->assertHasFormErrors(['tax_id']);
+
+    assertDatabaseMissing(User::class, ['email' => 'joe@doe.com']);
+    assertDatabaseCount(Detail::class, 1);
+});
+
+it('should not register a user with a document_id that already exists', function (): void {
+    Detail::factory()->create(['document_id' => '1234567890']);
+
+    livewire(UserRegistration::class)
+        ->assertOk()
+        ->fillForm([
+            'name' => 'John',
+            'email' => 'joe@doe.com',
+            'password' => 'password123',
+            'passwordConfirmation' => 'password123',
+            'tax_id' => '562.590.047-70',
+            'document_id' => '123.456.789-0',
+        ])
+        ->call('register')
+        ->assertHasFormErrors(['document_id']);
+
+    assertDatabaseMissing(User::class, ['email' => 'joe@doe.com']);
+    assertDatabaseCount(Detail::class, 1);
 });


### PR DESCRIPTION
…ation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now rejects duplicate tax ID and document ID values before creating an account.
  * Duplicate checks normalize entered values, so formatting differences like spaces or punctuation won’t bypass validation.
  * Tax ID validation also considers previously removed records, while document ID validation checks active records only.
* **Tests**
  * Added coverage for duplicate registration scenarios to confirm form errors are shown and no user record is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->