### PR TITLE
feat: panel app table defaults

### DIFF
--- a/app-modules/panel-app/lang/en/resources.php
+++ b/app-modules/panel-app/lang/en/resources.php
@@ -142,16 +142,24 @@ return [
         ],
     ],
     'documents' => [
-        'tabs' => [
-            'shared' => 'Shared with me',
-            'mine' => 'My Documents',
+        'my_materials' => [
+            'heading' => 'My materials',
+            'description' => 'Access and follow every material available to you.',
+            'new_document' => 'New document',
+        ],
+        'shared' => [
+            'heading' => 'Shared with me',
+            'description' => 'Access and follow every material available to you.',
+        ],
+        'actions' => [
+            'access' => 'Access',
         ],
         'table' => [
-            'title' => 'Document Type',
-            'extension_type' => 'Extension Type',
+            'title' => 'Document name',
+            'extension_type' => 'Type',
             'active' => 'Is Active',
             'consultant' => 'Consultant',
-            'created_at' => 'Sent At',
+            'created_at' => 'Sent at',
         ],
         'form' => [
             'heading' => 'New Document',

--- a/app-modules/panel-app/lang/en/resources.php
+++ b/app-modules/panel-app/lang/en/resources.php
@@ -9,8 +9,6 @@ return [
             'heading' => 'Booked consultations',
             'description' => 'Manage and follow your booked consultations.',
             'category_type' => 'Appointment Type',
-            'search_placeholder' => 'Search',
-            'filters_label' => 'Filter',
             'filters' => [
                 'status' => 'Status',
                 'category_type' => 'Appointment type',

--- a/app-modules/panel-app/lang/pt_BR/resources.php
+++ b/app-modules/panel-app/lang/pt_BR/resources.php
@@ -9,8 +9,6 @@ return [
             'heading' => 'Consultas agendadas',
             'description' => 'Gerencie e acompanhe suas consultas agendadas.',
             'category_type' => 'Tipo de Atendimento',
-            'search_placeholder' => 'Pesquisar',
-            'filters_label' => 'Filtro',
             'filters' => [
                 'status' => 'Status',
                 'category_type' => 'Tipo de atendimento',

--- a/app-modules/panel-app/lang/pt_BR/resources.php
+++ b/app-modules/panel-app/lang/pt_BR/resources.php
@@ -142,16 +142,24 @@ return [
         ],
     ],
     'documents' => [
-        'tabs' => [
-            'shared' => 'Compartilhados comigo',
-            'mine' => 'Meus Documentos',
+        'my_materials' => [
+            'heading' => 'Meus materiais',
+            'description' => 'Acesse e acompanhe todos os materiais disponíveis para você.',
+            'new_document' => 'Novo documento',
+        ],
+        'shared' => [
+            'heading' => 'Compartilhados comigo',
+            'description' => 'Acesse e acompanhe todos os materiais disponíveis para você.',
+        ],
+        'actions' => [
+            'access' => 'Acessar',
         ],
         'table' => [
-            'title' => 'Nome do Documento',
+            'title' => 'Nome do documento',
             'extension_type' => 'Tipo',
             'active' => 'Ativo',
             'consultant' => 'Consultor',
-            'created_at' => 'Data de Envio',
+            'created_at' => 'Data de envio',
         ],
         'form' => [
             'heading' => 'Novo Documento',

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/ListAppointments.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Pages/ListAppointments.php
@@ -20,14 +20,6 @@ class ListAppointments extends ListRecords implements ShowsCancelledConfirmation
         return __('panel-app::resources.appointments.table.title');
     }
 
-    /**
-     * @return array<string>
-     */
-    public function getBreadcrumbs(): array
-    {
-        return [];
-    }
-
     protected function getHeaderActions(): array
     {
         return [];

--- a/app-modules/panel-app/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-app/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -60,7 +60,6 @@ class AppointmentsTable
                     ->searchable(),
             ])
             ->defaultSort('appointment_at', 'desc')
-            ->searchPlaceholder(__('panel-app::resources.appointments.table.search_placeholder'))
             ->filters([
                 SelectFilter::make('status')
                     ->label(__('panel-app::resources.appointments.table.filters.status'))
@@ -71,25 +70,11 @@ class AppointmentsTable
                     ->options(AppointmentCategoryEnum::class)
                     ->multiple(),
             ])
-            ->filtersTriggerAction(fn (Action $action): Action => $action
-                ->button()
-                ->outlined()
-                ->color('gray')
-                ->label(function (Table $table): string {
-                    $label = __('panel-app::resources.appointments.table.filters_label');
-                    $count = $table->getActiveFiltersCount();
-
-                    return $count > 0 ? sprintf('%s (%d)', $label, $count) : $label;
-                }))
             ->recordActions([
                 ViewAppointmentRecordAction::make(),
                 FeedbackAction::make(),
                 RescheduleAppointmentAction::make(),
                 CancelAppointmentAction::make(),
-            ])
-            ->paginationPageOptions([6, 12, 24])
-            ->defaultPaginationPageOption(6)
-            ->extremePaginationLinks()
-            ->extraAttributes(['class' => 'fi-apt-table']);
+            ]);
     }
 }

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
@@ -14,11 +14,6 @@ class ListSharedDocuments extends ListRecords
 {
     protected static string $resource = SharedDocumentResource::class;
 
-    public function getTitle(): string
-    {
-        return '';
-    }
-
     protected function getHeaderActions(): array
     {
         return [

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
@@ -4,39 +4,28 @@ declare(strict_types=1);
 
 namespace TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages;
 
-use Filament\Actions\CreateAction;
 use Filament\Resources\Pages\ListRecords;
-use Filament\Schemas\Components\Tabs\Tab;
-use Illuminate\Database\Eloquent\Builder;
 use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\SharedDocumentResource;
+use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Widgets\MyMaterialsWidget;
 
 class ListSharedDocuments extends ListRecords
 {
     protected static string $resource = SharedDocumentResource::class;
 
-    protected function getHeaderActions(): array
+    /**
+     * As duas seções carregam seus próprios títulos ("Meus materiais" e
+     * "Compartilhados comigo"); sem heading, o Filament nem renderiza o
+     * cabeçalho da página. O getTitle segue preenchido para a aba do browser.
+     */
+    public function getHeading(): string
     {
-        return [
-            CreateAction::make()
-                ->label(__('panel-app::resources.documents.form.heading'))
-                ->visible(fn (): bool => $this->activeTab === 'mine'),
-        ];
+        return '';
     }
 
-    public function getTabs(): array
+    protected function getHeaderWidgets(): array
     {
         return [
-            'shared' => Tab::make(__('panel-app::resources.documents.tabs.shared'))
-                ->modifyQueryUsing(fn ($query) => $query?->where('active', 1)
-                    ->whereHas('shares', fn ($subquery) => $subquery?->where('employee_id', auth()->user()->getKey())
-                        ->where('active', 1)
-                    )),
-
-            'mine' => Tab::make(__('panel-app::resources.documents.tabs.mine'))
-                ->modifyQueryUsing(fn (Builder $query) => $query
-                    ->where('documentable_type', auth()->user()->getMorphClass())
-                    ->where('documentable_id', auth()->user()->getKey())
-                ),
+            MyMaterialsWidget::class,
         ];
     }
 }

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Pages/ListSharedDocuments.php
@@ -12,11 +12,6 @@ class ListSharedDocuments extends ListRecords
 {
     protected static string $resource = SharedDocumentResource::class;
 
-    /**
-     * As duas seções carregam seus próprios títulos ("Meus materiais" e
-     * "Compartilhados comigo"); sem heading, o Filament nem renderiza o
-     * cabeçalho da página. O getTitle segue preenchido para a aba do browser.
-     */
     public function getHeading(): string
     {
         return '';

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/SharedDocumentResource.php
@@ -15,6 +15,7 @@ use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages\EditSharedD
 use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages\ListSharedDocuments;
 use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Schemas\SharedDocumentForm;
 use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Tables\SharedDocumentsTable;
+use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Widgets\MyMaterialsWidget;
 use UnitEnum;
 
 class SharedDocumentResource extends Resource
@@ -50,6 +51,13 @@ class SharedDocumentResource extends Resource
             'index' => ListSharedDocuments::route('/'),
             'create' => CreateSharedDocument::route('/create'),
             'edit' => EditSharedDocument::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getWidgets(): array
+    {
+        return [
+            MyMaterialsWidget::class,
         ];
     }
 

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Tables/SharedDocumentsTable.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Tables/SharedDocumentsTable.php
@@ -23,6 +23,7 @@ class SharedDocumentsTable
                 ->with(['documentable', 'media']))
             ->heading(__('panel-app::resources.documents.shared.heading'))
             ->description(__('panel-app::resources.documents.shared.description'))
+            ->extraAttributes(['class' => 'fi-apt-inline-toolbar'])
             ->columns([
                 TextColumn::make('type')
                     ->label(__('panel-app::resources.documents.table.extension_type'))

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Tables/SharedDocumentsTable.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Tables/SharedDocumentsTable.php
@@ -3,27 +3,35 @@
 namespace TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Tables;
 
 use Filament\Actions\Action;
-use Filament\Actions\DeleteAction;
-use Filament\Actions\EditAction;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use TresPontosTech\Consultants\Models\Document;
-use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages\EditSharedDocument;
 use TresPontosTech\PanelConsultant\Filament\Actions\DownloadDocumentFilamentAction;
 
 class SharedDocumentsTable
 {
     public static function table(Table $table): Table
     {
-
         return $table
-            ->modifyQueryUsing(fn (Builder $query) => $query->with(['documentable', 'media']))
+            ->modifyQueryUsing(fn (Builder $query) => $query
+                ->where('active', 1)
+                ->whereHas('shares', fn ($subquery) => $subquery
+                    ->where('employee_id', auth()->user()->getKey())
+                    ->where('active', 1))
+                ->with(['documentable', 'media']))
+            ->heading(__('panel-app::resources.documents.shared.heading'))
+            ->description(__('panel-app::resources.documents.shared.description'))
             ->columns([
+                TextColumn::make('type')
+                    ->label(__('panel-app::resources.documents.table.extension_type'))
+                    ->badge()
+                    ->icon(Heroicon::OutlinedDocumentText)
+                    ->searchable(),
+
                 TextColumn::make('documentable.name')
                     ->label(__('panel-app::resources.documents.table.consultant'))
-                    ->hidden(fn ($livewire): bool => $livewire->activeTab === 'mine')
                     ->searchable()
                     ->sortable(),
 
@@ -32,31 +40,24 @@ class SharedDocumentsTable
                     ->searchable()
                     ->sortable(),
 
-                TextColumn::make('type')
-                    ->label(__('panel-app::resources.documents.table.extension_type'))
-                    ->searchable()
-                    ->sortable(),
-
                 TextColumn::make('created_at')
                     ->label(__('panel-app::resources.documents.table.created_at'))
                     ->dateTime('d/m/Y')
-                    ->searchable()
                     ->sortable(),
             ])
+            ->recordClasses(fn (Document $record): string => 'fi-apt-doc-' . $record->type->value)
+            ->defaultSort('created_at', 'desc')
             ->recordActions([
                 DownloadDocumentFilamentAction::make()
+                    ->label(__('panel-app::resources.documents.actions.access'))
+                    ->icon(Heroicon::OutlinedEye)
                     ->visible(fn (Document $record): bool => $record->hasLink() === false),
                 Action::make('open-link')
-                    ->label('Link')
-                    ->icon(Heroicon::ArrowTopRightOnSquare)
+                    ->label(__('panel-app::resources.documents.actions.access'))
+                    ->icon(Heroicon::OutlinedEye)
                     ->url(fn (Document $record): string => $record->link)
                     ->openUrlInNewTab()
                     ->visible(fn (Document $record): bool => $record->hasLink()),
-                EditAction::make()
-                    ->visible(fn ($livewire): bool => $livewire->activeTab === 'mine'),
-                DeleteAction::make()
-                    ->visible(fn ($livewire): bool => $livewire->activeTab === 'mine'),
-
-            ])->recordUrl(fn ($record): ?string => $record->documentable_id === auth()->user()->id ? EditSharedDocument::getUrl(['record' => $record->getKey()]) : null);
+            ]);
     }
 }

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
@@ -33,12 +33,16 @@ class MyMaterialsWidget extends TableWidget
                 ->with('media'))
             ->heading(__('panel-app::resources.documents.my_materials.heading'))
             ->description(__('panel-app::resources.documents.my_materials.description'))
-            ->headerActions([
+            // Na toolbar (e não no header) para dividir a linha com busca e
+            // filtros; o CSS de .fi-apt-inline-toolbar sobe essa linha para o
+            // lado do heading e põe o botão por último, como no layout.
+            ->toolbarActions([
                 Action::make('new-document')
                     ->label(__('panel-app::resources.documents.my_materials.new_document'))
                     ->icon(Heroicon::OutlinedDocumentPlus)
                     ->url(CreateSharedDocument::getUrl()),
             ])
+            ->extraAttributes(['class' => 'fi-apt-inline-toolbar'])
             ->columns([
                 Split::make([
                     TextColumn::make('type')

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
@@ -33,9 +33,6 @@ class MyMaterialsWidget extends TableWidget
                 ->with('media'))
             ->heading(__('panel-app::resources.documents.my_materials.heading'))
             ->description(__('panel-app::resources.documents.my_materials.description'))
-            // Na toolbar (e não no header) para dividir a linha com busca e
-            // filtros; o CSS de .fi-apt-inline-toolbar sobe essa linha para o
-            // lado do heading e põe o botão por último, como no layout.
             ->toolbarActions([
                 Action::make('new-document')
                     ->label(__('panel-app::resources.documents.my_materials.new_document'))

--- a/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
+++ b/app-modules/panel-app/src/Filament/Resources/SharedDocuments/Widgets/MyMaterialsWidget.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Widgets;
+
+use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\EditAction;
+use Filament\Support\Enums\FontWeight;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\Layout\Split;
+use Filament\Tables\Columns\Layout\Stack;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Filament\Widgets\TableWidget;
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages\CreateSharedDocument;
+use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Pages\EditSharedDocument;
+use TresPontosTech\PanelConsultant\Filament\Actions\DownloadDocumentFilamentAction;
+
+class MyMaterialsWidget extends TableWidget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->query(Document::query()
+                ->where('documentable_type', auth()->user()->getMorphClass())
+                ->where('documentable_id', auth()->user()->getKey())
+                ->with('media'))
+            ->heading(__('panel-app::resources.documents.my_materials.heading'))
+            ->description(__('panel-app::resources.documents.my_materials.description'))
+            ->headerActions([
+                Action::make('new-document')
+                    ->label(__('panel-app::resources.documents.my_materials.new_document'))
+                    ->icon(Heroicon::OutlinedDocumentPlus)
+                    ->url(CreateSharedDocument::getUrl()),
+            ])
+            ->columns([
+                Split::make([
+                    TextColumn::make('type')
+                        ->badge()
+                        ->icon(Heroicon::OutlinedDocumentText)
+                        ->grow(false),
+                    Stack::make([
+                        TextColumn::make('title')
+                            ->weight(FontWeight::SemiBold)
+                            ->extraAttributes(['class' => 'fi-apt-card-title'])
+                            ->searchable(),
+                        TextColumn::make('created_at')
+                            ->dateTime('d/m/Y'),
+                    ]),
+                ]),
+            ])
+            ->contentGrid(['md' => 2, 'xl' => 4])
+            ->recordClasses(fn (Document $record): string => 'fi-apt-doc-' . $record->type->value)
+            ->recordActions([
+                ActionGroup::make([
+                    DownloadDocumentFilamentAction::make()
+                        ->label(__('panel-app::resources.documents.actions.access')),
+                    EditAction::make()
+                        ->url(fn (Document $record): string => EditSharedDocument::getUrl(['record' => $record])),
+                    DeleteAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->paginationPageOptions([8, 16, 24])
+            ->defaultPaginationPageOption(8);
+    }
+}

--- a/app-modules/panel-app/tests/Feature/Filament/Widgets/MyMaterialsWidgetTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Widgets/MyMaterialsWidgetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use TresPontosTech\Consultants\Models\Document;
+use TresPontosTech\PanelApp\Filament\Resources\SharedDocuments\Widgets\MyMaterialsWidget;
+
+use function Pest\Laravel\assertSoftDeleted;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->employee = actingAsSubscribedEmployee();
+});
+
+function ownDocument(): Document
+{
+    return Document::factory()->withFile()->create([
+        'documentable_type' => test()->employee->getMorphClass(),
+        'documentable_id' => test()->employee->getKey(),
+        'active' => true,
+    ]);
+}
+
+it('lists only the employee own documents', function (): void {
+    $mine = ownDocument();
+    $someoneElses = Document::factory()->forConsultant()->active()->withFile()->create();
+
+    livewire(MyMaterialsWidget::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$mine])
+        ->assertCanNotSeeTableRecords([$someoneElses]);
+});
+
+it('offers access, edit and delete on an own document', function (): void {
+    $mine = ownDocument();
+
+    livewire(MyMaterialsWidget::class)
+        ->assertOk()
+        ->assertTableActionVisible('download-document-action', $mine)
+        ->assertTableActionVisible('edit', $mine)
+        ->assertTableActionVisible('delete', $mine);
+});
+
+it('deletes an own document from the grid', function (): void {
+    $mine = ownDocument();
+
+    livewire(MyMaterialsWidget::class)
+        ->callTableAction('delete', $mine);
+
+    assertSoftDeleted('documents', ['id' => $mine->getKey()]);
+});

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -118,11 +118,6 @@ class AppPanelProvider extends PanelProvider
             ->authMiddleware([
                 Authenticate::class,
             ])
-            // Padrão de toda tabela do painel, casando com o CSS do tema que
-            // já estiliza .fi-ta sem escopo por resource: paginação de 6 com
-            // saltos extremos e os rótulos de busca/filtro do layout. Fica no
-            // bootUsing para valer só quando este painel atende a request;
-            // cada resource segue livre para sobrescrever o que precisar.
             ->bootUsing(function (): void {
                 Table::configureUsing(function (Table $table): void {
                     $table

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Shared\Pages\LoginPage;
+use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
@@ -13,6 +14,7 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
 use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -105,6 +107,7 @@ class AppPanelProvider extends PanelProvider
                 DispatchServingFilamentEvent::class,
             ])
             ->searchableTenantMenu(false)
+            ->breadcrumbs(false)
             ->tenantMenu(false)
             ->tenantBillingProvider(new UserBillingProvider)
             ->tenant(Company::class, slugAttribute: 'slug')
@@ -115,6 +118,30 @@ class AppPanelProvider extends PanelProvider
             ->authMiddleware([
                 Authenticate::class,
             ])
+            // Padrão de toda tabela do painel, casando com o CSS do tema que
+            // já estiliza .fi-ta sem escopo por resource: paginação de 6 com
+            // saltos extremos e os rótulos de busca/filtro do layout. Fica no
+            // bootUsing para valer só quando este painel atende a request;
+            // cada resource segue livre para sobrescrever o que precisar.
+            ->bootUsing(function (): void {
+                Table::configureUsing(function (Table $table): void {
+                    $table
+                        ->searchPlaceholder(__('all.tables.search_placeholder'))
+                        ->filtersTriggerAction(fn (Action $action): Action => $action
+                            ->button()
+                            ->outlined()
+                            ->color('gray')
+                            ->label(function (Table $table): string {
+                                $label = __('all.tables.filters_label');
+                                $count = $table->getActiveFiltersCount();
+
+                                return $count > 0 ? sprintf('%s (%d)', $label, $count) : $label;
+                            }))
+                        ->paginationPageOptions([6, 12, 24])
+                        ->defaultPaginationPageOption(6)
+                        ->extremePaginationLinks();
+                });
+            })
             ->viteTheme('resources/css/filament/app/theme.css');
     }
 }

--- a/lang/en/all.php
+++ b/lang/en/all.php
@@ -10,4 +10,8 @@ return [
     'my_profile' => 'My Profile',
     'settings' => 'Settings',
     'back' => 'Back',
+    'tables' => [
+        'search_placeholder' => 'Search',
+        'filters_label' => 'Filter',
+    ],
 ];

--- a/lang/pt_BR/all.php
+++ b/lang/pt_BR/all.php
@@ -10,4 +10,8 @@ return [
     'my_profile' => 'Meu Perfil',
     'settings' => 'Configurações',
     'back' => 'Voltar',
+    'tables' => [
+        'search_placeholder' => 'Pesquisar',
+        'filters_label' => 'Filtro',
+    ],
 ];

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -274,9 +274,11 @@
         }
     }
 
+    /* Um fio de respiro na ponta: sem ele o hover das ações encosta na
+       borda direita da tabela. */
     & .fi-ta-header-cell:last-of-type,
     & .fi-ta-cell:last-of-type {
-        padding-inline-end: 0;
+        padding-inline-end: 8px;
     }
 
     /* Badge sem pill (nas células da tabela e nos cards do grid): ícone
@@ -434,6 +436,29 @@
         }
     }
 
+    /* Mobile: ação de cabeçalho e busca ocupam a largura toda. */
+    @media (max-width: 639px) {
+        & .fi-ta-header .fi-ta-actions {
+            width: 100%;
+
+            & > * {
+                flex: 1 1 0%;
+            }
+
+            & .fi-btn {
+                width: 100%;
+            }
+        }
+
+        & .fi-ta-header-toolbar > :nth-child(2) {
+            width: 100%;
+        }
+
+        & .fi-ta-search-field {
+            width: 100%;
+        }
+    }
+
     &:where(.dark, .dark *) .fi-ta-content-grid .fi-apt-card-title .fi-ta-text-item {
         color: white;
     }
@@ -525,6 +550,69 @@
 
         & .fi-pagination-item-label {
             color: white;
+        }
+    }
+}
+
+/*
+ * Variante opt-in (via extraAttributes da tabela): cabeçalho em linha única —
+ * título e descrição à esquerda; filtro, busca e a ação da tabela à direita,
+ * com a ação por último, como no layout. Header e toolbar são irmãos no DOM
+ * dentro de .fi-ta-header-ctn, então é o grid do container que os põe lado a
+ * lado; a ação precisa vir de toolbarActions() (não headerActions()) para
+ * morar na mesma linha da busca.
+ */
+.fi-apt-inline-toolbar {
+    & .fi-ta-header-ctn {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        align-items: center;
+        column-gap: 16px;
+        padding-bottom: var(--apt-space);
+    }
+
+    & .fi-ta-header,
+    & .fi-ta-header-toolbar {
+        padding-block: 0;
+    }
+
+    /* A ordem visual (…busca, ação) inverte a ordem do DOM (ação, busca). */
+    & .fi-ta-header-toolbar > :nth-child(1) {
+        order: 2;
+    }
+
+    & .fi-ta-header-toolbar > :nth-child(2) {
+        order: 1;
+        margin-inline-start: 0;
+    }
+
+    @media (max-width: 639px) {
+        & .fi-ta-header-ctn {
+            grid-template-columns: minmax(0, 1fr);
+            row-gap: 16px;
+        }
+
+        /* Empilhado, a ação volta para antes da busca e ocupa a linha toda. */
+        & .fi-ta-header-toolbar {
+            flex-direction: column;
+            align-items: stretch;
+
+            & > :nth-child(1) {
+                order: 1;
+                width: 100%;
+
+                & > * {
+                    flex: 1 1 0%;
+                }
+
+                & .fi-btn {
+                    width: 100%;
+                }
+            }
+
+            & > :nth-child(2) {
+                order: 2;
+            }
         }
     }
 }

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -279,8 +279,10 @@
         padding-inline-end: 0;
     }
 
-    /* Badge sem pill: ícone colorido + frase no token text-medium. */
-    & .fi-ta-cell .fi-badge {
+    /* Badge sem pill (nas células da tabela e nos cards do grid): ícone
+       colorido + frase no token text-medium. */
+    & .fi-ta-cell .fi-badge,
+    & .fi-ta-content-grid .fi-badge {
         min-width: 0;
         padding: 0;
         background-color: transparent;
@@ -325,6 +327,115 @@
     & .fi-apt-cat-retirement-and-estate-planning .fi-badge .fi-icon,
     & .fi-apt-status-cancelled-late .fi-badge .fi-icon {
         color: var(--apt-orange-300);
+    }
+
+    /* Cor por tipo de documento (recordClasses nas tabelas de materiais):
+       cada linha/card carrega a var, a tabela pinta só o ícone e os cards do
+       grid pintam ícone + rótulo. */
+    & .fi-apt-doc-pdf {
+        --apt-doc-color: var(--apt-red-300);
+    }
+
+    & .fi-apt-doc-png {
+        --apt-doc-color: var(--apt-emerald-300);
+    }
+
+    & .fi-apt-doc-docx {
+        --apt-doc-color: var(--apt-blue-300);
+    }
+
+    & .fi-apt-doc-xlsx {
+        --apt-doc-color: var(--apt-lime-300);
+    }
+
+    & .fi-apt-doc-svg {
+        --apt-doc-color: var(--apt-orange-300);
+    }
+
+    & .fi-apt-doc-jpg {
+        --apt-doc-color: var(--apt-cyan-300);
+    }
+
+    & .fi-apt-doc-link {
+        --apt-doc-color: var(--apt-text-medium);
+    }
+
+    & [class*='fi-apt-doc-'] .fi-badge .fi-icon {
+        color: var(--apt-doc-color);
+    }
+
+    & .fi-ta-content-grid [class*='fi-apt-doc-'] .fi-badge {
+        color: var(--apt-doc-color);
+    }
+
+    /* Grid de cards (contentGrid): cantos de 4px de volta (o token do painel
+       zera o rounded-xl do vendor), card baixo com o tipo em lockup vertical —
+       ícone grande com a sigla embaixo —, título em destaque e kebab
+       centralizado na borda direita. */
+    & .fi-ta-content-grid {
+        gap: 24px;
+        /* Respiro para o ring dos cards não ser clipado pelo overflow do
+           container. */
+        padding: 4px;
+
+        & .fi-ta-record {
+            position: relative;
+            border-radius: var(--radius-lg);
+        }
+
+        /* O position: relative acima empilha os cards na ordem do DOM, então
+           o card seguinte pintava por cima do dropdown aberto do anterior.
+           Com foco dentro (trigger clicado) ou painel visível, o card sobe. */
+        & .fi-ta-record:focus-within,
+        & .fi-ta-record:has(.fi-dropdown-panel:not([style*='display: none'])) {
+            z-index: 10;
+        }
+
+        /* O wrapper tem padding próprio de 16px que dobrava a altura do
+           card; o respiro fica todo no record-content. */
+        & .fi-ta-record-content-ctn {
+            padding: 0;
+        }
+
+        & .fi-ta-record-content {
+            padding: 12px 16px;
+        }
+
+        & .fi-ta-text:not(.fi-inline) {
+            padding: 0;
+        }
+
+        /* line-height de tabela (24px) esticava o card. */
+        & .fi-ta-text-item {
+            line-height: 1.3;
+        }
+
+        & .fi-badge {
+            flex-direction: column;
+            row-gap: 2px;
+            font-size: 12px;
+            font-weight: 700;
+
+            & .fi-icon {
+                width: 2rem;
+                height: 2rem;
+            }
+        }
+
+        & .fi-apt-card-title .fi-ta-text-item {
+            color: var(--gray-950);
+        }
+
+        & .fi-ta-actions {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+            inset-inline-end: 8px;
+        }
+    }
+
+    &:where(.dark, .dark *) .fi-ta-content-grid .fi-apt-card-title .fi-ta-text-item {
+        color: white;
     }
 
     & .fi-pagination {
@@ -434,6 +545,21 @@
 
 .fi-page:has(.fi-ta):where(.dark, .dark *) .fi-header {
     border-bottom-color: rgb(255 255 255 / 0.1);
+}
+
+/*
+ * Dropdowns do painel: o gray-900 do vendor é praticamente a cor dos cards
+ * (white/5 sobre preto) e a sombra padrão é imperceptível no tema escuro —
+ * aberto sobre um card, o painel parecia transparente. Um degrau de cor e
+ * sombra de verdade devolvem a elevação.
+ */
+.fi-dropdown-panel {
+    box-shadow: 0 12px 32px rgb(0 0 0 / 0.35);
+}
+
+:where(.dark, .dark *) .fi-dropdown-panel {
+    background-color: var(--gray-800);
+    box-shadow: 0 12px 32px rgb(0 0 0 / 0.6);
 }
 
 .scrollbar-hidden::-webkit-scrollbar {

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -183,13 +183,16 @@
 }
 
 /*
- * Listagem "Meus Agendamentos" (.fi-apt-table via extraAttributes): a tabela
- * do resource vira uma lista flat — sem o card do Filament, colunas rentes à
- * margem da página, linhas altas separadas por réguas finas. Badges perdem o
- * pill: fica o ícone na cor do enum ao lado do texto neutro. A paginação segue
- * o desenho de quadrados soltos com a página ativa preenchida em primary.
+ * Tabelas do painel — todas, sem opt-in por resource (este tema só é
+ * carregado pelo painel do colaborador): lista flat sem o card do Filament,
+ * colunas rentes à margem da página, linhas altas separadas por réguas finas.
+ * Badges perdem o pill: fica o ícone colorido ao lado do texto no token
+ * text-medium. A paginação segue o desenho de quadrados soltos com a página
+ * ativa preenchida em primary. Os comportamentos correspondentes (6 por
+ * página, saltos extremos, rótulos de busca/filtro) ficam no bootUsing do
+ * AppPanelProvider.
  */
-.fi-apt-table {
+.fi-ta {
     /* O card do container: bg + ring (box-shadow no Tailwind). */
     & .fi-ta-ctn {
         background-color: transparent;
@@ -293,8 +296,8 @@
         }
     }
 
-    /* Cor do ícone por categoria e status, nos tokens Flamma. As classes
-       vêm de extraCellAttributes na AppointmentsTable. */
+    /* Cor do ícone por categoria e status de consultoria, nos tokens Flamma.
+       As classes vêm de extraCellAttributes na AppointmentsTable. */
     & .fi-apt-cat-personal-finance .fi-badge .fi-icon,
     & .fi-apt-status-active .fi-badge .fi-icon,
     & .fi-apt-status-completed .fi-badge .fi-icon {
@@ -416,11 +419,11 @@
 }
 
 /*
- * Cabeçalho da página que hospeda a listagem: título no tamanho display do
- * layout e régua separando do conteúdo. O :has() amarra ao .fi-apt-table para
- * não vazar para as demais páginas do painel.
+ * Cabeçalho das páginas que hospedam listagens: título no tamanho display do
+ * layout e régua separando do conteúdo. O :has() amarra à presença de uma
+ * tabela para não vazar para as demais páginas do painel.
  */
-.fi-page:has(.fi-apt-table) .fi-header {
+.fi-page:has(.fi-ta) .fi-header {
     padding-bottom: var(--apt-space);
     border-bottom: 1px solid var(--gray-200);
 
@@ -429,7 +432,7 @@
     }
 }
 
-.fi-page:has(.fi-apt-table):where(.dark, .dark *) .fi-header {
+.fi-page:has(.fi-ta):where(.dark, .dark *) .fi-header {
     border-bottom-color: rgb(255 255 255 / 0.1);
 }
 


### PR DESCRIPTION
<img width="1907" height="952" alt="Screenshot 2026-08-04 at 14 46 33" src="https://github.com/user-attachments/assets/4882a28a-990d-472e-914e-3ec1f9097ddd" />


Ajustes na página de materiais

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a personal materials area for viewing, creating, downloading, editing, and deleting documents.
  * Improved shared document browsing with active shared files, access actions, sorting, and clearer document details.
  * Added localized table search and filter controls in English and Portuguese.

* **Enhancements**
  * Updated appointment and document table labels and filters.
  * Improved responsive table layouts, pagination, cards, dropdowns, and dark-mode styling.
  * Simplified page navigation by removing unnecessary breadcrumbs and tabs.

* **Tests**
  * Added coverage for personal document visibility and available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->