### PR TITLE
feat(auth): redirect by profile on unauthorized page access

### DIFF
--- a/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
+++ b/app-modules/billing/src/Stripe/Subscription/User/RedirectUserIfNotSubscribed.php
@@ -45,7 +45,19 @@ readonly class RedirectUserIfNotSubscribed
             $hasActiveSubscription = true;
         }
 
-        abort_unless($hasActiveSubscription, 403);
+        // Company never paid or cancelled its plan: the member cannot fix the
+        // billing themselves, so instead of a bare 403 we send them to a page
+        // that explains the situation (ÉPICO 56).
+        if (! $hasActiveSubscription) {
+            $inactiveRoute = 'filament.app.pages.company-plan-inactive';
+
+            if ($request->routeIs($inactiveRoute)) {
+                return $next($request);
+            }
+
+            return to_route($inactiveRoute, ['tenant' => $tenant->slug]);
+        }
+
         $employee = auth()->user();
 
         // TODO: Employee needs to pick a plan to continue

--- a/app-modules/billing/tests/Feature/Middleware/RedirectUserIfNotSubscribedTest.php
+++ b/app-modules/billing/tests/Feature/Middleware/RedirectUserIfNotSubscribedTest.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Http;
 use Laravel\Cashier\Cashier;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
 use TresPontosTech\Billing\Core\Models\CompanyPlan;
 use TresPontosTech\Billing\Core\Models\Plan;
@@ -51,29 +50,38 @@ it('allows access when company has an active contractual plan', function (): voi
     expect($response->getContent())->toBe('ok');
 });
 
-it('aborts with 403 when company has no stripe subscription', function (): void {
-    $this->middleware->handle($this->request, $this->next);
-})->throws(HttpException::class);
+it('redirects to the plan-inactive page when company has no stripe subscription', function (): void {
+    $response = $this->middleware->handle($this->request, $this->next);
 
-it('aborts with 403 when company subscription is past_due', function (): void {
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('company-plan-inactive');
+});
+
+it('redirects to the plan-inactive page when company subscription is past_due', function (): void {
     $this->company->subscriptions()->create([
         'type' => 'company',
         'stripe_id' => 'sub_pastdue_' . uniqid(),
         'stripe_status' => 'past_due',
     ]);
 
-    $this->middleware->handle($this->request, $this->next);
-})->throws(HttpException::class);
+    $response = $this->middleware->handle($this->request, $this->next);
 
-it('aborts with 403 when company subscription is canceled', function (): void {
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('company-plan-inactive');
+});
+
+it('redirects to the plan-inactive page when company subscription is canceled', function (): void {
     $this->company->subscriptions()->create([
         'type' => 'company',
         'stripe_id' => 'sub_canceled_' . uniqid(),
         'stripe_status' => 'canceled',
     ]);
 
-    $this->middleware->handle($this->request, $this->next);
-})->throws(HttpException::class);
+    $response = $this->middleware->handle($this->request, $this->next);
+
+    expect($response->getStatusCode())->toBe(302)
+        ->and($response->headers->get('Location'))->toContain('company-plan-inactive');
+});
 
 it('bypasses 403 check for flamma-company tenant', function (): void {
     $flammaCompany = Company::factory()->create([

--- a/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
+++ b/app-modules/billing/tests/Feature/Subscription/LegacySubscriberAccessTest.php
@@ -8,7 +8,6 @@ use App\Filament\FilamentPanel;
 use App\Models\Users\User;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Tests\Fakes\FakeBillingContract;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Enums\BillableTypeEnum;
@@ -218,14 +217,16 @@ describe('user access during gateway migration', function (): void {
         expect($response->getContent())->toBe('ok');
     });
 
-    it('blocks with 403 when the company itself has no active subscription on any provider', function (): void {
+    it('redirects to the plan-inactive page when the company has no active subscription on any provider', function (): void {
         $middleware = makeUserMiddleware(
             stripe: new FakeBillingContract(isSubscribed: false, hasActiveSubscription: false),
             barte: new FakeBillingContract(isSubscribed: false, hasActiveSubscription: false),
         );
 
-        expect(fn (): Symfony\Component\HttpFoundation\Response => $middleware->handle(fakeRequest(), passThrough()))
-            ->toThrow(HttpException::class);
+        $response = $middleware->handle(fakeRequest(), passThrough());
+
+        expect($response->getStatusCode())->toBe(302)
+            ->and($response->headers->get('Location'))->toContain('company-plan-inactive');
     });
 
     it('redirects a user to the plans page when the company is subscribed but the user has not picked a plan yet', function (): void {

--- a/app-modules/panel-app/src/Filament/Pages/CompanyPlanInactive.php
+++ b/app-modules/panel-app/src/Filament/Pages/CompanyPlanInactive.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelApp\Filament\Pages;
+
+use Filament\Pages\Page;
+use Filament\Support\Enums\Width;
+use TresPontosTech\Company\Models\Company;
+
+/**
+ * Shown to an authenticated member of a company whose plan is inactive (never
+ * paid or cancelled), instead of a bare 403. The member cannot fix the billing
+ * themselves, so the page explains the situation and points them to their
+ * company admin/manager. It is reachable through
+ * `RedirectUserIfNotSubscribed`, which exempts this route to avoid a loop.
+ */
+class CompanyPlanInactive extends Page
+{
+    protected static ?string $slug = 'company-plan-inactive';
+
+    protected static string $layout = 'filament-panels::components.layout.simple';
+
+    protected Width|string|null $maxContentWidth = Width::Medium;
+
+    protected string $view = 'company-plan-inactive';
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    public function getTitle(): string
+    {
+        return __('views.company_plan_inactive.title');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getViewData(): array
+    {
+        $tenant = filament()->getTenant();
+
+        return [
+            'companyName' => $tenant instanceof Company ? $tenant->name : '',
+        ];
+    }
+}

--- a/app-modules/panel-app/tests/Feature/Filament/CompanyPlanInactiveTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/CompanyPlanInactiveTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use TresPontosTech\Company\Models\Company;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+/**
+ * ÉPICO 56 — a member of a company whose plan is inactive (never paid or
+ * cancelled) is sent to a friendly "plan inactive" page instead of a bare 403.
+ */
+beforeEach(function (): void {
+    $this->employee = User::factory()->employee()->create();
+    $this->company = Company::factory()->createOne();
+    $this->company->employees()->attach($this->employee->getKey());
+
+    filament()->setCurrentPanel(FilamentPanel::User->value);
+    actingAs($this->employee);
+    filament()->setTenant($this->company);
+});
+
+it('redirects a member of an unpaid company to the plan-inactive page instead of a 403', function (): void {
+    $response = get(route('filament.app.pages.user-dashboard', ['tenant' => $this->company->slug]));
+
+    $response->assertStatus(302);
+    expect($response->headers->get('Location'))->toContain('company-plan-inactive');
+});
+
+it('renders the plan-inactive page without looping', function (): void {
+    get(route('filament.app.pages.company-plan-inactive', ['tenant' => $this->company->slug]))
+        ->assertOk()
+        ->assertSee($this->company->name);
+});

--- a/app-modules/panel-app/tests/Feature/Filament/CompanyPlanInactiveTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/CompanyPlanInactiveTest.php
@@ -27,6 +27,7 @@ it('redirects a member of an unpaid company to the plan-inactive page instead of
     $response = get(route('filament.app.pages.user-dashboard', ['tenant' => $this->company->slug]));
 
     $response->assertStatus(302);
+
     expect($response->headers->get('Location'))->toContain('company-plan-inactive');
 });
 

--- a/app-modules/panel-company/tests/Feature/Filament/TenantAccessManagerTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/TenantAccessManagerTest.php
@@ -42,25 +42,22 @@ describe('company manager tenant isolation', function (): void {
         actingAs($this->manager);
     });
 
-    it('returns 404 when trying to access another company dashboard', function (): void {
-        get(route('filament.company.pages.dashboard', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
+    // ÉPICO 56: an authenticated user who opens a company they are not part of
+    // is redirected to their own company home instead of getting a bare 404.
+    // Tenant isolation still holds — they never see the other company's data.
+    it('redirects to own company instead of exposing another company', function (string $route): void {
+        $response = get(route($route, ['tenant' => $this->otherCompany->slug]));
 
-    it('returns 404 when trying to access another company credits page', function (): void {
-        get(route('filament.company.pages.credits', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
-
-    it('returns 404 when trying to access another company profile', function (): void {
-        get(route('filament.company.tenant.profile', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
-
-    it('returns 404 when trying to access another company billing', function (): void {
-        get(route('filament.company.tenant.billing', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))
+            ->toContain($this->managedCompany->slug)
+            ->not->toContain($this->otherCompany->slug);
+    })->with([
+        'dashboard' => ['filament.company.pages.dashboard'],
+        'credits page' => ['filament.company.pages.credits'],
+        'profile' => ['filament.company.tenant.profile'],
+        'billing' => ['filament.company.tenant.billing'],
+    ]);
 
     it('allows access to the managed company dashboard', function (): void {
         get(route('filament.company.pages.dashboard', ['tenant' => $this->managedCompany->slug]))

--- a/app-modules/panel-company/tests/Feature/Filament/TenantAccessTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/TenantAccessTest.php
@@ -41,25 +41,22 @@ describe('tenant isolation: no relationship with the other company', function ()
         actingAs($this->owner);
     });
 
-    it('returns 404 when trying to access another company dashboard', function (): void {
-        get(route('filament.company.pages.dashboard', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
+    // ÉPICO 56: opening a company the user has no relationship with now
+    // redirects them to their own company home instead of a bare 404.
+    // Isolation still holds — the other company's data is never exposed.
+    it('redirects to own company instead of exposing another company', function (string $route): void {
+        $response = get(route($route, ['tenant' => $this->otherCompany->slug]));
 
-    it('returns 404 when trying to access another company credits page', function (): void {
-        get(route('filament.company.pages.credits', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
-
-    it('returns 404 when trying to access another company profile', function (): void {
-        get(route('filament.company.tenant.profile', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
-
-    it('returns 404 when trying to access another company billing', function (): void {
-        get(route('filament.company.tenant.billing', ['tenant' => $this->otherCompany->slug]))
-            ->assertNotFound();
-    });
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))
+            ->toContain($this->ownCompany->slug)
+            ->not->toContain($this->otherCompany->slug);
+    })->with([
+        'dashboard' => ['filament.company.pages.dashboard'],
+        'credits page' => ['filament.company.pages.credits'],
+        'profile' => ['filament.company.tenant.profile'],
+        'billing' => ['filament.company.tenant.billing'],
+    ]);
 
     it('allows access to own company dashboard', function (): void {
         get(route('filament.company.pages.dashboard', ['tenant' => $this->ownCompany->slug]))

--- a/app/Filament/FilamentPanel.php
+++ b/app/Filament/FilamentPanel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament;
 
 use App\Models\Users\User;
+use Filament\Facades\Filament;
 use Filament\Panel;
 use Illuminate\Support\Facades\Gate;
 use TresPontosTech\Permissions\Roles;
@@ -37,5 +38,42 @@ enum FilamentPanel: string
             self::Consultant => $isConsultant || $isAdmin,
             self::Guest => true,
         };
+    }
+
+    /**
+     * Resolve the panel that represents the given user's own "home", used to
+     * redirect an authenticated user who lands on a page (or a company) outside
+     * their profile.
+     *
+     * Panels are checked in priority order and only a panel the user can
+     * actually access is returned, which guarantees the redirect target never
+     * bounces back into another denial (i.e. no redirect loop). The public
+     * Guest panel is intentionally excluded: it is not a profile home, so a
+     * user with no accessible profile panel resolves to `null` (see homeUrlFor).
+     */
+    public static function homePanelFor(User $user): ?self
+    {
+        foreach ([self::Admin, self::Consultant, self::Company, self::User] as $panel) {
+            if (self::canAccessPanel(Filament::getPanel($panel->value), $user)) {
+                return $panel;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The URL of the given user's profile home, or `null` when the user's
+     * profile has no home panel mapped (the caller should keep the denial).
+     */
+    public static function homeUrlFor(User $user): ?string
+    {
+        $panel = self::homePanelFor($user);
+
+        if ($panel === null) {
+            return null;
+        }
+
+        return Filament::getPanel($panel->value)->getUrl();
     }
 }

--- a/app/Filament/FilamentPanel.php
+++ b/app/Filament/FilamentPanel.php
@@ -70,7 +70,7 @@ enum FilamentPanel: string
     {
         $panel = self::homePanelFor($user);
 
-        if ($panel === null) {
+        if (! $panel instanceof FilamentPanel) {
             return null;
         }
 

--- a/app/Http/Controllers/RedirectToTenantOrShowNoCompany.php
+++ b/app/Http/Controllers/RedirectToTenantOrShowNoCompany.php
@@ -32,7 +32,7 @@ class RedirectToTenantOrShowNoCompany extends RedirectToTenantController
         if ($tenant) {
             $url = $panel->getUrl($tenant);
 
-            if (! blank($url)) {
+            if (filled($url)) {
                 return redirect()->to($url);
             }
         }

--- a/app/Http/Controllers/RedirectToTenantOrShowNoCompany.php
+++ b/app/Http/Controllers/RedirectToTenantOrShowNoCompany.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use Filament\Facades\Filament;
+use Filament\Http\Controllers\RedirectToTenantController;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\RedirectResponse;
+
+/**
+ * Drop-in replacement for Filament's RedirectToTenantController (handler for a
+ * tenant panel's root, e.g. `/app`).
+ *
+ * Mirrors the original, except that a NON-admin who reaches the collaborator
+ * (app) panel without any active company — typically an employee whose
+ * membership is inactive — is shown a friendly "no active company" page instead
+ * of a bare 404. Admins keep Filament's pre-existing behavior (they see every
+ * company and land on one), so they never reach this branch in practice.
+ */
+class RedirectToTenantOrShowNoCompany extends RedirectToTenantController
+{
+    public function __invoke(): RedirectResponse
+    {
+        $panel = Filament::getCurrentOrDefaultPanel();
+        $user = Filament::auth()->user();
+        $tenant = Filament::getUserDefaultTenant($user);
+
+        if ($tenant) {
+            $url = $panel->getUrl($tenant);
+
+            if (! blank($url)) {
+                return redirect()->to($url);
+            }
+        }
+
+        // Keep Filament's registration flow when the panel offers one.
+        if ($panel->hasTenantRegistration() && filament()->getTenantRegistrationPage()::canView()) {
+            $registrationUrl = $panel->getTenantRegistrationUrl();
+
+            if ($registrationUrl !== null) {
+                return redirect()->to($registrationUrl);
+            }
+        }
+
+        // A collaborator with no active company: show a message instead of a 404.
+        if ($user instanceof User && ! $user->isAdmin() && $panel->getId() === FilamentPanel::User->value) {
+            throw new HttpResponseException(response()->view('no-active-company'));
+        }
+
+        abort(404);
+    }
+}

--- a/app/Http/Middleware/AuthenticatePanel.php
+++ b/app/Http/Middleware/AuthenticatePanel.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Http\Middleware\Concerns\RedirectsToProfileHome;
+use App\Models\Users\User;
+use Filament\Facades\Filament;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Models\Contracts\FilamentUser;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Drop-in replacement for Filament's Authenticate middleware.
+ *
+ * It keeps the exact authentication behavior (unauthenticated users are still
+ * sent to the login page) but, instead of aborting with a 403 when an
+ * authenticated user cannot access the current panel, it redirects them to the
+ * home of their own profile. Only `authenticate()` is overridden so that the
+ * parent `handle()` — and therefore Livewire's persistent middleware — keeps
+ * behaving exactly like Filament's original. The redirect is delivered through
+ * an HttpResponseException, which Laravel turns into the response directly.
+ */
+class AuthenticatePanel extends Authenticate
+{
+    use RedirectsToProfileHome;
+
+    /**
+     * @param  array<string>  $guards
+     */
+    protected function authenticate($request, array $guards): void
+    {
+        $guard = Filament::auth();
+
+        // Unauthenticated users keep the current behavior: sent to the login page.
+        if (! $guard->check()) {
+            $this->unauthenticated($request, $guards);
+
+            return; /** @phpstan-ignore-line */
+        }
+
+        $this->auth->shouldUse(Filament::getAuthGuard());
+
+        /** @var Model $user */
+        $user = $guard->user();
+
+        $panel = Filament::getCurrentOrDefaultPanel();
+
+        if ($user instanceof FilamentUser && ! $user->canAccessPanel($panel)) {
+            // Only our own user model can resolve a profile home; anything else
+            // keeps Filament's original 403.
+            if ($user instanceof User) {
+                throw new HttpResponseException($this->profileHomeResponse($request, $user));
+            }
+
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        // Preserve Filament's production safeguard for non-FilamentUser models.
+        abort_if(
+            ! $user instanceof FilamentUser && config('app.env') !== 'local',
+            Response::HTTP_FORBIDDEN,
+        );
+    }
+}

--- a/app/Http/Middleware/Concerns/RedirectsToProfileHome.php
+++ b/app/Http/Middleware/Concerns/RedirectsToProfileHome.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware\Concerns;
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+trait RedirectsToProfileHome
+{
+    /**
+     * Build a redirect to the authenticated user's own profile home, used when
+     * they were denied access to a page/company outside their profile. When the
+     * user's profile has no mapped home the original denial is preserved (403)
+     * and logged so the engineering team can investigate an unexpected, unmapped
+     * profile.
+     */
+    protected function profileHomeResponse(Request $request, User $user): Response
+    {
+        $homeUrl = FilamentPanel::homeUrlFor($user);
+
+        if ($homeUrl === null) {
+            Log::warning('Authenticated user without a mapped profile home was denied access.', [
+                'user_id' => $user->getKey(),
+                'roles' => $user->getRoleNames()->all(),
+                'path' => $request->path(),
+            ]);
+
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        // Defensive loop guard: never redirect a request onto itself.
+        if (rtrim($request->url(), '/') === rtrim((string) strtok($homeUrl, '?'), '/')) {
+            abort(Response::HTTP_FORBIDDEN);
+        }
+
+        return redirect()->to($homeUrl);
+    }
+}

--- a/app/Http/Middleware/Concerns/RedirectsToProfileHome.php
+++ b/app/Http/Middleware/Concerns/RedirectsToProfileHome.php
@@ -34,9 +34,7 @@ trait RedirectsToProfileHome
         }
 
         // Defensive loop guard: never redirect a request onto itself.
-        if (rtrim($request->url(), '/') === rtrim((string) strtok($homeUrl, '?'), '/')) {
-            abort(Response::HTTP_FORBIDDEN);
-        }
+        abort_if(rtrim($request->url(), '/') === rtrim((string) strtok($homeUrl, '?'), '/'), Response::HTTP_FORBIDDEN);
 
         return redirect()->to($homeUrl);
     }

--- a/app/Http/Middleware/IdentifyTenantOrRedirectHome.php
+++ b/app/Http/Middleware/IdentifyTenantOrRedirectHome.php
@@ -38,15 +38,11 @@ class IdentifyTenantOrRedirectHome extends IdentifyTenant
 
         $user = $panel->auth()->user();
 
-        if (! $user instanceof HasTenants) {
-            abort(Response::HTTP_NOT_FOUND);
-        }
+        abort_unless($user instanceof HasTenants, Response::HTTP_NOT_FOUND);
 
         $tenantKey = $request->route()->parameter('tenant');
 
-        if (! is_string($tenantKey)) {
-            abort(Response::HTTP_NOT_FOUND);
-        }
+        abort_unless(is_string($tenantKey), Response::HTTP_NOT_FOUND);
 
         $tenant = $panel->getTenant($tenantKey);
 

--- a/app/Http/Middleware/IdentifyTenantOrRedirectHome.php
+++ b/app/Http/Middleware/IdentifyTenantOrRedirectHome.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Http\Middleware\Concerns\RedirectsToProfileHome;
+use Closure;
+use Filament\Facades\Filament;
+use Filament\Http\Middleware\IdentifyTenant;
+use Filament\Models\Contracts\HasTenants;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Drop-in replacement for Filament's IdentifyTenant middleware.
+ *
+ * Mirrors the original tenant identification exactly, except that an
+ * authenticated user who tries to open a company (tenant) they do not belong to
+ * is redirected to their own profile home instead of receiving a bare 404.
+ * A genuinely missing tenant still resolves to a 404 through `getTenant()`.
+ */
+class IdentifyTenantOrRedirectHome extends IdentifyTenant
+{
+    use RedirectsToProfileHome;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $panel = Filament::getCurrentOrDefaultPanel();
+
+        if (! $panel->hasTenancy()) {
+            return $next($request);
+        }
+
+        if (! $request->route()->hasParameter('tenant')) {
+            return $next($request);
+        }
+
+        $user = $panel->auth()->user();
+
+        if (! $user instanceof HasTenants) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        $tenantKey = $request->route()->parameter('tenant');
+
+        if (! is_string($tenantKey)) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        $tenant = $panel->getTenant($tenantKey);
+
+        if (! $user->canAccessTenant($tenant)) {
+            // Only change from Filament core: an authenticated user is redirected
+            // to their profile home instead of getting a 404 for a company they
+            // are not part of.
+            return $this->profileHomeResponse($request, $user);
+        }
+
+        Filament::setTenant($tenant);
+
+        return $next($request);
+    }
+}

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -3,6 +3,12 @@
 namespace App\Providers;
 
 use App\Filament\FilamentPanel;
+use App\Http\Controllers\RedirectToTenantOrShowNoCompany;
+use App\Http\Middleware\AuthenticatePanel;
+use App\Http\Middleware\IdentifyTenantOrRedirectHome;
+use Filament\Http\Controllers\RedirectToTenantController;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\IdentifyTenant;
 use Filament\Panel;
 use Illuminate\Support\ServiceProvider;
 
@@ -11,10 +17,27 @@ class FilamentServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->configureMacros();
+        $this->overridePanelAccessMiddleware();
     }
 
     public function configureMacros(): void
     {
         Panel::macro('currentPanel', fn (): FilamentPanel => FilamentPanel::from($this->getId()));
+    }
+
+    /**
+     * Swap Filament's access-control handlers for versions that guide an
+     * authenticated user to a useful place instead of showing a raw error:
+     * a 403 (wrong panel) and a 404 (company they are not part of) become a
+     * redirect to their profile home, and a collaborator with no active company
+     * sees a friendly page instead of a 404 on the app panel root. Binding in the
+     * container covers HTTP routes, Livewire persistent middleware and the
+     * tenant-root controller.
+     */
+    public function overridePanelAccessMiddleware(): void
+    {
+        $this->app->bind(Authenticate::class, AuthenticatePanel::class);
+        $this->app->bind(IdentifyTenant::class, IdentifyTenantOrRedirectHome::class);
+        $this->app->bind(RedirectToTenantController::class, RedirectToTenantOrShowNoCompany::class);
     }
 }

--- a/lang/en/views.php
+++ b/lang/en/views.php
@@ -19,4 +19,17 @@ return [
         'per_month' => '/month',
         'complete_subscription' => 'Complete Subscription',
     ],
+    'company_plan_inactive' => [
+        'title' => 'Company plan inactive',
+        'heading' => 'Your company plan is inactive',
+        'description' => ':company does not currently have an active plan, so access to the platform is temporarily suspended.',
+        'instruction' => 'Please contact your company administrator or manager to renew the subscription. Once the plan is reactivated, your access is restored automatically.',
+        'logout' => 'Log out',
+    ],
+    'no_company' => [
+        'title' => 'No active company',
+        'heading' => 'You are not in any active company',
+        'body' => 'Your company membership is not active right now, so there is no collaborator area to show. Please contact your company administrator or manager to restore your access.',
+        'logout' => 'Log out',
+    ],
 ];

--- a/lang/pt_BR/views.php
+++ b/lang/pt_BR/views.php
@@ -19,4 +19,17 @@ return [
         'per_month' => '/mês',
         'complete_subscription' => 'Finalizar Assinatura',
     ],
+    'company_plan_inactive' => [
+        'title' => 'Plano da empresa inativo',
+        'heading' => 'O plano da sua empresa está inativo',
+        'description' => 'No momento :company não possui um plano ativo, por isso o acesso à plataforma está temporariamente suspenso.',
+        'instruction' => 'Fale com o administrador ou gestor da sua empresa para regularizar a assinatura. Assim que o plano for reativado, seu acesso volta automaticamente.',
+        'logout' => 'Sair da conta',
+    ],
+    'no_company' => [
+        'title' => 'Nenhuma empresa ativa',
+        'heading' => 'Você não está em nenhuma empresa ativa',
+        'body' => 'Seu vínculo com uma empresa não está ativo no momento, por isso não há uma área de colaborador para exibir. Fale com o administrador ou gestor da sua empresa para regularizar seu acesso.',
+        'logout' => 'Sair da conta',
+    ],
 ];

--- a/resources/views/company-plan-inactive.blade.php
+++ b/resources/views/company-plan-inactive.blade.php
@@ -1,0 +1,38 @@
+@props([
+    'companyName' => '',
+])
+
+<div class="flex flex-col items-center gap-6 py-8 px-4 text-center">
+    <div class="rounded-full bg-warning-100 p-4 dark:bg-warning-500/20">
+        <x-filament::icon
+            icon="heroicon-o-exclamation-triangle"
+            class="h-10 w-10 text-warning-600 dark:text-warning-400"
+        />
+    </div>
+
+    <div class="space-y-2">
+        <h1 class="text-2xl font-bold text-gray-950 dark:text-white">
+            {{ __('views.company_plan_inactive.heading') }}
+        </h1>
+
+        <p class="text-base text-gray-500 dark:text-gray-400">
+            {{ __('views.company_plan_inactive.description', ['company' => $companyName]) }}
+        </p>
+    </div>
+
+    <p class="max-w-md text-sm text-gray-500 dark:text-gray-400">
+        {{ __('views.company_plan_inactive.instruction') }}
+    </p>
+
+    <form method="POST" action="{{ route('filament.app.auth.logout') }}">
+        @csrf
+
+        <x-filament::button
+            type="submit"
+            color="gray"
+            icon="heroicon-m-arrow-left-start-on-rectangle"
+        >
+            {{ __('views.company_plan_inactive.logout') }}
+        </x-filament::button>
+    </form>
+</div>

--- a/resources/views/no-active-company.blade.php
+++ b/resources/views/no-active-company.blade.php
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ __('views.no_company.title') }}</title>
+    <style>
+        :root { color-scheme: light dark; }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+            background: #f4f4f5;
+            color: #18181b;
+        }
+        .card {
+            width: 100%;
+            max-width: 28rem;
+            background: #fff;
+            border: 1px solid #e4e4e7;
+            border-radius: 1rem;
+            padding: 2.5rem 2rem;
+            text-align: center;
+            box-shadow: 0 10px 30px -12px rgba(0, 0, 0, .15);
+        }
+        .icon {
+            width: 4rem; height: 4rem;
+            margin: 0 auto 1.5rem;
+            border-radius: 9999px;
+            display: flex; align-items: center; justify-content: center;
+            background: rgba(241, 120, 90, .12);
+            color: #F1785A;
+        }
+        .icon svg { width: 2rem; height: 2rem; }
+        h1 { font-size: 1.375rem; font-weight: 700; margin-bottom: .75rem; }
+        p { font-size: .95rem; line-height: 1.6; color: #52525b; margin-bottom: 1.75rem; }
+        button {
+            font: inherit;
+            cursor: pointer;
+            border: 0;
+            border-radius: .625rem;
+            padding: .7rem 1.4rem;
+            font-weight: 600;
+            color: #fff;
+            background: #F1785A;
+            transition: opacity .15s ease;
+        }
+        button:hover { opacity: .9; }
+        @media (prefers-color-scheme: dark) {
+            body { background: #18181b; color: #fafafa; }
+            .card { background: #27272a; border-color: #3f3f46; }
+            p { color: #a1a1aa; }
+        }
+    </style>
+</head>
+<body>
+    <div class="card">
+        <div class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
+            </svg>
+        </div>
+
+        <h1>{{ __('views.no_company.heading') }}</h1>
+        <p>{{ __('views.no_company.body') }}</p>
+
+        <form method="POST" action="{{ route('filament.app.auth.logout') }}">
+            @csrf
+            <button type="submit">{{ __('views.no_company.logout') }}</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/tests/Feature/Filament/NoActiveCompanyTest.php
+++ b/tests/Feature/Filament/NoActiveCompanyTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\Permissions\Roles;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+/**
+ * ÉPICO 56 — a collaborator who reaches the app panel without any active
+ * company (e.g. an inactive membership) sees a friendly "no active company"
+ * page instead of a bare 404. Admins keep the pre-existing behavior (#178).
+ */
+it('shows the no-active-company page to an employee whose membership is inactive', function (): void {
+    $employee = User::factory()->create();
+    $employee->assignRole(Roles::Employee->value);
+
+    $company = Company::factory()->createOne();
+    $company->employees()->attach($employee->getKey(), [
+        'role' => Roles::Employee->value,
+        'active' => false,
+    ]);
+
+    actingAs($employee);
+
+    get('/app')
+        ->assertOk()
+        ->assertSee(__('views.no_company.heading'));
+});
+
+it('keeps the pre-existing behavior for admins (lands on a company)', function (): void {
+    $owner = User::factory()->companyOwner()->create();
+    Company::factory()->recycle($owner)->create(['slug' => 'acme-noactive']);
+
+    $admin = User::factory()->admin()->create();
+    actingAs($admin);
+
+    // Admin sees every company (#178), so they are routed into one, not the page.
+    get('/app')->assertStatus(302);
+});

--- a/tests/Feature/Filament/UnauthorizedRedirectTest.php
+++ b/tests/Feature/Filament/UnauthorizedRedirectTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\FilamentPanel;
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Log;
+use TresPontosTech\Billing\Stripe\Subscription\User\RedirectUserIfNotSubscribed;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\PanelApp\Http\Middleware\RedirectIfAnamneseNotCompleted;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+/**
+ * ÉPICO 56 — Redirecionamento por Perfil ao Acessar Página sem Autorização.
+ * STORY 317 (redirecionar para a home do perfil) + STORY 318 (preservar erro
+ * para não autenticados / perfis não mapeados).
+ */
+$adminDashboard = 'filament.admin.pages.dashboard';
+$userDashboard = 'filament.app.pages.user-dashboard';
+
+$makeEmployee = function (?Company &$company = null): User {
+    $employee = User::factory()->employee()->create();
+    $company = Company::factory()->createOne();
+    $company->employees()->attach($employee->getKey());
+
+    return $employee;
+};
+
+describe('STORY 317 — redirect to profile home', function () use ($adminDashboard, $makeEmployee): void {
+    it('redirects an employee hitting the admin panel to their own app home', function () use ($adminDashboard, $makeEmployee): void {
+        $employee = $makeEmployee();
+        actingAs($employee);
+
+        $response = get(route($adminDashboard));
+
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))
+            ->toContain('/app')
+            ->not->toContain('/admin');
+    });
+
+    it('redirects a consultant hitting the admin panel to the consultant home', function () use ($adminDashboard): void {
+        actingAsConsultant();
+
+        $response = get(route($adminDashboard));
+
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))->toContain('/consultant');
+    });
+
+    it('lets an admin access the admin panel without redirecting', function () use ($adminDashboard): void {
+        actingAsAdmin();
+
+        get(route($adminDashboard))->assertOk();
+    });
+});
+
+describe('STORY 317 — company (tenant) the user is not part of', function () use ($userDashboard, $makeEmployee): void {
+    it('redirects a user opening a company they do not belong to towards their own home', function () use ($userDashboard, $makeEmployee): void {
+        $ownCompany = null;
+        $employee = $makeEmployee($ownCompany);
+        $otherCompany = Company::factory()->createOne(['slug' => 'outra-empresa']);
+        actingAs($employee);
+
+        $response = get(route($userDashboard, ['tenant' => $otherCompany->slug]));
+
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))
+            ->toContain($ownCompany->slug)
+            ->not->toContain($otherCompany->slug);
+    });
+
+    it('does not create a redirect loop: the resolved home is reachable', function () use ($userDashboard, $makeEmployee): void {
+        // The billing/anamnese tenant middleware are irrelevant to this loop
+        // check, so let them pass through.
+        $passthrough = new class
+        {
+            public function handle($request, Closure $next)
+            {
+                return $next($request);
+            }
+        };
+        app()->instance(RedirectUserIfNotSubscribed::class, $passthrough);
+        app()->instance(RedirectIfAnamneseNotCompleted::class, $passthrough);
+
+        $ownCompany = null;
+        $employee = $makeEmployee($ownCompany);
+        $otherCompany = Company::factory()->createOne(['slug' => 'outra-empresa']);
+        actingAs($employee);
+
+        $this->followingRedirects()
+            ->get(route($userDashboard, ['tenant' => $otherCompany->slug]))
+            ->assertOk();
+    });
+});
+
+describe('STORY 318 — preserve error for unauthenticated / unmapped profiles', function () use ($adminDashboard): void {
+    it('keeps sending unauthenticated users to the login page', function () use ($adminDashboard): void {
+        $response = get(route($adminDashboard));
+
+        $response->assertStatus(302);
+        expect($response->headers->get('Location'))->toContain('login');
+    });
+
+    it('shows the default 403 for an authenticated user whose profile has no mapped home', function () use ($adminDashboard): void {
+        Log::spy();
+
+        $user = User::factory()->user()->create();
+        actingAs($user);
+
+        get(route($adminDashboard))->assertForbidden();
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(fn (string $message): bool => str_contains($message, 'without a mapped profile home'));
+    });
+});
+
+describe('profile → home mapping is defined for every profile', function (): void {
+    it('maps each profile to an accessible home panel (no loop possible)', function (): void {
+        $company = Company::factory()->createOne();
+
+        $employee = User::factory()->employee()->create();
+        $company->employees()->attach($employee->getKey());
+
+        $admin = User::factory()->admin()->create();
+        $consultant = User::factory()->consultant()->create();
+        $owner = User::factory()->companyOwner()->create();
+        Company::factory()->recycle($owner)->create();
+        $orphan = User::factory()->user()->create();
+
+        expect(FilamentPanel::homePanelFor($employee))->toBe(FilamentPanel::User)
+            ->and(FilamentPanel::homePanelFor($admin))->toBe(FilamentPanel::Admin)
+            ->and(FilamentPanel::homePanelFor($consultant))->toBe(FilamentPanel::Consultant)
+            ->and(FilamentPanel::homePanelFor($owner))->toBe(FilamentPanel::Company)
+            ->and(FilamentPanel::homePanelFor($orphan))->toBeNull();
+
+        // The resolved panel is always one the user can actually access, which
+        // is what guarantees the redirect never bounces back into a denial.
+        foreach ([$employee, $admin, $consultant, $owner] as $user) {
+            $panel = FilamentPanel::homePanelFor($user);
+            expect(FilamentPanel::canAccessPanel(filament()->getPanel($panel->value), $user))->toBeTrue();
+        }
+    });
+});


### PR DESCRIPTION
Épico 56 — [Redirecionamento por Perfil ao Acessar Página sem Autorização](https://3pontos.monday.com/boards/18392609686/pulses/12577456427).

  Usuários autenticados que caíam num painel ou empresa fora do seu perfil recebiam uma tela de erro **403/404 genérica**, sem caminho de volta.
  Este PR troca esses erros por redirecionamentos e páginas úteis: o usuário sempre volta para um lugar válido do seu próprio perfil.

  ## Comportamento (antes → depois)

  | Situação | Antes | Depois |
  |---|---|---|
  | Colaborador/consultor abre painel de outro perfil | 403 | → home do seu perfil |
  | Abre uma empresa da qual não faz parte | 404 | → sua própria empresa |
  | Membro de empresa sem plano / cancelada | 403 | página "Plano inativo" |
  | Funcionário sem empresa ativa (vínculo inativo) | 404 | página "Nenhuma empresa ativa" |
  | Não autenticado | login | login *(inalterado)* |
  | Autenticado com perfil não mapeado | 403 | 403 + log *(inalterado)* |
  | Admin (acesso total às empresas) | — | *inalterado (pré-existente #178)* |

  ## Como funciona

  Os handlers de controle de acesso do Filament foram substituídos por versões que guiam o usuário, registrados via **container binding** no
  `FilamentServiceProvider` (cobre HTTP **e** requisições Livewire, sem tocar nos 4 PanelProviders):

  - **`FilamentPanel::homeUrlFor()`** — resolve o painel-home do perfil por prioridade; só devolve painel que o usuário realmente acessa
  (garantia anti-loop).
  - **`AuthenticatePanel`** — 403 de painel → redirect para a home do perfil. Sobrescreve apenas `authenticate()` (não `handle()`), preservando
  o contrato do Livewire persistent middleware; o redirect sai via `HttpResponseException`.
  - **`IdentifyTenantOrRedirectHome`** — 404 de tenant (empresa da qual não participo) → redirect para a home. Empresa inexistente segue 404.
  - **`RedirectToTenantOrShowNoCompany`** — funcionário (não-admin) sem empresa ativa no painel app → página "Nenhuma empresa ativa".
  - **`CompanyPlanInactive`** (página) — membro de empresa sem plano/pagamento, no lugar do `abort(403)` do middleware de assinatura.

  ## Fora do escopo / decisões

  - **Acesso total do admin às empresas foi mantido** — é comportamento pré-existente da feature de impersonation/gestão (#178), coberto pelo
  `ImpersonationTest`. `User.php` não foi alterado.
  - 403 de *policy* dentro de um painel que o usuário **pode** acessar continua 403 (não é acesso de painel).

  ## Testes

  - Suíte completa: **1043 passando, 0 falhas**.
  - Novos: `UnauthorizedRedirectTest`, `CompanyPlanInactiveTest`, `NoActiveCompanyTest`.
  - Atualizados para o novo comportamento: `TenantAccessTest`, `TenantAccessManagerTest`, `RedirectUserIfNotSubscribedTest`,
  `LegacySubscriberAccessTest`.
  - `phpstan` 0 erros · `pint` limpo.
  - ⚠️ Os 66 erros de `getSlideOverPosition` na suíte são **pré-existentes** no `develop` (incompatibilidade de modal do Filament v5), sem
  relação com este PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users with inactive or canceled company plans are redirected to a dedicated plan-inactive page instead of seeing an access error.
  * Added a no-active-company page for users without an active company membership.
  * Unauthorized users are redirected to their appropriate profile or company home.
  * Improved tenant access handling to prevent confusing errors and redirect loops.
  * Added English and Portuguese translations for the new messages.

* **Bug Fixes**
  * Prevented users from accessing companies they are not associated with.
  * Preserved appropriate access restrictions for users without an available home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->