### PR TITLE
feat(billing): pedido de crédito local em vez de metadata do gateway

### DIFF
--- a/app-modules/billing/database/factories/CreditOrderFactory.php
+++ b/app-modules/billing/database/factories/CreditOrderFactory.php
@@ -28,7 +28,7 @@ class CreditOrderFactory extends Factory
             'billable_id' => User::factory(),
             'company_id' => Company::factory(),
             'quantity' => $quantity,
-            'amount_cents' => $quantity * UserCredit::PRICE_IN_CENTS,
+            'amount_cents' => fn (array $attributes): int => UserCredit::priceFor($attributes['quantity']),
             'status' => CreditOrderStatusEnum::Pending,
             'paid_at' => null,
         ];

--- a/app-modules/billing/database/factories/CreditOrderFactory.php
+++ b/app-modules/billing/database/factories/CreditOrderFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Database\Factories;
+
+use App\Models\Users\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Company\Models\Company;
+
+/** @extends Factory<CreditOrder> */
+class CreditOrderFactory extends Factory
+{
+    protected $model = CreditOrder::class;
+
+    public function definition(): array
+    {
+        $quantity = $this->faker->numberBetween(1, 10);
+
+        return [
+            'provider' => BillingProviderEnum::checkoutCases()[0],
+            'checkout_id' => 'checkout_' . $this->faker->unique()->uuid(),
+            'billable_type' => (new User)->getMorphClass(),
+            'billable_id' => User::factory(),
+            'company_id' => Company::factory(),
+            'quantity' => $quantity,
+            'amount_cents' => $quantity * 15000,
+            'status' => CreditOrderStatusEnum::Pending,
+            'paid_at' => null,
+        ];
+    }
+
+    public function paid(): self
+    {
+        return $this->state([
+            'status' => CreditOrderStatusEnum::Paid,
+            'paid_at' => now(),
+        ]);
+    }
+
+    public function forCompany(Company $company): self
+    {
+        return $this->state([
+            'billable_type' => $company->getMorphClass(),
+            'billable_id' => $company->getKey(),
+            'company_id' => $company->getKey(),
+        ]);
+    }
+}

--- a/app-modules/billing/database/factories/CreditOrderFactory.php
+++ b/app-modules/billing/database/factories/CreditOrderFactory.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
 
 /** @extends Factory<CreditOrder> */
@@ -27,7 +28,7 @@ class CreditOrderFactory extends Factory
             'billable_id' => User::factory(),
             'company_id' => Company::factory(),
             'quantity' => $quantity,
-            'amount_cents' => $quantity * 15000,
+            'amount_cents' => $quantity * UserCredit::PRICE_IN_CENTS,
             'status' => CreditOrderStatusEnum::Pending,
             'paid_at' => null,
         ];

--- a/app-modules/billing/database/migrations/2026_08_15_130000_create_billing_credit_orders_table.php
+++ b/app-modules/billing/database/migrations/2026_08_15_130000_create_billing_credit_orders_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('billing_credit_orders', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('provider');
+            $table->string('checkout_id')->nullable();
+            $table->string('billable_type');
+            $table->string('billable_id');
+            $table->foreignUuid('company_id')->constrained('companies')->cascadeOnDelete();
+            $table->unsignedInteger('quantity');
+            $table->unsignedInteger('amount_cents');
+            $table->string('status')->default('pending');
+            $table->timestamp('paid_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['provider', 'checkout_id']);
+            $table->index(['billable_type', 'billable_id']);
+            $table->index(['status', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('billing_credit_orders');
+    }
+};

--- a/app-modules/billing/database/migrations/2026_08_15_130000_create_credit_orders_table.php
+++ b/app-modules/billing/database/migrations/2026_08_15_130000_create_credit_orders_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('billing_credit_orders', function (Blueprint $table): void {
+        Schema::create('credit_orders', function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->string('provider');
             $table->string('checkout_id')->nullable();
@@ -32,6 +32,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('billing_credit_orders');
+        Schema::dropIfExists('credit_orders');
     }
 };

--- a/app-modules/billing/database/migrations/2026_08_15_140000_add_credit_order_id_to_user_credits_table.php
+++ b/app-modules/billing/database/migrations/2026_08_15_140000_add_credit_order_id_to_user_credits_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_credits', function (Blueprint $table): void {
+            $table->foreignUuid('credit_order_id')
+                ->nullable()
+                ->after('grant_id')
+                ->constrained('credit_orders')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_credits', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('credit_order_id');
+        });
+    }
+};

--- a/app-modules/billing/lang/en/enums.php
+++ b/app-modules/billing/lang/en/enums.php
@@ -3,6 +3,10 @@
 declare(strict_types=1);
 
 return [
+    'credit_order_status' => [
+        'pending' => 'Awaiting payment',
+        'paid' => 'Paid',
+    ],
     'price_audience' => [
         'subsidized' => 'Subsidized',
         'standalone' => 'Full price',

--- a/app-modules/billing/lang/pt_BR/enums.php
+++ b/app-modules/billing/lang/pt_BR/enums.php
@@ -3,6 +3,10 @@
 declare(strict_types=1);
 
 return [
+    'credit_order_status' => [
+        'pending' => 'Aguardando pagamento',
+        'paid' => 'Pago',
+    ],
     'price_audience' => [
         'subsidized' => 'Subsidiado',
         'standalone' => 'Valor cheio',

--- a/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
+++ b/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
@@ -13,7 +13,6 @@ use TresPontosTech\Billing\Barte\DTOs\BarteWebhookDto;
 use TresPontosTech\Billing\Barte\Enums\BarteWebhookEventEnum;
 use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
-use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionActivated;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCancelled;
@@ -106,37 +105,11 @@ class HandleBarteWebhook
     {
         $creditOrderId = $dto->metadata->get('credit_order_id');
 
-        if (is_string($creditOrderId) && filled($creditOrderId)) {
-            return CreditOrder::query()->find($creditOrderId);
-        }
-
-        return $this->createOrderFromLegacyMetadata($dto);
-    }
-
-    private function createOrderFromLegacyMetadata(BarteWebhookDto $dto): ?CreditOrder
-    {
-        $billableType = $dto->metadata->get('billable_type');
-        $billableId = $dto->metadata->get('billable_id');
-        $companyId = $dto->metadata->get('company_id');
-        $quantity = (int) $dto->metadata->get('quantity', 0);
-
-        if (! $billableType || ! $billableId || ! $companyId || $quantity <= 0) {
+        if (! is_string($creditOrderId) || blank($creditOrderId)) {
             return null;
         }
 
-        Log::info('Barte ORDER webhook no formato antigo: pedido reconstruído da metadata', ['uuid' => $dto->uuid]);
-
-        return CreditOrder::query()->firstOrCreate(
-            ['provider' => BillingProviderEnum::Barte, 'checkout_id' => $dto->uuid],
-            [
-                'billable_type' => $billableType,
-                'billable_id' => $billableId,
-                'company_id' => $companyId,
-                'quantity' => $quantity,
-                'amount_cents' => $quantity * 150 * 100,
-                'status' => CreditOrderStatusEnum::Pending,
-            ]
-        );
+        return CreditOrder::query()->find($creditOrderId);
     }
 
     private function notifyOrderPending(string $billableType, string $billableId, int $quantity): void

--- a/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
+++ b/app-modules/billing/src/Barte/Actions/HandleBarteWebhook.php
@@ -13,12 +13,14 @@ use TresPontosTech\Billing\Barte\DTOs\BarteWebhookDto;
 use TresPontosTech\Billing\Barte\Enums\BarteWebhookEventEnum;
 use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionActivated;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCancelled;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCreated;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionDefaulted;
 use TresPontosTech\Billing\Core\Models\BillingCustomer;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\Plan;
 use TresPontosTech\Company\Models\Company;
 
@@ -83,30 +85,58 @@ class HandleBarteWebhook
             return;
         }
 
+        $order = $this->resolveCreditOrder($dto);
+
+        if (! $order instanceof CreditOrder) {
+            Log::warning('Barte ORDER webhook sem pedido de crédito correspondente', ['uuid' => $dto->uuid]);
+
+            return;
+        }
+
+        if ($dto->event === BarteWebhookEventEnum::OrderSent) {
+            $this->notifyOrderPending($order->billable_type, $order->billable_id, $order->quantity);
+
+            return;
+        }
+
+        event(new OrderCreditPurchased(creditOrderId: $order->getKey()));
+    }
+
+    private function resolveCreditOrder(BarteWebhookDto $dto): ?CreditOrder
+    {
+        $creditOrderId = $dto->metadata->get('credit_order_id');
+
+        if (is_string($creditOrderId) && filled($creditOrderId)) {
+            return CreditOrder::query()->find($creditOrderId);
+        }
+
+        return $this->createOrderFromLegacyMetadata($dto);
+    }
+
+    private function createOrderFromLegacyMetadata(BarteWebhookDto $dto): ?CreditOrder
+    {
         $billableType = $dto->metadata->get('billable_type');
         $billableId = $dto->metadata->get('billable_id');
         $companyId = $dto->metadata->get('company_id');
         $quantity = (int) $dto->metadata->get('quantity', 0);
 
         if (! $billableType || ! $billableId || ! $companyId || $quantity <= 0) {
-            Log::warning('Barte ORDER webhook com metadata incompleto', ['uuid' => $dto->uuid]);
-
-            return;
+            return null;
         }
 
-        if ($dto->event === BarteWebhookEventEnum::OrderSent) {
-            $this->notifyOrderPending($billableType, $billableId, $quantity);
+        Log::info('Barte ORDER webhook no formato antigo: pedido reconstruído da metadata', ['uuid' => $dto->uuid]);
 
-            return;
-        }
-
-        event(new OrderCreditPurchased(
-            orderUuid: $dto->uuid,
-            billableType: $billableType,
-            billableId: $billableId,
-            companyId: $companyId,
-            quantity: $quantity,
-        ));
+        return CreditOrder::query()->firstOrCreate(
+            ['provider' => BillingProviderEnum::Barte, 'checkout_id' => $dto->uuid],
+            [
+                'billable_type' => $billableType,
+                'billable_id' => $billableId,
+                'company_id' => $companyId,
+                'quantity' => $quantity,
+                'amount_cents' => $quantity * 150 * 100,
+                'status' => CreditOrderStatusEnum::Pending,
+            ]
+        );
     }
 
     private function notifyOrderPending(string $billableType, string $billableId, int $quantity): void

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -8,6 +8,7 @@ use TresPontosTech\Billing\Barte\DTOs\CreatePaymentLinkDto;
 use TresPontosTech\Billing\Barte\DTOs\PaymentOrderDto;
 use TresPontosTech\Billing\Barte\DTOs\PaymentSubscriptionDto;
 use TresPontosTech\Billing\Core\Actions\CreateBillingCustomer;
+use TresPontosTech\Billing\Core\Actions\Credit\StartCreditOrder;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\Contracts\SupportsSubscriptionCancellation;
@@ -167,14 +168,19 @@ final readonly class BarteAdapter implements BillingContract, SupportsCreditPurc
 
         $pricePerCredit = 150;
 
+        $order = resolve(StartCreditOrder::class)->handle(
+            provider: BillingProviderEnum::Barte,
+            billable: $billable,
+            company: $company,
+            quantity: $quantity,
+            amountCents: $quantity * $pricePerCredit * 100,
+        );
+
         $response = $this->client->createPaymentLink(new CreatePaymentLinkDto(
             uuidSellerClient: $customerId,
             scheduledDate: now()->toDateString(),
             metadata: [
-                ['key' => 'billable_type', 'value' => $billable->getMorphClass()],
-                ['key' => 'billable_id', 'value' => (string) $billable->getKey()],
-                ['key' => 'company_id', 'value' => (string) $company->getKey()],
-                ['key' => 'quantity', 'value' => (string) $quantity],
+                ['key' => 'credit_order_id', 'value' => $order->getKey()],
             ],
             type: 'ORDER',
             paymentMethods: ['PIX', 'CREDIT_CARD_EARLY_BUYER'],

--- a/app-modules/billing/src/Barte/BarteAdapter.php
+++ b/app-modules/billing/src/Barte/BarteAdapter.php
@@ -166,14 +166,11 @@ final readonly class BarteAdapter implements BillingContract, SupportsCreditPurc
 
         $customerId = $this->findCustomer($billable);
 
-        $pricePerCredit = 150;
-
         $order = resolve(StartCreditOrder::class)->handle(
             provider: BillingProviderEnum::Barte,
             billable: $billable,
             company: $company,
             quantity: $quantity,
-            amountCents: $quantity * $pricePerCredit * 100,
         );
 
         $response = $this->client->createPaymentLink(new CreatePaymentLinkDto(
@@ -186,7 +183,7 @@ final readonly class BarteAdapter implements BillingContract, SupportsCreditPurc
             paymentMethods: ['PIX', 'CREDIT_CARD_EARLY_BUYER'],
             paymentOrder: new PaymentOrderDto(
                 title: sprintf('Compra de %d crédito(s)', $quantity),
-                value: $quantity * $pricePerCredit,
+                value: $order->amount_cents / 100,
                 customInstallmentsValues: [
                     ['paymentMethod' => 'PIX', 'installments' => 1],
                     ['paymentMethod' => 'CREDIT_CARD_EARLY_BUYER', 'installments' => 1],

--- a/app-modules/billing/src/Core/Actions/Credit/IssueCredits.php
+++ b/app-modules/billing/src/Core/Actions/Credit/IssueCredits.php
@@ -25,6 +25,7 @@ final readonly class IssueCredits
                     'holder_id' => $dto->holderId,
                     'company_id' => $dto->companyId,
                     'grant_id' => $dto->grantId,
+                    'credit_order_id' => $dto->creditOrderId,
                     'status' => UserCreditStatusEnum::Available,
                 ]);
             }

--- a/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
@@ -21,25 +21,18 @@ final readonly class SettleCreditOrder
 
     public function handle(string $creditOrderId): void
     {
-        $order = $this->claim($creditOrderId);
+        $delivered = $this->settle($creditOrderId);
 
-        if (! $order instanceof CreditOrder) {
+        if (! $delivered instanceof CreditsDelivered) {
             return;
         }
 
-        $dto = $this->creditFor($order);
-
-        $this->issueCredits->handle($dto);
-
-        event(new CreditsDelivered(
-            ownerId: (string) $dto->ownerId,
-            quantity: $order->quantity,
-        ));
+        event($delivered);
     }
 
-    private function claim(string $creditOrderId): ?CreditOrder
+    private function settle(string $creditOrderId): ?CreditsDelivered
     {
-        return DB::transaction(function () use ($creditOrderId): ?CreditOrder {
+        return DB::transaction(function () use ($creditOrderId): ?CreditsDelivered {
             $order = CreditOrder::query()
                 ->whereKey($creditOrderId)
                 ->lockForUpdate()
@@ -49,12 +42,19 @@ final readonly class SettleCreditOrder
                 return null;
             }
 
+            $dto = $this->creditFor($order);
+
+            $this->issueCredits->handle($dto);
+
             $order->update([
                 'status' => CreditOrderStatusEnum::Paid,
                 'paid_at' => now(),
             ]);
 
-            return $order;
+            return new CreditsDelivered(
+                ownerId: (string) $dto->ownerId,
+                quantity: $order->quantity,
+            );
         });
     }
 

--- a/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
@@ -69,6 +69,7 @@ final readonly class SettleCreditOrder
                 ownerId: $billable->getKey(),
                 companyId: $order->company_id,
                 quantity: $order->quantity,
+                creditOrderId: $order->getKey(),
             );
         }
 
@@ -78,6 +79,7 @@ final readonly class SettleCreditOrder
             ownerId: $billable->user_id,
             companyId: $billable->getKey(),
             quantity: $order->quantity,
+            creditOrderId: $order->getKey(),
         );
     }
 }

--- a/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/SettleCreditOrder.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Actions\Credit;
+
+use App\Models\Users\User;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\DB;
+use TresPontosTech\Billing\Core\DTOs\CreditDTO;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Events\Credit\CreditsDelivered;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Company\Models\Company;
+
+final readonly class SettleCreditOrder
+{
+    public function __construct(
+        private IssueCredits $issueCredits,
+    ) {}
+
+    public function handle(string $creditOrderId): void
+    {
+        $order = $this->claim($creditOrderId);
+
+        if (! $order instanceof CreditOrder) {
+            return;
+        }
+
+        $dto = $this->creditFor($order);
+
+        $this->issueCredits->handle($dto);
+
+        event(new CreditsDelivered(
+            ownerId: (string) $dto->ownerId,
+            quantity: $order->quantity,
+        ));
+    }
+
+    private function claim(string $creditOrderId): ?CreditOrder
+    {
+        return DB::transaction(function () use ($creditOrderId): ?CreditOrder {
+            $order = CreditOrder::query()
+                ->whereKey($creditOrderId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $order instanceof CreditOrder || $order->isPaid()) {
+                return null;
+            }
+
+            $order->update([
+                'status' => CreditOrderStatusEnum::Paid,
+                'paid_at' => now(),
+            ]);
+
+            return $order;
+        });
+    }
+
+    private function creditFor(CreditOrder $order): CreditDTO
+    {
+        $modelClass = Relation::getMorphedModel($order->billable_type);
+        $billable = $modelClass::findOrFail($order->billable_id);
+
+        if ($billable instanceof User) {
+            return new CreditDTO(
+                holderId: $billable->getKey(),
+                ownerId: $billable->getKey(),
+                companyId: $order->company_id,
+                quantity: $order->quantity,
+            );
+        }
+
+        /** @var Company $billable */
+        return new CreditDTO(
+            holderId: $billable->user_id,
+            ownerId: $billable->user_id,
+            companyId: $billable->getKey(),
+            quantity: $order->quantity,
+        );
+    }
+}

--- a/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Actions\Credit;
+
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Company\Models\Company;
+
+final readonly class StartCreditOrder
+{
+    public function handle(
+        BillingProviderEnum $provider,
+        Company|User $billable,
+        Company $company,
+        int $quantity,
+        int $amountCents,
+    ): CreditOrder {
+        return CreditOrder::query()->create([
+            'provider' => $provider,
+            'billable_type' => $billable->getMorphClass(),
+            'billable_id' => $billable->getKey(),
+            'company_id' => $company->getKey(),
+            'quantity' => $quantity,
+            'amount_cents' => $amountCents,
+            'status' => CreditOrderStatusEnum::Pending,
+        ]);
+    }
+}

--- a/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
@@ -8,6 +8,7 @@ use App\Models\Users\User;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
 
 final readonly class StartCreditOrder
@@ -17,7 +18,6 @@ final readonly class StartCreditOrder
         Company|User $billable,
         Company $company,
         int $quantity,
-        int $amountCents,
     ): CreditOrder {
         return CreditOrder::query()->create([
             'provider' => $provider,
@@ -25,7 +25,7 @@ final readonly class StartCreditOrder
             'billable_id' => $billable->getKey(),
             'company_id' => $company->getKey(),
             'quantity' => $quantity,
-            'amount_cents' => $amountCents,
+            'amount_cents' => $quantity * UserCredit::PRICE_IN_CENTS,
             'status' => CreditOrderStatusEnum::Pending,
         ]);
     }

--- a/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
+++ b/app-modules/billing/src/Core/Actions/Credit/StartCreditOrder.php
@@ -18,14 +18,16 @@ final readonly class StartCreditOrder
         Company|User $billable,
         Company $company,
         int $quantity,
+        ?string $checkoutId = null,
     ): CreditOrder {
         return CreditOrder::query()->create([
             'provider' => $provider,
+            'checkout_id' => $checkoutId,
             'billable_type' => $billable->getMorphClass(),
             'billable_id' => $billable->getKey(),
             'company_id' => $company->getKey(),
             'quantity' => $quantity,
-            'amount_cents' => $quantity * UserCredit::PRICE_IN_CENTS,
+            'amount_cents' => UserCredit::priceFor($quantity),
             'status' => CreditOrderStatusEnum::Pending,
         ]);
     }

--- a/app-modules/billing/src/Core/BillingManager.php
+++ b/app-modules/billing/src/Core/BillingManager.php
@@ -13,7 +13,7 @@ class BillingManager extends Manager
 {
     public function getDefaultDriver(): string
     {
-        return 'barte';
+        return BillingProviderEnum::checkoutCases()[0]->value;
     }
 
     public function createStripeDriver(): BillingContract
@@ -26,8 +26,10 @@ class BillingManager extends Manager
         return new BarteAdapter(new BarteClient);
     }
 
-    public function getDriver(BillingProviderEnum $provider = BillingProviderEnum::Barte): BillingContract
+    public function getDriver(?BillingProviderEnum $provider = null): BillingContract
     {
+        $provider ??= BillingProviderEnum::checkoutCases()[0];
+
         throw_if($provider === BillingProviderEnum::Contractual, \Exception::class, 'To be implemented');
 
         return $this->driver($provider->value);

--- a/app-modules/billing/src/Core/BillingManager.php
+++ b/app-modules/billing/src/Core/BillingManager.php
@@ -28,10 +28,8 @@ class BillingManager extends Manager
 
     public function getDriver(?BillingProviderEnum $provider = null): BillingContract
     {
-        $provider ??= BillingProviderEnum::checkoutCases()[0];
-
         throw_if($provider === BillingProviderEnum::Contractual, \Exception::class, 'To be implemented');
 
-        return $this->driver($provider->value);
+        return $this->driver($provider?->value);
     }
 }

--- a/app-modules/billing/src/Core/DTOs/CreditDTO.php
+++ b/app-modules/billing/src/Core/DTOs/CreditDTO.php
@@ -13,5 +13,6 @@ final readonly class CreditDTO
         public string|int|null $appointmentId = null,
         public int $quantity = 1,
         public string|int|null $grantId = null,
+        public ?string $creditOrderId = null,
     ) {}
 }

--- a/app-modules/billing/src/Core/DTOs/CreditOrderDTO.php
+++ b/app-modules/billing/src/Core/DTOs/CreditOrderDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\DTOs;
+
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
+
+final readonly class CreditOrderDTO
+{
+    public function __construct(
+        public BillingProviderEnum $provider,
+        public Company|User $billable,
+        public Company $company,
+        public int $quantity,
+        public ?string $checkoutId = null,
+    ) {}
+
+    public function amountCents(): int
+    {
+        return UserCredit::priceFor($this->quantity);
+    }
+
+    public function withCheckout(?string $checkoutId): self
+    {
+        return new self(
+            provider: $this->provider,
+            billable: $this->billable,
+            company: $this->company,
+            quantity: $this->quantity,
+            checkoutId: $checkoutId,
+        );
+    }
+}

--- a/app-modules/billing/src/Core/Enums/CreditOrderStatusEnum.php
+++ b/app-modules/billing/src/Core/Enums/CreditOrderStatusEnum.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Enums;
+
+use Filament\Support\Colors\Color;
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum CreditOrderStatusEnum: string implements HasColor, HasLabel
+{
+    case Pending = 'pending';
+
+    case Paid = 'paid';
+
+    public function getColor(): array
+    {
+        return match ($this) {
+            self::Pending => Color::Amber,
+            self::Paid => Color::Green,
+        };
+    }
+
+    public function getLabel(): string
+    {
+        return __('billing::enums.credit_order_status.' . $this->value);
+    }
+}

--- a/app-modules/billing/src/Core/Events/Credit/CreditOrderPlaced.php
+++ b/app-modules/billing/src/Core/Events/Credit/CreditOrderPlaced.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Events\Credit;
+
+use TresPontosTech\Billing\Core\DTOs\CreditOrderDTO;
+
+final class CreditOrderPlaced
+{
+    public function __construct(
+        public readonly CreditOrderDTO $dto,
+    ) {}
+}

--- a/app-modules/billing/src/Core/Events/Credit/OrderCreditPurchased.php
+++ b/app-modules/billing/src/Core/Events/Credit/OrderCreditPurchased.php
@@ -7,10 +7,6 @@ namespace TresPontosTech\Billing\Core\Events\Credit;
 final class OrderCreditPurchased
 {
     public function __construct(
-        public readonly string $orderUuid,
-        public readonly string $billableType,
-        public readonly string $billableId,
-        public readonly string $companyId,
-        public readonly int $quantity,
+        public readonly string $creditOrderId,
     ) {}
 }

--- a/app-modules/billing/src/Core/Jobs/ProcessCreditPurchaseJob.php
+++ b/app-modules/billing/src/Core/Jobs/ProcessCreditPurchaseJob.php
@@ -4,22 +4,14 @@ declare(strict_types=1);
 
 namespace TresPontosTech\Billing\Core\Jobs;
 
-use App\Models\Users\User;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
-use TresPontosTech\Billing\Core\Actions\Credit\IssueCredits;
-use TresPontosTech\Billing\Core\DTOs\CreditDTO;
-use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
-use TresPontosTech\Billing\Core\Events\Credit\CreditsDelivered;
+use TresPontosTech\Billing\Core\Actions\Credit\SettleCreditOrder;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
-use TresPontosTech\Billing\Core\Models\CreditOrder;
-use TresPontosTech\Company\Models\Company;
 
 class ProcessCreditPurchaseJob implements ShouldBeUnique, ShouldQueue
 {
@@ -41,54 +33,8 @@ class ProcessCreditPurchaseJob implements ShouldBeUnique, ShouldQueue
         return $this->event->creditOrderId;
     }
 
-    public function handle(IssueCredits $action): void
+    public function handle(SettleCreditOrder $action): void
     {
-        $order = DB::transaction(function (): ?CreditOrder {
-            $order = CreditOrder::query()
-                ->whereKey($this->event->creditOrderId)
-                ->lockForUpdate()
-                ->first();
-
-            if (! $order instanceof CreditOrder || $order->isPaid()) {
-                return null;
-            }
-
-            $order->update([
-                'status' => CreditOrderStatusEnum::Paid,
-                'paid_at' => now(),
-            ]);
-
-            return $order;
-        });
-
-        if (! $order instanceof CreditOrder) {
-            return;
-        }
-
-        $modelClass = Relation::getMorphedModel($order->billable_type);
-        $billable = $modelClass::findOrFail($order->billable_id);
-
-        if ($billable instanceof User) {
-            $dto = new CreditDTO(
-                holderId: $billable->getKey(),
-                ownerId: $billable->getKey(),
-                companyId: $order->company_id,
-                quantity: $order->quantity,
-            );
-            $ownerId = (string) $billable->getKey();
-        } else {
-            /** @var Company $billable */
-            $dto = new CreditDTO(
-                holderId: $billable->user_id,
-                ownerId: $billable->user_id,
-                companyId: $billable->getKey(),
-                quantity: $order->quantity,
-            );
-            $ownerId = (string) $billable->user_id;
-        }
-
-        $action->handle($dto);
-
-        event(new CreditsDelivered(ownerId: $ownerId, quantity: $order->quantity));
+        $action->handle($this->event->creditOrderId);
     }
 }

--- a/app-modules/billing/src/Core/Jobs/ProcessCreditPurchaseJob.php
+++ b/app-modules/billing/src/Core/Jobs/ProcessCreditPurchaseJob.php
@@ -12,10 +12,13 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
 use TresPontosTech\Billing\Core\Actions\Credit\IssueCredits;
 use TresPontosTech\Billing\Core\DTOs\CreditDTO;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\CreditsDelivered;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Company\Models\Company;
 
 class ProcessCreditPurchaseJob implements ShouldBeUnique, ShouldQueue
@@ -35,20 +38,42 @@ class ProcessCreditPurchaseJob implements ShouldBeUnique, ShouldQueue
 
     public function uniqueId(): string
     {
-        return $this->event->orderUuid;
+        return $this->event->creditOrderId;
     }
 
     public function handle(IssueCredits $action): void
     {
-        $modelClass = Relation::getMorphedModel($this->event->billableType);
-        $billable = $modelClass::findOrFail($this->event->billableId);
+        $order = DB::transaction(function (): ?CreditOrder {
+            $order = CreditOrder::query()
+                ->whereKey($this->event->creditOrderId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $order instanceof CreditOrder || $order->isPaid()) {
+                return null;
+            }
+
+            $order->update([
+                'status' => CreditOrderStatusEnum::Paid,
+                'paid_at' => now(),
+            ]);
+
+            return $order;
+        });
+
+        if (! $order instanceof CreditOrder) {
+            return;
+        }
+
+        $modelClass = Relation::getMorphedModel($order->billable_type);
+        $billable = $modelClass::findOrFail($order->billable_id);
 
         if ($billable instanceof User) {
             $dto = new CreditDTO(
                 holderId: $billable->getKey(),
                 ownerId: $billable->getKey(),
-                companyId: $this->event->companyId,
-                quantity: $this->event->quantity,
+                companyId: $order->company_id,
+                quantity: $order->quantity,
             );
             $ownerId = (string) $billable->getKey();
         } else {
@@ -57,13 +82,13 @@ class ProcessCreditPurchaseJob implements ShouldBeUnique, ShouldQueue
                 holderId: $billable->user_id,
                 ownerId: $billable->user_id,
                 companyId: $billable->getKey(),
-                quantity: $this->event->quantity,
+                quantity: $order->quantity,
             );
             $ownerId = (string) $billable->user_id;
         }
 
         $action->handle($dto);
 
-        event(new CreditsDelivered(ownerId: $ownerId, quantity: $this->event->quantity));
+        event(new CreditsDelivered(ownerId: $ownerId, quantity: $order->quantity));
     }
 }

--- a/app-modules/billing/src/Core/Listeners/Credit/PersistCreditOrder.php
+++ b/app-modules/billing/src/Core/Listeners/Credit/PersistCreditOrder.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Listeners\Credit;
+
+use TresPontosTech\Billing\Core\Actions\Credit\StartCreditOrder;
+use TresPontosTech\Billing\Core\Events\Credit\CreditOrderPlaced;
+
+class PersistCreditOrder
+{
+    public function __construct(private readonly StartCreditOrder $action) {}
+
+    public function handle(CreditOrderPlaced $event): void
+    {
+        $this->action->handle(
+            provider: $event->dto->provider,
+            billable: $event->dto->billable,
+            company: $event->dto->company,
+            quantity: $event->dto->quantity,
+            checkoutId: $event->dto->checkoutId,
+        );
+    }
+}

--- a/app-modules/billing/src/Core/Models/CreditOrder.php
+++ b/app-modules/billing/src/Core/Models/CreditOrder.php
@@ -41,8 +41,6 @@ class CreditOrder extends Model
     use HasUuids;
     use SoftDeletes;
 
-    protected $table = 'billing_credit_orders';
-
     protected $fillable = [
         'provider',
         'checkout_id',

--- a/app-modules/billing/src/Core/Models/CreditOrder.php
+++ b/app-modules/billing/src/Core/Models/CreditOrder.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Billing\Core\Models;
+
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Database\Factories\CreditOrderFactory;
+use TresPontosTech\Company\Models\Company;
+
+/**
+ * @property string $id
+ * @property BillingProviderEnum $provider
+ * @property string|null $checkout_id
+ * @property string $billable_type
+ * @property string $billable_id
+ * @property string $company_id
+ * @property int $quantity
+ * @property int $amount_cents
+ * @property CreditOrderStatusEnum $status
+ * @property Carbon|null $paid_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
+ */
+#[UseFactory(CreditOrderFactory::class)]
+class CreditOrder extends Model
+{
+    /** @use HasFactory<CreditOrderFactory> */
+    use HasFactory;
+
+    use HasUuids;
+    use SoftDeletes;
+
+    protected $table = 'billing_credit_orders';
+
+    protected $fillable = [
+        'provider',
+        'checkout_id',
+        'billable_type',
+        'billable_id',
+        'company_id',
+        'quantity',
+        'amount_cents',
+        'status',
+        'paid_at',
+    ];
+
+    /**
+     * @return MorphTo<Model, $this>
+     */
+    public function billable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    /**
+     * @return BelongsTo<Company, $this>
+     */
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function isPaid(): bool
+    {
+        return $this->status === CreditOrderStatusEnum::Paid;
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'provider' => BillingProviderEnum::class,
+            'status' => CreditOrderStatusEnum::class,
+            'quantity' => 'integer',
+            'amount_cents' => 'integer',
+            'paid_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/billing/src/Core/Models/CreditOrder.php
+++ b/app-modules/billing/src/Core/Models/CreditOrder.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace TresPontosTech\Billing\Core\Models;
 
+use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
@@ -67,6 +69,25 @@ class CreditOrder extends Model
     public function company(): BelongsTo
     {
         return $this->belongsTo(Company::class);
+    }
+
+    /**
+     * @return HasMany<UserCredit, $this>
+     */
+    public function credits(): HasMany
+    {
+        return $this->hasMany(UserCredit::class);
+    }
+
+    public function buyerName(): ?string
+    {
+        $billable = $this->billable;
+
+        if ($billable instanceof Company || $billable instanceof User) {
+            return $billable->name;
+        }
+
+        return null;
     }
 
     public function isPaid(): bool

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -26,6 +26,7 @@ use TresPontosTech\Company\Models\Company;
  * @property string $holder_id
  * @property string $company_id
  * @property string|null $grant_id
+ * @property string|null $credit_order_id
  * @property UserCreditStatusEnum $status
  * @property string|null $appointment_id
  * @property Carbon|null $transferred_at
@@ -47,6 +48,7 @@ class UserCredit extends Model
         'holder_id',
         'company_id',
         'grant_id',
+        'credit_order_id',
         'status',
         'appointment_id',
         'transferred_at',
@@ -90,6 +92,14 @@ class UserCredit extends Model
     public function appointment(): BelongsTo
     {
         return $this->belongsTo(Appointment::class);
+    }
+
+    /**
+     * @return BelongsTo<CreditOrder, $this>
+     */
+    public function creditOrder(): BelongsTo
+    {
+        return $this->belongsTo(CreditOrder::class);
     }
 
     /**

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -45,6 +45,11 @@ class UserCredit extends Model
 
     public const int PRICE_IN_CENTS = 15_000;
 
+    public static function priceFor(int $quantity): int
+    {
+        return $quantity * self::PRICE_IN_CENTS;
+    }
+
     protected $fillable = [
         'owner_id',
         'holder_id',

--- a/app-modules/billing/src/Core/Models/UserCredit.php
+++ b/app-modules/billing/src/Core/Models/UserCredit.php
@@ -43,6 +43,8 @@ class UserCredit extends Model
     use HasUuids;
     use SoftDeletes;
 
+    public const int PRICE_IN_CENTS = 15_000;
+
     protected $fillable = [
         'owner_id',
         'holder_id',

--- a/app-modules/billing/tests/Feature/Credit/PersistCreditOrderTest.php
+++ b/app-modules/billing/tests/Feature/Credit/PersistCreditOrderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use TresPontosTech\Billing\Core\DTOs\CreditOrderDTO;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Events\Credit\CreditOrderPlaced;
+use TresPontosTech\Billing\Core\Listeners\Credit\PersistCreditOrder;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
+
+it('opens the order when a gateway announces the checkout', function (): void {
+    $company = Company::factory()->create();
+
+    event(new CreditOrderPlaced(new CreditOrderDTO(
+        provider: BillingProviderEnum::Virtu,
+        billable: $company,
+        company: $company,
+        quantity: 2,
+        checkoutId: 'checkout_abc',
+    )));
+
+    $order = CreditOrder::query()->sole();
+
+    expect($order->provider)->toBe(BillingProviderEnum::Virtu)
+        ->and($order->billable_id)->toBe($company->getKey())
+        ->and($order->quantity)->toBe(2)
+        ->and($order->checkout_id)->toBe('checkout_abc')
+        ->and($order->status)->toBe(CreditOrderStatusEnum::Pending);
+});
+
+it('prices the order from the credit itself, not from the gateway', function (): void {
+    $company = Company::factory()->create();
+
+    event(new CreditOrderPlaced(new CreditOrderDTO(
+        provider: BillingProviderEnum::Virtu,
+        billable: $company,
+        company: $company,
+        quantity: 3,
+        checkoutId: 'checkout_abc',
+    )));
+
+    expect(CreditOrder::query()->sole()->amount_cents)->toBe(UserCredit::priceFor(3));
+});
+
+it('runs in the same request as the checkout', function (): void {
+    expect(is_subclass_of(PersistCreditOrder::class, ShouldQueue::class))->toBeFalse();
+});

--- a/app-modules/billing/tests/Feature/Credit/ProcessCreditPurchaseJobTest.php
+++ b/app-modules/billing/tests/Feature/Credit/ProcessCreditPurchaseJobTest.php
@@ -7,7 +7,6 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Concurrency;
 use Illuminate\Support\Facades\Queue;
-use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Jobs\ProcessCreditPurchaseJob;
 use TresPontosTech\Billing\Core\Models\CreditOrder;
@@ -26,18 +25,13 @@ class ProcessCreditPurchaseJobWithoutIdempotency extends ProcessCreditPurchaseJo
     }
 }
 
-function makeCreditOrder(int $quantity = 5, ?Company $company = null): CreditOrder
+function makeCreditEvent(int $quantity = 5): OrderCreditPurchased
 {
-    $company ??= Company::factory()->create();
-
-    return CreditOrder::factory()
-        ->forCompany($company)
+    $order = CreditOrder::factory()
+        ->forCompany(Company::factory()->create())
         ->create(['quantity' => $quantity]);
-}
 
-function makeCreditEvent(?CreditOrder $order = null): OrderCreditPurchased
-{
-    return new OrderCreditPurchased(creditOrderId: ($order ?? makeCreditOrder())->getKey());
+    return new OrderCreditPurchased(creditOrderId: $order->getKey());
 }
 
 // --- vulnerability tests (documents the bug without the protection) ---
@@ -98,32 +92,14 @@ it('with ShouldBeUnique: concurrent webhooks for the same order queue only 1 job
     Queue::assertPushed(ProcessCreditPurchaseJob::class, 1);
 });
 
-it('issues the credits and settles the order', function (): void {
-    $company = Company::factory()->create();
-    $order = makeCreditOrder(3, $company);
-
-    dispatch_sync(new ProcessCreditPurchaseJob(makeCreditEvent($order)));
-
-    expect(UserCredit::query()->count())->toBe(3)
-        ->and($order->refresh()->status)->toBe(CreditOrderStatusEnum::Paid)
-        ->and($order->paid_at)->not->toBeNull();
-});
-
-it('does not issue credits twice even when dispatchSync bypasses ShouldBeUnique', function (): void {
-    $order = makeCreditOrder(3);
-    $event = makeCreditEvent($order);
-
-    // dispatchSync bypasses ShouldBeUnique entirely: the settled order is what
-    // stops the second run.
-    dispatch_sync(new ProcessCreditPurchaseJob($event));
-    dispatch_sync(new ProcessCreditPurchaseJob($event));
+it('hands the order over to be settled', function (): void {
+    dispatch_sync(new ProcessCreditPurchaseJob(makeCreditEvent(3)));
 
     expect(UserCredit::query()->count())->toBe(3);
 });
 
 it('with ShouldBeUnique: a duplicate dispatch while job is pending creates no extra credits', function (): void {
-    $order = makeCreditOrder(3);
-    $event = makeCreditEvent($order);
+    $event = makeCreditEvent(3);
 
     $job = new ProcessCreditPurchaseJob($event);
 
@@ -135,10 +111,4 @@ it('with ShouldBeUnique: a duplicate dispatch while job is pending creates no ex
     dispatch($job);
 
     expect(UserCredit::query()->count())->toBe(3);
-});
-
-it('ignores an event pointing at an order that no longer exists', function (): void {
-    dispatch_sync(new ProcessCreditPurchaseJob(new OrderCreditPurchased(creditOrderId: '00000000-0000-0000-0000-000000000000')));
-
-    expect(UserCredit::query()->count())->toBe(0);
 });

--- a/app-modules/billing/tests/Feature/Credit/ProcessCreditPurchaseJobTest.php
+++ b/app-modules/billing/tests/Feature/Credit/ProcessCreditPurchaseJobTest.php
@@ -7,15 +7,16 @@ use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Concurrency;
 use Illuminate\Support\Facades\Queue;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Jobs\ProcessCreditPurchaseJob;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
 
 /**
  * Test subclass that breaks idempotency: returns a random uniqueId on every
  * dispatch so ShouldBeUnique never detects a duplicate.
- * Used only to document the vulnerability in tests.
  */
 class ProcessCreditPurchaseJobWithoutIdempotency extends ProcessCreditPurchaseJob
 {
@@ -25,15 +26,18 @@ class ProcessCreditPurchaseJobWithoutIdempotency extends ProcessCreditPurchaseJo
     }
 }
 
-function makeCreditEvent(string $orderUuid = 'order-uuid-test'): OrderCreditPurchased
+function makeCreditOrder(int $quantity = 5, ?Company $company = null): CreditOrder
 {
-    return new OrderCreditPurchased(
-        orderUuid: $orderUuid,
-        billableType: 'company',
-        billableId: '1',
-        companyId: '1',
-        quantity: 5,
-    );
+    $company ??= Company::factory()->create();
+
+    return CreditOrder::factory()
+        ->forCompany($company)
+        ->create(['quantity' => $quantity]);
+}
+
+function makeCreditEvent(?CreditOrder $order = null): OrderCreditPurchased
+{
+    return new OrderCreditPurchased(creditOrderId: ($order ?? makeCreditOrder())->getKey());
 }
 
 // --- vulnerability tests (documents the bug without the protection) ---
@@ -41,7 +45,7 @@ function makeCreditEvent(string $orderUuid = 'order-uuid-test'): OrderCreditPurc
 it('without idempotency: duplicate webhooks queue 2 jobs (vulnerability)', function (): void {
     Queue::fake();
 
-    $event = makeCreditEvent('order-uuid-no-protection');
+    $event = makeCreditEvent();
 
     Concurrency::driver('sync')->run([
         fn (): PendingDispatch => dispatch(new ProcessCreditPurchaseJobWithoutIdempotency($event)),
@@ -56,15 +60,15 @@ it('without idempotency: duplicate webhooks queue 2 jobs (vulnerability)', funct
 it('dispatches the job normally for a new order', function (): void {
     Queue::fake();
 
-    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent('order-uuid-1')));
+    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent()));
 
     Queue::assertPushed(ProcessCreditPurchaseJob::class, 1);
 });
 
-it('does not dispatch a duplicate job for the same order uuid', function (): void {
+it('does not dispatch a duplicate job for the same order', function (): void {
     Queue::fake();
 
-    $event = makeCreditEvent('order-uuid-duplicate');
+    $event = makeCreditEvent();
 
     dispatch(new ProcessCreditPurchaseJob($event));
     dispatch(new ProcessCreditPurchaseJob($event));
@@ -72,19 +76,19 @@ it('does not dispatch a duplicate job for the same order uuid', function (): voi
     Queue::assertPushed(ProcessCreditPurchaseJob::class, 1);
 });
 
-it('dispatches distinct jobs for different order uuids', function (): void {
+it('dispatches distinct jobs for different orders', function (): void {
     Queue::fake();
 
-    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent('order-uuid-A')));
-    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent('order-uuid-B')));
+    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent()));
+    dispatch(new ProcessCreditPurchaseJob(makeCreditEvent()));
 
     Queue::assertPushed(ProcessCreditPurchaseJob::class, 2);
 });
 
-it('with ShouldBeUnique: concurrent webhooks with the same uuid queue only 1 job', function (): void {
+it('with ShouldBeUnique: concurrent webhooks for the same order queue only 1 job', function (): void {
     Queue::fake();
 
-    $event = makeCreditEvent('order-uuid-concurrent');
+    $event = makeCreditEvent();
 
     Concurrency::driver('sync')->run([
         fn (): PendingDispatch => dispatch(new ProcessCreditPurchaseJob($event)),
@@ -94,47 +98,47 @@ it('with ShouldBeUnique: concurrent webhooks with the same uuid queue only 1 job
     Queue::assertPushed(ProcessCreditPurchaseJob::class, 1);
 });
 
-it('without idempotency: dispatching twice creates double the credits in the database', function (): void {
+it('issues the credits and settles the order', function (): void {
     $company = Company::factory()->create();
+    $order = makeCreditOrder(3, $company);
 
-    $event = new OrderCreditPurchased(
-        orderUuid: 'order-uuid-db-vulnerable',
-        billableType: 'company',
-        billableId: (string) $company->getKey(),
-        companyId: (string) $company->getKey(),
-        quantity: 3,
-    );
+    dispatch_sync(new ProcessCreditPurchaseJob(makeCreditEvent($order)));
 
-    // dispatchSync bypasses ShouldBeUnique entirely → no protection
+    expect(UserCredit::query()->count())->toBe(3)
+        ->and($order->refresh()->status)->toBe(CreditOrderStatusEnum::Paid)
+        ->and($order->paid_at)->not->toBeNull();
+});
 
+it('does not issue credits twice even when dispatchSync bypasses ShouldBeUnique', function (): void {
+    $order = makeCreditOrder(3);
+    $event = makeCreditEvent($order);
+
+    // dispatchSync bypasses ShouldBeUnique entirely: the settled order is what
+    // stops the second run.
     dispatch_sync(new ProcessCreditPurchaseJob($event));
     dispatch_sync(new ProcessCreditPurchaseJob($event));
 
-    expect(UserCredit::query()->count())->toBe(6);
+    expect(UserCredit::query()->count())->toBe(3);
 });
 
 it('with ShouldBeUnique: a duplicate dispatch while job is pending creates no extra credits', function (): void {
-    $company = Company::factory()->create();
-
-    $event = new OrderCreditPurchased(
-        orderUuid: 'order-uuid-db-protected',
-        billableType: 'company',
-        billableId: (string) $company->getKey(),
-        companyId: (string) $company->getKey(),
-        quantity: 3,
-    );
+    $order = makeCreditOrder(3);
+    $event = makeCreditEvent($order);
 
     $job = new ProcessCreditPurchaseJob($event);
 
     dispatch_sync(new ProcessCreditPurchaseJob($event));
     expect(UserCredit::query()->count())->toBe(3);
 
-    // Simulate the job still pending in queue (lock held by another process/request),
-    // as if the first job hasn't finished processing yet in an async queue.
-
     Cache::lock(UniqueLock::getKey($job), 3600)->get();
 
-    dispatch($job); // lock is held → duplicate is dropped by ShouldBeUnique
+    dispatch($job);
 
-    expect(UserCredit::query()->count())->toBe(3); // no extra credits created
+    expect(UserCredit::query()->count())->toBe(3);
+});
+
+it('ignores an event pointing at an order that no longer exists', function (): void {
+    dispatch_sync(new ProcessCreditPurchaseJob(new OrderCreditPurchased(creditOrderId: '00000000-0000-0000-0000-000000000000')));
+
+    expect(UserCredit::query()->count())->toBe(0);
 });

--- a/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
+++ b/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
@@ -26,6 +26,24 @@ it('issues the credits and settles the order', function (): void {
         ->and($order->paid_at)->not->toBeNull();
 });
 
+it('links every issued credit back to the order that paid for it', function (): void {
+    $order = CreditOrder::factory()->forCompany(Company::factory()->create())->create(['quantity' => 3]);
+
+    settle($order);
+
+    expect($order->credits()->count())->toBe(3)
+        ->and(UserCredit::query()->whereNull('credit_order_id')->count())->toBe(0)
+        ->and(UserCredit::query()->first()->creditOrder->is($order))->toBeTrue();
+});
+
+it('leaves credit_order_id null on credits that did not come from a purchase', function (): void {
+    // Crédito de grant e o que já existe em produção nunca terão pedido.
+    $credit = UserCredit::factory()->create();
+
+    expect($credit->credit_order_id)->toBeNull()
+        ->and($credit->creditOrder)->toBeNull();
+});
+
 it('credits the company owner when the buyer is a company', function (): void {
     $company = Company::factory()->create();
     $order = CreditOrder::factory()->forCompany($company)->create(['quantity' => 2]);

--- a/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
+++ b/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Event;
 use TresPontosTech\Billing\Core\Actions\Credit\SettleCreditOrder;
 use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
@@ -55,6 +56,30 @@ it('announces the delivery', function (): void {
         CreditsDelivered::class,
         fn (CreditsDelivered $event): bool => $event->quantity === 4 && $event->ownerId === (string) $company->user_id
     );
+});
+
+it('keeps the order pending and retryable when settling fails', function (): void {
+    $company = Company::factory()->create();
+
+    $order = CreditOrder::factory()->create([
+        'billable_type' => $company->getMorphClass(),
+        'billable_id' => '00000000-0000-0000-0000-000000000000',
+        'company_id' => $company->getKey(),
+        'quantity' => 3,
+    ]);
+
+    expect(fn () => settle($order))->toThrow(ModelNotFoundException::class);
+
+    expect(UserCredit::query()->count())->toBe(0)
+        ->and($order->refresh()->status)->toBe(CreditOrderStatusEnum::Pending)
+        ->and($order->paid_at)->toBeNull();
+
+    $order->update(['billable_id' => $company->getKey()]);
+
+    settle($order);
+
+    expect(UserCredit::query()->count())->toBe(3)
+        ->and($order->refresh()->status)->toBe(CreditOrderStatusEnum::Paid);
 });
 
 it('ignores an order that no longer exists', function (): void {

--- a/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
+++ b/app-modules/billing/tests/Feature/Credit/SettleCreditOrderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use TresPontosTech\Billing\Core\Actions\Credit\SettleCreditOrder;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Events\Credit\CreditsDelivered;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
+
+function settle(CreditOrder $order): void
+{
+    resolve(SettleCreditOrder::class)->handle($order->getKey());
+}
+
+it('issues the credits and settles the order', function (): void {
+    $order = CreditOrder::factory()->forCompany(Company::factory()->create())->create(['quantity' => 3]);
+
+    settle($order);
+
+    expect(UserCredit::query()->count())->toBe(3)
+        ->and($order->refresh()->status)->toBe(CreditOrderStatusEnum::Paid)
+        ->and($order->paid_at)->not->toBeNull();
+});
+
+it('credits the company owner when the buyer is a company', function (): void {
+    $company = Company::factory()->create();
+    $order = CreditOrder::factory()->forCompany($company)->create(['quantity' => 2]);
+
+    settle($order);
+
+    expect(UserCredit::query()->pluck('owner_id')->unique()->all())->toBe([$company->user_id]);
+});
+
+it('does not issue credits twice for an order already settled', function (): void {
+    $order = CreditOrder::factory()->forCompany(Company::factory()->create())->create(['quantity' => 3]);
+
+    settle($order);
+    settle($order);
+
+    expect(UserCredit::query()->count())->toBe(3);
+});
+
+it('announces the delivery', function (): void {
+    Event::fake([CreditsDelivered::class]);
+
+    $company = Company::factory()->create();
+    $order = CreditOrder::factory()->forCompany($company)->create(['quantity' => 4]);
+
+    settle($order);
+
+    Event::assertDispatched(
+        CreditsDelivered::class,
+        fn (CreditsDelivered $event): bool => $event->quantity === 4 && $event->ownerId === (string) $company->user_id
+    );
+});
+
+it('ignores an order that no longer exists', function (): void {
+    resolve(SettleCreditOrder::class)->handle('00000000-0000-0000-0000-000000000000');
+
+    expect(UserCredit::query()->count())->toBe(0);
+});

--- a/app-modules/integration-virtu/src/Actions/HandleVirtuWebhook.php
+++ b/app-modules/integration-virtu/src/Actions/HandleVirtuWebhook.php
@@ -6,7 +6,10 @@ namespace TresPontosTech\IntegrationVirtu\Actions;
 
 use Illuminate\Support\Facades\Log;
 use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionActivated;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\IntegrationVirtu\DTO\VirtuWebhookDTO;
 use TresPontosTech\IntegrationVirtu\Enums\VirtuWebhookEventEnum;
@@ -40,6 +43,10 @@ final class HandleVirtuWebhook
             return;
         }
 
+        if ($this->creditOrderPaid($dto)) {
+            return;
+        }
+
         $subscription = $this->findPendingSubscription($dto);
 
         if (! $subscription instanceof Subscription) {
@@ -68,6 +75,26 @@ final class HandleVirtuWebhook
             quantity: $subscription->quantity ?? 1,
             endsAt: null,
         )));
+    }
+
+    private function creditOrderPaid(VirtuWebhookDTO $dto): bool
+    {
+        if (blank($dto->checkoutId)) {
+            return false;
+        }
+
+        $order = CreditOrder::query()
+            ->where('provider', BillingProviderEnum::Virtu)
+            ->where('checkout_id', $dto->checkoutId)
+            ->first();
+
+        if (! $order instanceof CreditOrder) {
+            return false;
+        }
+
+        event(new OrderCreditPurchased(creditOrderId: $order->getKey()));
+
+        return true;
     }
 
     /**

--- a/app-modules/integration-virtu/src/DTO/CheckoutIdentityDTO.php
+++ b/app-modules/integration-virtu/src/DTO/CheckoutIdentityDTO.php
@@ -24,6 +24,7 @@ final readonly class CheckoutIdentityDTO
         public string $name,
         public ?string $email,
         public ?string $taxId,
+        public ?string $phone = null,
     ) {}
 
     public static function fromBillable(Company|User $billable): self
@@ -33,6 +34,7 @@ final readonly class CheckoutIdentityDTO
                 name: $billable->name,
                 email: $billable->owner?->email,
                 taxId: $billable->tax_id,
+                phone: $billable->owner?->detail?->phone_number,
             );
         }
 
@@ -42,6 +44,7 @@ final readonly class CheckoutIdentityDTO
             // `detail` is a separate record and may not exist yet — the Barte
             // adapter guards on the same relation before creating a buyer.
             taxId: $billable->detail?->tax_id,
+            phone: $billable->detail?->phone_number,
         );
     }
 
@@ -54,6 +57,12 @@ final readonly class CheckoutIdentityDTO
             'name' => $this->name,
             'email' => $this->email,
             'cpf' => $this->taxId,
+            'phone' => $this->digitsOf($this->phone),
         ], fn (?string $value): bool => filled($value));
+    }
+
+    private function digitsOf(?string $value): ?string
+    {
+        return preg_replace('/\D/', '', (string) $value) ?: null;
     }
 }

--- a/app-modules/integration-virtu/src/VirtuAdapter.php
+++ b/app-modules/integration-virtu/src/VirtuAdapter.php
@@ -43,8 +43,6 @@ final readonly class VirtuAdapter implements BillingContract, SupportsCreditPurc
      */
     private const MINIMUM_CHARGE_IN_CENTS = 100;
 
-    private const CREDIT_PRICE_IN_CENTS = 15000;
-
     public function __construct(
         private VirtuClient $client
     ) {}
@@ -115,19 +113,16 @@ final readonly class VirtuAdapter implements BillingContract, SupportsCreditPurc
 
     public function purchaseCredits(Company|User $billable, Company $company, int $quantity, string $successUrl, string $cancelUrl): string
     {
-        $amountCents = $quantity * self::CREDIT_PRICE_IN_CENTS;
-
         $order = resolve(StartCreditOrder::class)->handle(
             provider: BillingProviderEnum::Virtu,
             billable: $billable,
             company: $company,
             quantity: $quantity,
-            amountCents: $amountCents,
         );
 
         $link = $this->client->createPaymentLink(CreatePaymentLinkDTO::order(
             title: sprintf('Compra de %d crédito(s)', $quantity),
-            amountCents: $amountCents,
+            amountCents: $order->amount_cents,
             description: sprintf('Pedido %s', $order->getKey()),
         ));
 

--- a/app-modules/integration-virtu/src/VirtuAdapter.php
+++ b/app-modules/integration-virtu/src/VirtuAdapter.php
@@ -6,9 +6,12 @@ namespace TresPontosTech\IntegrationVirtu;
 
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Builder;
+use TresPontosTech\Billing\Core\Actions\Credit\StartCreditOrder;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
+use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
 use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Enums\SeatPricingTierEnum;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCreated;
 use TresPontosTech\Billing\Core\Models\Price;
@@ -28,19 +31,19 @@ use TresPontosTech\PanelApp\Filament\Pages\UserBillingManagePage;
  * billing_subscriptions — no regression, since the Barte adapter never asked
  * Barte for it either.
  *
- * Implements neither SupportsSubscriptionCancellation nor SupportsCreditPurchase,
- * and that absence is the feature: Virtu exposes no cancellation endpoint, and a
- * credit purchase has no way to carry the company and quantity back to the
- * webhook without a metadata field. Callers check `instanceof` and hide those
- * actions rather than offering a button that can only fail.
+ * Does not implement SupportsSubscriptionCancellation, and that absence is the
+ * feature: Virtu exposes no cancellation endpoint, so callers check `instanceof`
+ * and hide the action rather than offering a button that can only fail.
  */
-final readonly class VirtuAdapter implements BillingContract
+final readonly class VirtuAdapter implements BillingContract, SupportsCreditPurchase
 {
     /**
      * Floor for any generated charge. Virtu accepts amountCents: 1 without
      * complaint, so the guard the gateway does not provide lives here.
      */
     private const MINIMUM_CHARGE_IN_CENTS = 100;
+
+    private const CREDIT_PRICE_IN_CENTS = 15000;
 
     public function __construct(
         private VirtuClient $client
@@ -106,6 +109,29 @@ final readonly class VirtuAdapter implements BillingContract
             quantity: $data->quantity,
             endsAt: null,
         )));
+
+        return $this->withBuyerIdentity($link->url, $billable);
+    }
+
+    public function purchaseCredits(Company|User $billable, Company $company, int $quantity, string $successUrl, string $cancelUrl): string
+    {
+        $amountCents = $quantity * self::CREDIT_PRICE_IN_CENTS;
+
+        $order = resolve(StartCreditOrder::class)->handle(
+            provider: BillingProviderEnum::Virtu,
+            billable: $billable,
+            company: $company,
+            quantity: $quantity,
+            amountCents: $amountCents,
+        );
+
+        $link = $this->client->createPaymentLink(CreatePaymentLinkDTO::order(
+            title: sprintf('Compra de %d crédito(s)', $quantity),
+            amountCents: $amountCents,
+            description: sprintf('Pedido %s', $order->getKey()),
+        ));
+
+        $order->update(['checkout_id' => $link->checkoutId ?? $link->id]);
 
         return $this->withBuyerIdentity($link->url, $billable);
     }

--- a/app-modules/integration-virtu/src/VirtuAdapter.php
+++ b/app-modules/integration-virtu/src/VirtuAdapter.php
@@ -6,13 +6,14 @@ namespace TresPontosTech\IntegrationVirtu;
 
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Builder;
-use TresPontosTech\Billing\Core\Actions\Credit\StartCreditOrder;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
+use TresPontosTech\Billing\Core\DTOs\CreditOrderDTO;
 use TresPontosTech\Billing\Core\DTOs\SubscriptionDTO;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Enums\SeatPricingTierEnum;
+use TresPontosTech\Billing\Core\Events\Credit\CreditOrderPlaced;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionCreated;
 use TresPontosTech\Billing\Core\Models\Price;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
@@ -113,7 +114,7 @@ final readonly class VirtuAdapter implements BillingContract, SupportsCreditPurc
 
     public function purchaseCredits(Company|User $billable, Company $company, int $quantity, string $successUrl, string $cancelUrl): string
     {
-        $order = resolve(StartCreditOrder::class)->handle(
+        $order = new CreditOrderDTO(
             provider: BillingProviderEnum::Virtu,
             billable: $billable,
             company: $company,
@@ -122,11 +123,11 @@ final readonly class VirtuAdapter implements BillingContract, SupportsCreditPurc
 
         $link = $this->client->createPaymentLink(CreatePaymentLinkDTO::order(
             title: sprintf('Compra de %d crédito(s)', $quantity),
-            amountCents: $order->amount_cents,
-            description: sprintf('Pedido %s', $order->getKey()),
+            amountCents: $order->amountCents(),
+            description: sprintf('%d crédito(s) para %s', $quantity, $company->name),
         ));
 
-        $order->update(['checkout_id' => $link->checkoutId ?? $link->id]);
+        event(new CreditOrderPlaced($order->withCheckout($link->checkoutId ?? $link->id)));
 
         return $this->withBuyerIdentity($link->url, $billable);
     }

--- a/app-modules/integration-virtu/tests/Feature/BillingManagerDriverTest.php
+++ b/app-modules/integration-virtu/tests/Feature/BillingManagerDriverTest.php
@@ -39,3 +39,10 @@ it('still honours subscriptions sold through the previous gateways', function ()
         ->toContain(BillingProviderEnum::Stripe)
         ->toContain(BillingProviderEnum::Virtu);
 });
+
+it('defaults to the gateway that sells today', function (): void {
+    $manager = resolve(BillingManager::class);
+
+    expect($manager->getDefaultDriver())->toBe(BillingProviderEnum::checkoutCases()[0]->value)
+        ->and($manager->getDriver())->toBeInstanceOf(VirtuAdapter::class);
+});

--- a/app-modules/integration-virtu/tests/Feature/CheckoutIdentityDTOTest.php
+++ b/app-modules/integration-virtu/tests/Feature/CheckoutIdentityDTOTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\Detail;
+use App\Models\Users\User;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\IntegrationVirtu\DTO\CheckoutIdentityDTO;
+
+function paramsFor(Company|User $billable): array
+{
+    return CheckoutIdentityDTO::fromBillable($billable)->toQueryParams();
+}
+
+it('pre-fills the buyer phone when the user has one', function (): void {
+    $user = User::factory()->create();
+    Detail::factory()->for($user)->create(['phone_number' => '(11) 99999-0000']);
+
+    expect(paramsFor($user->refresh()))
+        ->toHaveKey('phone', '11999990000');
+});
+
+it('omits the phone when the user has none', function (): void {
+    $user = User::factory()->create();
+    Detail::factory()->for($user)->create(['phone_number' => null]);
+
+    expect(paramsFor($user->refresh()))->not->toHaveKey('phone');
+});
+
+it('omits the phone when the user has no detail record at all', function (): void {
+    expect(paramsFor(User::factory()->create()))->not->toHaveKey('phone');
+});
+
+it('uses the owner phone when the buyer is a company', function (): void {
+    $owner = User::factory()->create();
+    Detail::factory()->for($owner)->create(['phone_number' => '11988887777']);
+
+    $company = Company::factory()->recycle($owner)->create();
+
+    expect(paramsFor($company->refresh()))->toHaveKey('phone', '11988887777');
+});

--- a/app-modules/integration-virtu/tests/Feature/HandleVirtuWebhookTest.php
+++ b/app-modules/integration-virtu/tests/Feature/HandleVirtuWebhookTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Models\Users\User;
 use Illuminate\Support\Facades\Event;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Events\Credit\OrderCreditPurchased;
 use TresPontosTech\Billing\Core\Events\Subscription\SubscriptionActivated;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
 use TresPontosTech\IntegrationVirtu\Actions\HandleVirtuWebhook;
 use TresPontosTech\IntegrationVirtu\DTO\VirtuWebhookDTO;
@@ -121,4 +124,34 @@ it('ignores events with no mapping yet', function (): void {
     resolve(HandleVirtuWebhook::class)->handle(virtuWebhookDto(event: 'WITHDRAWAL'));
 
     Event::assertNotDispatched(SubscriptionActivated::class);
+});
+
+it('credits a paid order matched by checkout id', function (): void {
+    Event::fake([OrderCreditPurchased::class, SubscriptionActivated::class]);
+
+    $order = CreditOrder::factory()->create([
+        'provider' => BillingProviderEnum::Virtu,
+        'checkout_id' => 'checkout_fake1',
+    ]);
+
+    resolve(HandleVirtuWebhook::class)->handle(virtuWebhookDto());
+
+    Event::assertDispatched(
+        OrderCreditPurchased::class,
+        fn (OrderCreditPurchased $event): bool => $event->creditOrderId === $order->getKey()
+    );
+    Event::assertNotDispatched(SubscriptionActivated::class);
+});
+
+it('does not credit an order belonging to another provider', function (): void {
+    Event::fake([OrderCreditPurchased::class]);
+
+    CreditOrder::factory()->create([
+        'provider' => BillingProviderEnum::Barte,
+        'checkout_id' => 'checkout_fake1',
+    ]);
+
+    resolve(HandleVirtuWebhook::class)->handle(virtuWebhookDto());
+
+    Event::assertNotDispatched(OrderCreditPurchased::class);
 });

--- a/app-modules/integration-virtu/tests/Feature/VirtuAdapterTest.php
+++ b/app-modules/integration-virtu/tests/Feature/VirtuAdapterTest.php
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use App\Models\Users\User;
+use Illuminate\Support\Facades\Event;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\Contracts\SupportsSubscriptionCancellation;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Events\Credit\CreditOrderPlaced;
 use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\Plan;
 use TresPontosTech\Billing\Core\Models\Price;
@@ -125,6 +127,45 @@ it('sells credits through a local order', function (): void {
         ->and($order->amount_cents)->toBe(30000)
         ->and($order->status)->toBe(CreditOrderStatusEnum::Pending)
         ->and($order->checkout_id)->not->toBeNull();
+});
+
+it('leaves the writing to billing and only announces the order', function (): void {
+    Event::fake([CreditOrderPlaced::class]);
+
+    $company = Company::factory()->create();
+
+    $this->adapter->purchaseCredits(
+        billable: $company,
+        company: $company,
+        quantity: 2,
+        successUrl: 'https://app.test/credits',
+        cancelUrl: 'https://app.test/credits',
+    );
+
+    expect(CreditOrder::query()->count())->toBe(0);
+
+    Event::assertDispatched(CreditOrderPlaced::class, function (CreditOrderPlaced $event) use ($company): bool {
+        return $event->dto->provider === BillingProviderEnum::Virtu
+            && $event->dto->billable->is($company)
+            && $event->dto->quantity === 2
+            && $event->dto->checkoutId === 'checkout_fake1';
+    });
+});
+
+it('does not open an order when the gateway refuses the link', function (): void {
+    $this->client->shouldFail = true;
+
+    $company = Company::factory()->create();
+
+    expect(fn (): string => $this->adapter->purchaseCredits(
+        billable: $company,
+        company: $company,
+        quantity: 2,
+        successUrl: 'https://app.test/credits',
+        cancelUrl: 'https://app.test/credits',
+    ))->toThrow(VirtuApiException::class);
+
+    expect(CreditOrder::query()->count())->toBe(0);
 });
 
 // DELETE on a payment link only works while it is unpaid, so an active

--- a/app-modules/integration-virtu/tests/Feature/VirtuAdapterTest.php
+++ b/app-modules/integration-virtu/tests/Feature/VirtuAdapterTest.php
@@ -8,6 +8,8 @@ use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\Contracts\SupportsSubscriptionCancellation;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
 use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
 use TresPontosTech\Billing\Core\Models\Plan;
 use TresPontosTech\Billing\Core\Models\Price;
 use TresPontosTech\Billing\Core\Models\Subscriptions\Subscription;
@@ -102,12 +104,27 @@ it('refuses to create a link for an implausible amount', function (): void {
         ->toThrow(VirtuApiException::class);
 });
 
-// A credit purchase has to tell the webhook which company and how many — Barte
-// carried that in checkout metadata and Virtu has no such field, with no
-// subscription row to hang it on either. Declining the capability is what makes
-// PurchaseCreditsAction hide the button instead of offering one that throws.
-it('does not claim to sell credits', function (): void {
-    expect($this->adapter)->not->toBeInstanceOf(SupportsCreditPurchase::class);
+it('sells credits through a local order', function (): void {
+    expect($this->adapter)->toBeInstanceOf(SupportsCreditPurchase::class);
+
+    $company = Company::factory()->create();
+
+    $url = $this->adapter->purchaseCredits(
+        billable: $company,
+        company: $company,
+        quantity: 2,
+        successUrl: 'https://app.test/credits',
+        cancelUrl: 'https://app.test/credits',
+    );
+
+    $order = CreditOrder::query()->sole();
+
+    expect($url)->toStartWith('https://')
+        ->and($order->provider)->toBe(BillingProviderEnum::Virtu)
+        ->and($order->quantity)->toBe(2)
+        ->and($order->amount_cents)->toBe(30000)
+        ->and($order->status)->toBe(CreditOrderStatusEnum::Pending)
+        ->and($order->checkout_id)->not->toBeNull();
 });
 
 // DELETE on a payment link only works while it is unpaid, so an active

--- a/app-modules/panel-admin/lang/en/resources.php
+++ b/app-modules/panel-admin/lang/en/resources.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'navigation_group' => [
         'billing' => 'Billing',
+        'credits' => 'Credits',
         'administration' => 'Administration',
         'appointments' => 'Appointments',
         'reports' => 'Reports',
@@ -240,6 +241,36 @@ return [
                     'starts_at' => 'Start',
                     'ends_at' => 'End',
                 ],
+            ],
+        ],
+    ],
+    'credit_orders' => [
+        'navigation_label' => 'Credit Purchases',
+        'model_label' => 'Credit Purchase',
+        'plural_model_label' => 'Credit Purchases',
+        'no_checkout' => 'no gateway reference',
+        'fields' => [
+            'created_at' => 'Date',
+            'status' => 'Status',
+            'billable' => 'Buyer',
+            'company' => 'Company',
+            'quantity' => 'Quantity',
+            'issued' => 'Issued',
+            'amount' => 'Amount',
+            'provider' => 'Gateway',
+            'paid_at' => 'Paid at',
+            'checkout_id' => 'Gateway reference',
+        ],
+        'filters' => [
+            'unfulfilled' => 'Paid with no credits issued',
+            'from' => 'From',
+            'until' => 'Until',
+        ],
+        'actions' => [
+            'settle' => [
+                'label' => 'Settle manually',
+                'heading' => 'Confirm this order was paid?',
+                'description' => 'Issues :quantity credit(s) to :name. Use only after confirming the payment in the gateway panel — this screen cannot verify it.',
             ],
         ],
     ],

--- a/app-modules/panel-admin/lang/en/resources.php
+++ b/app-modules/panel-admin/lang/en/resources.php
@@ -336,6 +336,9 @@ return [
             'document_id' => 'Document ID',
         ],
     ],
+    'credits_cluster' => [
+        'navigation_label' => 'Credits',
+    ],
     'management_cluster' => [
         'navigation_label' => 'Users Management',
     ],

--- a/app-modules/panel-admin/lang/pt_BR/resources.php
+++ b/app-modules/panel-admin/lang/pt_BR/resources.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 return [
     'navigation_group' => [
         'billing' => 'Faturamento',
+        'credits' => 'Créditos',
         'administration' => 'Administração',
         'appointments' => 'Agendamentos',
         'reports' => 'Relatórios',
@@ -240,6 +241,36 @@ return [
                     'starts_at' => 'Início',
                     'ends_at' => 'Fim',
                 ],
+            ],
+        ],
+    ],
+    'credit_orders' => [
+        'navigation_label' => 'Compras de Crédito',
+        'model_label' => 'Compra de Crédito',
+        'plural_model_label' => 'Compras de Crédito',
+        'no_checkout' => 'sem referência no gateway',
+        'fields' => [
+            'created_at' => 'Data',
+            'status' => 'Situação',
+            'billable' => 'Comprador',
+            'company' => 'Empresa',
+            'quantity' => 'Quantidade',
+            'issued' => 'Emitidos',
+            'amount' => 'Valor',
+            'provider' => 'Gateway',
+            'paid_at' => 'Pago em',
+            'checkout_id' => 'Referência do gateway',
+        ],
+        'filters' => [
+            'unfulfilled' => 'Pago sem crédito emitido',
+            'from' => 'Data início',
+            'until' => 'Data fim',
+        ],
+        'actions' => [
+            'settle' => [
+                'label' => 'Liquidar manualmente',
+                'heading' => 'Confirmar que este pedido foi pago?',
+                'description' => 'Emite :quantity crédito(s) para :name. Use apenas depois de confirmar o pagamento no painel do gateway — daqui não há como verificar.',
             ],
         ],
     ],

--- a/app-modules/panel-admin/lang/pt_BR/resources.php
+++ b/app-modules/panel-admin/lang/pt_BR/resources.php
@@ -336,6 +336,9 @@ return [
             'document_id' => 'RG',
         ],
     ],
+    'credits_cluster' => [
+        'navigation_label' => 'Créditos',
+    ],
     'management_cluster' => [
         'navigation_label' => 'Gestão de Usuários',
     ],

--- a/app-modules/panel-admin/src/Filament/Clusters/Credits/CreditsCluster.php
+++ b/app-modules/panel-admin/src/Filament/Clusters/Credits/CreditsCluster.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelAdmin\Filament\Clusters\Credits;
+
+use BackedEnum;
+use Filament\Clusters\Cluster;
+use Filament\Navigation\NavigationItem;
+use Filament\Support\Icons\Heroicon;
+use UnitEnum;
+
+class CreditsCluster extends Cluster
+{
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedTicket;
+
+    protected static ?string $slug = 'credits';
+
+    public static function getNavigationGroup(): string|UnitEnum|null
+    {
+        return __('panel-admin::resources.navigation_group.credits');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('panel-admin::resources.credits_cluster.navigation_label');
+    }
+
+    /**
+     * Um item de sidebar por componente, em vez do único item do cluster.
+     *
+     * O padrão do Filament esconde os componentes atrás do cluster, e a doc trata
+     * isso como característica, não como opção. Aqui o agrupamento importa mas a
+     * descoberta importa mais: ninguém deve precisar entrar para saber o que tem.
+     *
+     * As URLs, abas de topo e breadcrumbs do cluster continuam valendo.
+     *
+     * @return array<NavigationItem>
+     */
+    public static function getNavigationItems(): array
+    {
+        return collect(static::getClusteredComponents())
+            ->flatMap(fn (string $component): array => $component::getNavigationItems())
+            ->all();
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditGrants/CreditGrantResource.php
+++ b/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditGrants/CreditGrantResource.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants;
+namespace TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants;
 
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\DatePicker;
+use Filament\Pages\Enums\SubNavigationPosition;
 use Filament\Resources\Resource;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
@@ -18,7 +19,8 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use TresPontosTech\Billing\Core\Actions\Credit\RevokeCreditGrant;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\CreditGrant;
-use TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants\Pages\ListCreditGrants;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\CreditsCluster;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants\Pages\ListCreditGrants;
 
 class CreditGrantResource extends Resource
 {
@@ -28,9 +30,13 @@ class CreditGrantResource extends Resource
 
     protected static string|BackedEnum|null $navigationIcon = Heroicon::Gift;
 
+    protected static ?string $cluster = CreditsCluster::class;
+
+    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
+
     public static function getNavigationGroup(): ?string
     {
-        return __('panel-admin::resources.navigation_group.administration');
+        return __('panel-admin::resources.navigation_group.credits');
     }
 
     public static function getNavigationLabel(): string

--- a/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditGrants/Pages/ListCreditGrants.php
+++ b/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditGrants/Pages/ListCreditGrants.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants\Pages;
+namespace TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants\Pages;
 
 use Filament\Resources\Pages\ListRecords;
-use TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants\CreditGrantResource;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants\CreditGrantResource;
 
 class ListCreditGrants extends ListRecords
 {

--- a/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditOrders/CreditOrderResource.php
+++ b/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditOrders/CreditOrderResource.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditOrders;
+
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Forms\Components\DatePicker;
+use Filament\Pages\Enums\SubNavigationPosition;
+use Filament\Resources\Resource;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use TresPontosTech\Billing\Core\Actions\Credit\SettleCreditOrder;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\CreditsCluster;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditOrders\Pages\ListCreditOrders;
+
+class CreditOrderResource extends Resource
+{
+    protected static ?string $model = CreditOrder::class;
+
+    protected static ?string $slug = 'credit-orders';
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::ShoppingCart;
+
+    protected static ?string $cluster = CreditsCluster::class;
+
+    protected static ?SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('panel-admin::resources.navigation_group.credits');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('panel-admin::resources.credit_orders.navigation_label');
+    }
+
+    public static function getModelLabel(): string
+    {
+        return __('panel-admin::resources.credit_orders.model_label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('panel-admin::resources.credit_orders.plural_model_label');
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationBadge(): ?string
+    {
+        $pending = CreditOrder::query()
+            ->where('status', CreditOrderStatusEnum::Pending)
+            ->count();
+
+        return $pending > 0 ? (string) $pending : null;
+    }
+
+    public static function getNavigationBadgeColor(): ?string
+    {
+        return 'warning';
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('created_at')
+                    ->label(__('panel-admin::resources.credit_orders.fields.created_at'))
+                    ->dateTime('d/m/Y H:i')
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->label(__('panel-admin::resources.credit_orders.fields.status'))
+                    ->badge()
+                    ->sortable(),
+
+                TextColumn::make('billable.name')
+                    ->label(__('panel-admin::resources.credit_orders.fields.billable'))
+                    ->searchable()
+                    ->placeholder('—'),
+
+                TextColumn::make('company.name')
+                    ->label(__('panel-admin::resources.credit_orders.fields.company'))
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('quantity')
+                    ->label(__('panel-admin::resources.credit_orders.fields.quantity'))
+                    ->numeric()
+                    ->sortable(),
+
+                TextColumn::make('credits_count')
+                    ->label(__('panel-admin::resources.credit_orders.fields.issued'))
+                    ->badge()
+                    ->color(fn (CreditOrder $record): string => $record->credits_count === $record->quantity ? 'success' : 'danger'),
+
+                TextColumn::make('amount_cents')
+                    ->label(__('panel-admin::resources.credit_orders.fields.amount'))
+                    ->money('BRL', divideBy: 100)
+                    ->sortable(),
+
+                TextColumn::make('provider')
+                    ->label(__('panel-admin::resources.credit_orders.fields.provider'))
+                    ->badge(),
+
+                TextColumn::make('paid_at')
+                    ->label(__('panel-admin::resources.credit_orders.fields.paid_at'))
+                    ->dateTime('d/m/Y H:i')
+                    ->placeholder('—')
+                    ->sortable(),
+
+                TextColumn::make('checkout_id')
+                    ->label(__('panel-admin::resources.credit_orders.fields.checkout_id'))
+                    ->placeholder(__('panel-admin::resources.credit_orders.no_checkout'))
+                    ->copyable()
+                    ->limit(20)
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->label(__('panel-admin::resources.credit_orders.fields.status'))
+                    ->options(CreditOrderStatusEnum::class),
+
+                SelectFilter::make('provider')
+                    ->label(__('panel-admin::resources.credit_orders.fields.provider'))
+                    ->options(BillingProviderEnum::class),
+
+                SelectFilter::make('company')
+                    ->label(__('panel-admin::resources.credit_orders.fields.company'))
+                    ->relationship('company', 'name')
+                    ->searchable()
+                    ->preload(),
+
+                Filter::make('unfulfilled')
+                    ->label(__('panel-admin::resources.credit_orders.filters.unfulfilled'))
+                    ->query(fn (Builder $query): Builder => $query
+                        ->where('status', CreditOrderStatusEnum::Paid)
+                        ->whereDoesntHave('credits')),
+
+                Filter::make('period')
+                    ->schema([
+                        DatePicker::make('from')
+                            ->label(__('panel-admin::resources.credit_orders.filters.from'))
+                            ->displayFormat('d/m/Y'),
+                        DatePicker::make('until')
+                            ->label(__('panel-admin::resources.credit_orders.filters.until'))
+                            ->displayFormat('d/m/Y'),
+                    ])
+                    ->query(fn (Builder $query, array $data): Builder => $query
+                        ->when($data['from'] ?? null, fn (Builder $q, $date) => $q->whereDate('created_at', '>=', $date))
+                        ->when($data['until'] ?? null, fn (Builder $q, $date) => $q->whereDate('created_at', '<=', $date))),
+            ])
+            ->defaultSort('created_at', 'desc')
+            ->recordActions([
+                Action::make('settle')
+                    ->label(__('panel-admin::resources.credit_orders.actions.settle.label'))
+                    ->icon(Heroicon::OutlinedCheckCircle)
+                    ->color('warning')
+                    ->requiresConfirmation()
+                    ->modalHeading(__('panel-admin::resources.credit_orders.actions.settle.heading'))
+                    ->modalDescription(fn (CreditOrder $record): string => __('panel-admin::resources.credit_orders.actions.settle.description', [
+                        'quantity' => $record->quantity,
+                        'name' => $record->buyerName() ?? '—',
+                    ]))
+                    ->visible(fn (CreditOrder $record): bool => ! $record->isPaid())
+                    ->action(fn (CreditOrder $record) => resolve(SettleCreditOrder::class)->handle($record->getKey())),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->with(['billable', 'company'])
+            ->withCount('credits');
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListCreditOrders::route('/'),
+        ];
+    }
+}

--- a/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditOrders/Pages/ListCreditOrders.php
+++ b/app-modules/panel-admin/src/Filament/Clusters/Credits/Resources/CreditOrders/Pages/ListCreditOrders.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditOrders\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditOrders\CreditOrderResource;
+
+class ListCreditOrders extends ListRecords
+{
+    protected static string $resource = CreditOrderResource::class;
+}

--- a/app-modules/panel-admin/tests/Feature/Filament/CreditGrants/ListCreditGrantsTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/CreditGrants/ListCreditGrantsTest.php
@@ -6,9 +6,9 @@ use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Models\CreditGrant;
 use TresPontosTech\Billing\Core\Models\UserCredit;
 use TresPontosTech\Company\Models\Company;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants\CreditGrantResource;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditGrants\Pages\ListCreditGrants;
 use TresPontosTech\PanelAdmin\Filament\Resources\Companies\Pages\EditCompany;
-use TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants\CreditGrantResource;
-use TresPontosTech\PanelAdmin\Filament\Resources\CreditGrants\Pages\ListCreditGrants;
 
 use function Pest\Livewire\livewire;
 

--- a/app-modules/panel-admin/tests/Feature/Filament/CreditOrders/ListCreditOrdersTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/CreditOrders/ListCreditOrdersTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Navigation\NavigationItem;
+use Filament\Pages\Enums\SubNavigationPosition;
+use TresPontosTech\Billing\Core\Enums\CreditOrderStatusEnum;
+use TresPontosTech\Billing\Core\Models\CreditOrder;
+use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\CreditsCluster;
+use TresPontosTech\PanelAdmin\Filament\Clusters\Credits\Resources\CreditOrders\Pages\ListCreditOrders;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    actingAsAdmin();
+});
+
+function creditOrder(array $attributes = []): CreditOrder
+{
+    return CreditOrder::factory()
+        ->forCompany(Company::factory()->create())
+        ->create($attributes);
+}
+
+it('lists credit orders', function (): void {
+    $order = creditOrder(['quantity' => 4]);
+
+    livewire(ListCreditOrders::class)
+        ->assertCanSeeTableRecords([$order])
+        ->assertSee($order->company->name);
+});
+
+it('filters the orders that were paid but never issued credits', function (): void {
+    $unfulfilled = creditOrder(['status' => CreditOrderStatusEnum::Paid, 'paid_at' => now()]);
+    $pending = creditOrder();
+
+    livewire(ListCreditOrders::class)
+        ->filterTable('unfulfilled')
+        ->assertCanSeeTableRecords([$unfulfilled])
+        ->assertCanNotSeeTableRecords([$pending]);
+});
+
+it('settles a pending order and issues the credits', function (): void {
+    $order = creditOrder(['quantity' => 2]);
+
+    livewire(ListCreditOrders::class)
+        ->callTableAction('settle', $order);
+
+    expect($order->refresh()->status)->toBe(CreditOrderStatusEnum::Paid)
+        ->and(UserCredit::query()->where('credit_order_id', $order->getKey())->count())->toBe(2);
+});
+
+it('does not offer the settle action on an order already paid', function (): void {
+    $order = creditOrder(['status' => CreditOrderStatusEnum::Paid, 'paid_at' => now()]);
+
+    livewire(ListCreditOrders::class)
+        ->assertTableActionHidden('settle', $order);
+});
+
+it('exposes both credit resources in the sidebar instead of hiding them behind the cluster', function (): void {
+    // O padrão do Filament esconde componentes de cluster da navegação principal.
+    // CreditsCluster::getNavigationItems() sobrescreve isso; se um upgrade mudar
+    // o ponto de extensão, é aqui que aparece.
+    $labels = collect(CreditsCluster::getNavigationItems())
+        ->map(fn (NavigationItem $item): string => $item->getLabel())
+        ->all();
+
+    expect($labels)->toHaveCount(2)
+        ->and($labels)->toContain(
+            __('panel-admin::resources.credit_grants.navigation_label'),
+            __('panel-admin::resources.credit_orders.navigation_label'),
+        );
+});
+
+it('keeps the cluster tabs inside the page', function (): void {
+    $page = new ListCreditOrders;
+
+    expect($page->getSubNavigation())->toHaveCount(2)
+        ->and($page->getSubNavigationPosition())->toBe(SubNavigationPosition::Top);
+});

--- a/app-modules/panel-company/src/Filament/Actions/PurchaseCreditsAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/PurchaseCreditsAction.php
@@ -11,7 +11,6 @@ use Filament\Support\Icons\Heroicon;
 use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
-use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Pages\CompanyCreditPage;
 
@@ -43,7 +42,7 @@ class PurchaseCreditsAction extends Action
 
     private function sellingDriver(): BillingContract
     {
-        return resolve(BillingManager::class)->getDriver(BillingProviderEnum::checkoutCases()[0]);
+        return resolve(BillingManager::class)->getDriver();
     }
 
     public function forBillable(Company|User|null $billable = null, ?string $successUrl = null, ?string $cancelUrl = null): static

--- a/app-modules/panel-company/src/Filament/Actions/PurchaseCreditsAction.php
+++ b/app-modules/panel-company/src/Filament/Actions/PurchaseCreditsAction.php
@@ -9,7 +9,9 @@ use Filament\Actions\Action;
 use Filament\Forms\Components\TextInput;
 use Filament\Support\Icons\Heroicon;
 use TresPontosTech\Billing\Core\BillingManager;
+use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Pages\CompanyCreditPage;
 
@@ -39,13 +41,15 @@ class PurchaseCreditsAction extends Action
         $this->forBillable();
     }
 
+    private function sellingDriver(): BillingContract
+    {
+        return resolve(BillingManager::class)->getDriver(BillingProviderEnum::checkoutCases()[0]);
+    }
+
     public function forBillable(Company|User|null $billable = null, ?string $successUrl = null, ?string $cancelUrl = null): static
     {
         return $this
-            // The default driver is what sells credits; if that gateway cannot
-            // carry the purchase back to its webhook, there is no point offering
-            // the form at all.
-            ->visible(fn (): bool => resolve(BillingManager::class)->getDriver() instanceof SupportsCreditPurchase)
+            ->visible(fn (): bool => $this->sellingDriver() instanceof SupportsCreditPurchase)
             ->action(function (array $data, $livewire) use ($billable, $successUrl, $cancelUrl): void {
                 /** @var Company $company */
                 $company = filament()->getTenant();
@@ -54,7 +58,7 @@ class PurchaseCreditsAction extends Action
                 $resolvedSuccessUrl = $successUrl ?? CompanyCreditPage::getUrl();
                 $resolvedCancelUrl = $cancelUrl ?? CompanyCreditPage::getUrl();
 
-                $driver = resolve(BillingManager::class)->getDriver();
+                $driver = $this->sellingDriver();
 
                 if (! $driver instanceof SupportsCreditPurchase) {
                     return;

--- a/app-modules/panel-company/tests/Feature/Filament/PurchaseCreditsActionTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/PurchaseCreditsActionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use TresPontosTech\Billing\Core\BillingManager;
+use TresPontosTech\Billing\Core\Contracts\BillingContract;
+use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
+use TresPontosTech\Billing\Core\DTOs\CheckoutData;
+use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
+use TresPontosTech\Company\Models\Company;
+use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
+
+class CreditlessGateway implements BillingContract
+{
+    public function ensureCustomerExists(Company|User $billable): void {}
+
+    public function isSubscribed(Company|User $billable, string $planSlug): bool
+    {
+        return false;
+    }
+
+    public function createCheckout(Company|User $billable, CheckoutData $data): string
+    {
+        return 'https://checkout.test';
+    }
+
+    public function checkoutOpensInNewTab(): bool
+    {
+        return false;
+    }
+
+    public function getBillingPortalUrl(Company|User $billable, string $returnUrl, array $options = []): string
+    {
+        return 'https://billing.test';
+    }
+
+    public function hasActiveSubscription(Company|User $billable): bool
+    {
+        return false;
+    }
+}
+
+class CreditSellingGateway extends CreditlessGateway implements SupportsCreditPurchase
+{
+    public function purchaseCredits(Company|User $billable, Company $company, int $quantity, string $successUrl, string $cancelUrl): string
+    {
+        return 'https://checkout.test/credits';
+    }
+}
+
+function mockDriversFor(BillingContract $selling, BillingContract $default): void
+{
+    test()->instance(BillingManager::class, Mockery::mock(BillingManager::class, function ($mock) use ($selling, $default): void {
+        $mock->shouldReceive('getDriver')
+            ->with(BillingProviderEnum::checkoutCases()[0])
+            ->andReturn($selling);
+        $mock->shouldReceive('getDriver')->andReturn($default);
+    }));
+}
+
+it('offers the button when the selling gateway can charge for credits', function (): void {
+    mockDriversFor(selling: new CreditSellingGateway, default: new CreditlessGateway);
+
+    expect(PurchaseCreditsAction::make()->isVisible())->toBeTrue();
+});
+
+it('hides the button when the selling gateway cannot charge for credits', function (): void {
+    mockDriversFor(selling: new CreditlessGateway, default: new CreditSellingGateway);
+
+    expect(PurchaseCreditsAction::make()->isVisible())->toBeFalse();
+});

--- a/app-modules/panel-company/tests/Feature/Filament/PurchaseCreditsActionTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/PurchaseCreditsActionTest.php
@@ -7,7 +7,6 @@ use TresPontosTech\Billing\Core\BillingManager;
 use TresPontosTech\Billing\Core\Contracts\BillingContract;
 use TresPontosTech\Billing\Core\Contracts\SupportsCreditPurchase;
 use TresPontosTech\Billing\Core\DTOs\CheckoutData;
-use TresPontosTech\Billing\Core\Enums\BillingProviderEnum;
 use TresPontosTech\Company\Models\Company;
 use TresPontosTech\PanelCompany\Filament\Actions\PurchaseCreditsAction;
 
@@ -49,24 +48,21 @@ class CreditSellingGateway extends CreditlessGateway implements SupportsCreditPu
     }
 }
 
-function mockDriversFor(BillingContract $selling, BillingContract $default): void
+function mockSellingDriver(BillingContract $driver): void
 {
-    test()->instance(BillingManager::class, Mockery::mock(BillingManager::class, function ($mock) use ($selling, $default): void {
-        $mock->shouldReceive('getDriver')
-            ->with(BillingProviderEnum::checkoutCases()[0])
-            ->andReturn($selling);
-        $mock->shouldReceive('getDriver')->andReturn($default);
+    test()->instance(BillingManager::class, Mockery::mock(BillingManager::class, function ($mock) use ($driver): void {
+        $mock->shouldReceive('getDriver')->andReturn($driver);
     }));
 }
 
 it('offers the button when the selling gateway can charge for credits', function (): void {
-    mockDriversFor(selling: new CreditSellingGateway, default: new CreditlessGateway);
+    mockSellingDriver(new CreditSellingGateway);
 
     expect(PurchaseCreditsAction::make()->isVisible())->toBeTrue();
 });
 
 it('hides the button when the selling gateway cannot charge for credits', function (): void {
-    mockDriversFor(selling: new CreditlessGateway, default: new CreditSellingGateway);
+    mockSellingDriver(new CreditlessGateway);
 
     expect(PurchaseCreditsAction::make()->isVisible())->toBeFalse();
 });


### PR DESCRIPTION
> Empilhado sobre #258 — o base é `feat/integration-virtu`, então o diff aqui é só o commit de crédito. Quando o #258 for mergeado o GitHub re-aponta este para `develop` sozinho.

A compra de crédito só existia como metadata do link de pagamento: quatro campos que a Barte devolvia no webhook.

```php
// BarteAdapter, antes
metadata: [
    ['key' => 'billable_type', 'value' => $billable->getMorphClass()],
    ['key' => 'billable_id',   'value' => (string) $billable->getKey()],
    ['key' => 'company_id',    'value' => (string) $company->getKey()],
    ['key' => 'quantity',      'value' => (string) $quantity],
],
```

Isso amarra a venda de crédito a um gateway que tenha campo de metadata. A Virtu não tem — confirmado contra a API, o validador nomeia cada propriedade recusada —, e era por isso que o `VirtuAdapter` recusava `SupportsCreditPurchase` e o botão sumia da tela.

## O desenho já era frágil onde funcionava

```php
// HandleBarteWebhook, antes
if (! $billableType || ! $billableId || ! $companyId || $quantity <= 0) {
    Log::warning('Barte ORDER webhook com metadata incompleto', ['uuid' => $dto->uuid]);
    return;
}
```

O cliente pagou, não recebeu crédito, e não existe linha nenhuma dizendo isso. Nada para reprocessar, nada para auditar, nada que apareça em tela. Um log.

## O que muda

O pedido nasce local e `pending` **antes** de mandar o cliente para o gateway, quando ainda sabemos tudo. O webhook só precisa reencontrar a linha e virar para `paid`.

Cada gateway carrega uma referência só, do jeito que consegue:

| | Como o webhook reencontra o pedido |
|---|---|
| **Barte** | `credit_order_id` na metadata — um id opaco no lugar de quatro campos |
| **Virtu** | `checkout_id`, a mesma correlação que a assinatura já usa e que foi verificada com pagamento real no sandbox |

O `OrderCreditPurchased` passa a carregar só o id do pedido. Quem consome resolve o resto da linha, então adicionar um gateway não mexe mais no evento nem no job.

Com isso **a Virtu passa a vender crédito**.

## O botão não estava chamando quem vende

Tornar o adapter capaz não bastava. O `PurchaseCreditsAction` pedia `getDriver()` **sem argumento**, e o default do `BillingManager` continua `barte`. O botão seguia cobrando pela Barte enquanto as assinaturas já iam pela Virtu — duas cobranças por gateways diferentes na mesma aplicação.

Passa a usar `checkoutCases()[0]`, a mesma regra da tela de assinatura. A action não tinha teste nenhum; agora tem dois, e o segundo falha se alguém voltar para o `getDriver()` sem argumento.

E o default do manager foi junto: `getDefaultDriver()` e o parâmetro de `getDriver()` passam a derivar de `checkoutCases()[0]` em vez de dizer `barte`. Eram três lugares afirmando qual gateway vende, e a divergência entre eles é o que causou o descompasso acima.

Os únicos chamadores sem argumento são os dois do portal de cobrança, e neles esse caminho só roda para billable sem registro em `billing_customers` — quem nunca comprou. Antes ia à Barte tentar criar cliente; agora vai à Virtu, cujo `ensureCustomerExists` é no-op e cujo portal é a página local.

## A liquidação saiu do job

O `ProcessCreditPurchaseJob` acumulava a regra inteira. Virou `SettleCreditOrder`: `claim()` faz o lock e a transição para `paid`, `creditFor()` monta o `CreditDTO` conforme o comprador seja usuário ou empresa. O job ficou só com `tries`, `timeout`, `uniqueFor` e `uniqueId`.

De quebra, dá para liquidar um pedido fora da fila — reconciliação manual, comando, tinker.

## Liquidação numa transação só

Primeira versão tinha um `claim()` que marcava o pedido como `paid` e **commitava** antes de emitir os créditos. Falha depois disso — billable apagado, banco caindo — deixava o pedido `paid` sem crédito, e o retry batia no `isPaid()` e desistia calado. Era o mesmo buraco que este PR fecha, deslocado para dentro da liquidação.

Emitir e marcar agora acontecem na mesma transação, nessa ordem, com o lock segurado até o commit. Inverter a ordem sem a transação não resolveria: dois jobs concorrentes leriam `pending`, os dois emitiriam, e só então um marcaria.

O `CreditsDelivered` é disparado **fora** da transação — dentro, um listener poderia reagir a crédito que o rollback desfaz depois.

## Idempotência ganhou uma segunda guarda

O `ShouldBeUnique` continua, mas ele depende de janela de tempo (`uniqueFor = 3600`) e é contornado por `dispatchSync`. Agora o job carrega o pedido com `lockForUpdate` e desiste se já estiver `paid` — proteção que não expira.

Isso muda um teste existente. Havia um caso documentando a vulnerabilidade:

> `it('without idempotency: dispatching twice creates double the credits in the database')` → esperava 6 créditos

Não dobra mais. Foi reescrito para afirmar o comportamento novo: duas execuções, três créditos.

## Sem caminho de compatibilidade — de propósito

Cheguei a escrever um fallback que reconstruía o pedido a partir da metadata antiga, e tirei: significava um webhook escrever no banco algo que não existia quando o link foi gerado, e manter viva a modelagem que este PR remove.

O webhook da Barte tem um caminho só. Sem `credit_order_id`, warning.

**Consequência a considerar no deploy:** link de crédito gerado antes e pago depois não vira crédito. Se acontecer, o acerto é um `credit_grant` — a tabela já existe justamente para emissão manual auditada.

## Telefone pré-preenchido

O checkout hospedado aceita `phone` como query param, ao lado de `name`, `email` e `cpf` que já mandávamos. Sem ele o cliente redigita o telefone toda vez.

Entrou no `CheckoutIdentityDTO`, então vale para assinatura e crédito sem tocar nos dois fluxos — os dois terminam em `withBuyerIdentity()`. Normalizado para dígitos, porque `phone_number` é `varchar(20)` e costuma vir com máscara, que a Virtu descartaria. Opcional em todos os níveis: sem `detail`, telefone nulo, ou vazio depois do filtro, a chave some da URL. Empresa usa o telefone do dono, mesma lógica do e-mail.

## Verificado com pagamento real no sandbox

O `CreatePaymentLinkDTO::order()` existia no módulo desde o começo e nunca tinha saído da máquina — o único uso era um teste com `Http::fake`, que afirma o que **mandamos**, não o que a Virtu responde. Como o `checkoutId` não é campo do JSON e sim o último segmento da URL, valia para assinatura e era suposição para o link avulso.

Exercitado por uma sonda que chama `purchaseCredits()` pelo `BillingManager`, sem atalho pelo client:

```
webhook chegou            SIM
checkout_id gravado       checkout_81afb117fe1898c0a2ff808f7d018995
checkoutId do webhook     checkout_81afb117fe1898c0a2ff808f7d018995
os dois batem             SIM
pedido liquidado          SIM   (paid_at 2s depois do pagamento)
créditos emitidos         1 de 1  (status available)
```

Conferido no banco também, não só no relatório do comando. A cadeia inteira roda: pedido local → link avulso → webhook → `SettleCreditOrder` → `UserCredit`. E `data.subscriptions` veio `[]`, confirmando que os dois ramos do `HandleVirtuWebhook` não se confundem.

**Achado que vale para quem for validar valor pago:** o webhook manda `"amountCents": "150.00"` — o campo vem em **reais**, apesar do nome. Nosso `amount_cents` é `15000`. Comparar os dois pelo nome reprovaria todo pagamento legítimo.

## Crédito emitido aponta para o pedido

`user_credits` já tinha `grant_id` para crédito dado por admin, e nada para crédito comprado. Dava para saber que um pedido foi pago, não quais créditos ele gerou — a auditabilidade que motivou o `CreditOrder` parava na metade.

Espelha o `grant_id`: coluna nullable com `nullOnDelete`, relação nos dois lados, e o `CreditDTO` carregando o id como já carregava o do grant. Nullable porque produção tem crédito anterior a isto, e crédito de `credit_grant` nunca terá pedido.

É o que torna o estorno possível — hoje `REFUND` é ignorado e o cliente fica com o dinheiro e os créditos. Com a FK, dá para achar exatamente as linhas daquele pagamento.

## Tela de compras de crédito

Não havia onde ver um pedido. "Auditável por query" na prática significa que ninguém olha.

Somente leitura, como a de créditos extras ao lado. A coluna **emitidos** fica vermelha quando não bate com a quantidade, então "pago sem crédito" aparece sem ninguém procurar; mais badge de pendentes na navegação e um filtro para o mesmo estado.

A ação **liquidar manualmente** chama `SettleCreditOrder` direto — foi para isso que ele saiu do job. Só aparece em pedido não pago, e o modal avisa que daqui não há como verificar o pagamento: o admin está afirmando que aconteceu. É meia solução; a versão certa consulta o `GET /sales`.

Os dois resources de crédito passam a viver num cluster, seguindo `Partners` e `Management`. **Com uma diferença deliberada:** o padrão do Filament esconde os componentes atrás do cluster — a doc trata isso como característica, não opção — e aqui a descoberta importa mais que o agrupamento. `CreditsCluster` sobrescreve `getNavigationItems()` para expor um item por componente na sidebar, mantendo URLs aninhadas, abas e breadcrumbs. Como é uso não previsto, tem teste: se um upgrade mexer no ponto de extensão, o CI avisa.

Grupo de navegação próprio, não o `billing` existente — crédito não é assinatura, mesmo motivo do rename da tabela.

## Preço do crédito saiu dos adapters

Estava escrito duas vezes e em grandezas diferentes: `15000` no `VirtuAdapter`, `150` no `BarteAdapter`. Nada garantia que os dois falassem do mesmo valor, e mexer no preço exigia lembrar dos dois lugares e da unidade de cada um.

`UserCredit::PRICE_IN_CENTS` passa a ser a fonte. O `StartCreditOrder` deriva `amount_cents` de quantidade × constante e **perdeu o parâmetro `amountCents`** — é isso que fecha a porta. Com o valor ainda chegando de fora, cada adapter seguiria fazendo sua própria multiplicação e a divergência voltaria pela mesma fresta.

Cada adapter pergunta o valor em vez de calcular, e se vira com a unidade que sua API pede: a Virtu manda os centavos direto, a Barte divide por 100 porque o payment order é em reais.

## O gateway anuncia, o billing persiste

O `purchaseCredits` da Virtu chamava `StartCreditOrder` e depois fazia um `update()` cru em `credit_orders`. Era o único lugar fora do módulo `billing` que escrevia nessa tabela — e logo na coluna que sustenta a correlação inteira: o adapter afirmava, de dentro do gateway, que `checkout_id` é o último segmento da URL que a Virtu devolveu.

```php
$order = new CreditOrderDTO(provider: Virtu, billable: ..., company: ..., quantity: ...);

$link = $this->client->createPaymentLink(CreatePaymentLinkDTO::order(
    amountCents: $order->amountCents(),
    ...
));

event(new CreditOrderPlaced($order->withCheckout($link->checkoutId ?? $link->id)));
```

Quem grava é `PersistCreditOrder`, o mesmo par action+listener que `SubscriptionCreated` já usava. Os dois caminhos do adapter passam a colaborar do mesmo jeito, e ele não toca mais em Eloquent.

**O link vem antes do pedido**, então some a linha `pending` órfã quando o gateway recusa a cobrança: só nasce pedido depois que há link. Em troca o listener precisa ser síncrono — enfileirado, o comprador receberia o link antes da linha existir e um PIX rápido chegaria a um webhook sem o que casar. Tem teste afirmando que ele não é `ShouldQueue`.

Efeito colateral visível: a descrição do link perdeu o id do pedido, que agora só existe depois. Virou quantidade + nome da empresa, que diz mais a quem abre o painel da Virtu do que um uuid.

**A Barte fica como está** — não vai vender crédito. `StartCreditOrder` só ganhou `checkoutId` opcional no fim, então a chamada dela continua idêntica.

## O que fica de fora

- **Nada reconcilia.** O webhook é o único caminho para o crédito existir: túnel fora do ar ou deploy na hora errada e o pagamento acontece sem contrapartida, para sempre. A Virtu tem `GET /sales`, então uma varredura de pedidos `pending` resolveria — e serviria para a Barte também.
- **O valor pago não é conferido** contra o pedido. Gravamos `amount_cents` e nunca comparamos. Ver a ressalva de unidade acima antes de implementar.
- **A correlação ainda é decidida dentro do gateway.** O `HandleVirtuWebhook` monta duas queries em tabelas de billing — `CreditOrder` por `provider` + `checkout_id`, e `Subscription` por `stripe_id` — para descobrir a que pertence o pagamento. É o lado leitura do que o commit acima tirou do lado escrita, e as duas têm a mesma forma, então sai numa correção só: o handler entrega `(provider, checkoutId, pago)` e o billing decide se é crédito, assinatura ou nada. Fica para um PR próprio.
- **O contrato descreve um mundo que não existe mais.** O docblock de `SupportsCreditPurchase` afirma que um gateway sem campo de metadata não pode implementar a interface — a Virtu implementou. E `successUrl`/`cancelUrl` continuam na assinatura sem uso nenhum na Virtu: é a forma do checkout da Barte virada requisito de todo gateway.

## Testes

Suíte completa passando, 1382 testes.

Cobertura nova: emissão e liquidação do pedido, comprador empresa creditando o dono — ramo que nunca tinha sido exercitado —, dupla execução não dobrando crédito, pedido seguindo `pending` e liquidável de novo quando a emissão falha, o `CreditsDelivered`, pedido inexistente, webhook da Virtu creditando por `checkout_id` e **não** creditando pedido de outro provider, os dois casos de visibilidade do botão, o default do manager, quatro casos para o `CheckoutIdentityDTO`, que não tinha nenhum, a ligação crédito↔pedido nos dois sentidos, e seis para a tela — listagem, filtro de pago-sem-crédito, a liquidação manual emitindo com o vínculo correto, a ação escondida em pedido pago, e os dois que guardam o override de navegação do cluster.

Mais três com a inversão: o adapter rodando sob `Event::fake` sem criar linha nenhuma — quebra se alguém voltar a persistir dentro do gateway —, o gateway recusando o link sem deixar pedido órfão, e o listener não sendo `ShouldQueue`.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added credit-order tracking with pending and paid statuses.
  * Enabled credit purchases through the Virtu checkout gateway.
  * Automatically fulfills purchased credits after successful payment notifications.
  * Added an administration area for viewing, filtering, and manually settling credit orders.
  * Linked issued credits to their originating orders.
* **Improvements**
  * Checkout links now include normalized buyer phone details when available.
  * Added English and Portuguese translations for credit-order statuses and administration screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->