### PR TITLE
feat(appointments): no_show status for consultancies with credit consumption

### DIFF
--- a/app-modules/appointments/lang/en/enums.php
+++ b/app-modules/appointments/lang/en/enums.php
@@ -9,15 +9,18 @@ return [
         'completed' => 'Completed',
         'cancelled' => 'Cancelled',
         'cancelled_late' => 'Cancelled (Late)',
+        'no_show' => 'No-show',
     ],
     'appointment_history_action_type' => [
         'consultant_assigned' => 'Consultant assigned',
         'consultant_left' => 'Consultant removed',
         'consultant_changed' => 'Consultant changed',
         're_scheduled' => 'Rescheduled',
+        'no_show_marked' => 'No-show recorded',
     ],
     'appointment_history_actor' => [
         'admin' => 'Administrator',
         'user' => 'Client',
+        'consultant' => 'Consultant',
     ],
 ];

--- a/app-modules/appointments/lang/pt_BR/enums.php
+++ b/app-modules/appointments/lang/pt_BR/enums.php
@@ -9,15 +9,18 @@ return [
         'completed' => 'Concluído',
         'cancelled' => 'Cancelado',
         'cancelled_late' => 'Cancelado (fora do prazo)',
+        'no_show' => 'Não compareceu',
     ],
     'appointment_history_action_type' => [
         'consultant_assigned' => 'Consultor atribuído',
         'consultant_left' => 'Consultor removido',
         'consultant_changed' => 'Consultor alterado',
         're_scheduled' => 'Reagendado',
+        'no_show_marked' => 'Não comparecimento registrado',
     ],
     'appointment_history_actor' => [
         'admin' => 'Administrador',
         'user' => 'Cliente',
+        'consultant' => 'Consultor',
     ],
 ];

--- a/app-modules/appointments/src/Actions/Transitions/AbstractAppointmentTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/AbstractAppointmentTransition.php
@@ -64,7 +64,7 @@ abstract class AbstractAppointmentTransition
         ]);
 
         $this->appointment->loadMissing('user');
-        $this->appointment->user->forgetMonthlyAppointmentsLeftCache();
+        DB::afterCommit(fn () => $this->appointment->user->forgetMonthlyAppointmentsLeftCache());
 
         if ($this->appointment->status === AppointmentStatus::Cancelled) {
             event(new AppointmentCreditReturned((string) $this->appointment->getKey()));

--- a/app-modules/appointments/src/Actions/Transitions/ActiveTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/ActiveTransition.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace TresPontosTech\Appointments\Actions\Transitions;
 
-use App\Models\Users\User;
 use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use TresPontosTech\Appointments\Actions\AppointmentHistory\StoreAppointmentHistoryAction;
 use TresPontosTech\Appointments\DTO\StoreAppointmentHistoryDTO;
 use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
 use TresPontosTech\Appointments\Enums\AppointmentHistoryActor;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Enums\CreditImpact;
 use TresPontosTech\Appointments\Events\AppointmentCompleted;
-use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
+use TresPontosTech\Appointments\Events\AppointmentNoShow;
+use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
 use TresPontosTech\Appointments\Mail\AppointmentCompletedMail;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
@@ -38,9 +40,9 @@ final class ActiveTransition extends AbstractAppointmentTransition
     public function validate(TransitionData $data): void
     {
         throw_if(
-            $data->noShow && blank($data->noShowMarkedBy),
-            MissingTransitionDataException::class,
-            'A user must be provided when marking an appointment as no-show.'
+            filled($data->noShowMarkedBy) && filled($data->cancellationActor),
+            InvalidTransitionException::class,
+            'An appointment cannot be marked as no-show and cancelled at the same time.'
         );
     }
 
@@ -52,7 +54,7 @@ final class ActiveTransition extends AbstractAppointmentTransition
             return;
         }
 
-        if ($data->noShow) {
+        if (filled($data->noShowMarkedBy)) {
             $this->noShowProcessStep($data);
 
             return;
@@ -64,16 +66,6 @@ final class ActiveTransition extends AbstractAppointmentTransition
         event(new AppointmentCompleted($this->appointment));
     }
 
-    /**
-     * Marks the appointment as a no-show, applies the credit rule and writes the
-     * audit trail. Runs inside the handle() DB transaction: the status update,
-     * the credit update (synchronous listeners) and the history row all commit
-     * or roll back together.
-     *
-     * Credit rule (Option A): a no-show consumes the credit exactly like a
-     * completed appointment — the beneficiary booked the slot and did not
-     * free it up in time, so it is billed the same way.
-     */
     private function noShowProcessStep(TransitionData $data): void
     {
         $previousStatus = $this->appointment->status;
@@ -81,34 +73,29 @@ final class ActiveTransition extends AbstractAppointmentTransition
         $this->appointment->update(['status' => AppointmentStatus::NoShow]);
 
         $this->appointment->loadMissing('user');
-        $this->appointment->user->forgetMonthlyAppointmentsLeftCache();
-
-        $hasCreditInUse = $this->appointment->credit()
-            ->where('status', UserCreditStatusEnum::InUse)
-            ->exists();
-
-        $creditImpact = 'none';
-
-        if ($hasCreditInUse) {
-            $creditImpact = 'consumed';
-        }
+        DB::afterCommit(fn () => $this->appointment->user->forgetMonthlyAppointmentsLeftCache());
 
         event(new AppointmentCreditUsed((string) $this->appointment->getKey()));
 
-        /** @var User $markedBy */
-        $markedBy = $data->noShowMarkedBy;
+        $creditImpact = $this->appointment->credit()
+            ->where('status', UserCreditStatusEnum::Used)
+            ->exists()
+            ? CreditImpact::Consumed
+            : CreditImpact::None;
 
         resolve(StoreAppointmentHistoryAction::class)->execute(StoreAppointmentHistoryDTO::make([
             'appointment_id' => (string) $this->appointment->getKey(),
-            'actor_id' => (string) $markedBy->getKey(),
+            'actor_id' => (string) $data->noShowMarkedBy->getKey(),
             'actor_type' => AppointmentHistoryActor::Consultant->value,
             'action_type' => AppointmentHistoryActionType::NoShowMarked->value,
             'old_values' => ['status' => $previousStatus->value],
             'new_values' => [
                 'status' => AppointmentStatus::NoShow->value,
-                'credit_impact' => $creditImpact,
+                'credit_impact' => $creditImpact->value,
             ],
         ]));
+
+        event(new AppointmentNoShow($this->appointment));
     }
 
     public function notify(TransitionData $data): void
@@ -119,7 +106,7 @@ final class ActiveTransition extends AbstractAppointmentTransition
             return;
         }
 
-        if ($data->noShow) {
+        if (filled($data->noShowMarkedBy)) {
             return;
         }
 

--- a/app-modules/appointments/src/Actions/Transitions/ActiveTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/ActiveTransition.php
@@ -4,18 +4,30 @@ declare(strict_types=1);
 
 namespace TresPontosTech\Appointments\Actions\Transitions;
 
+use App\Models\Users\User;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
+use TresPontosTech\Appointments\Actions\AppointmentHistory\StoreAppointmentHistoryAction;
+use TresPontosTech\Appointments\DTO\StoreAppointmentHistoryDTO;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActor;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Events\AppointmentCompleted;
+use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
 use TresPontosTech\Appointments\Mail\AppointmentCompletedMail;
+use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
 
 final class ActiveTransition extends AbstractAppointmentTransition
 {
     public function choices(): array
     {
-        return [AppointmentStatus::Completed, AppointmentStatus::Cancelled, AppointmentStatus::CancelledLate];
+        return [
+            AppointmentStatus::Completed,
+            AppointmentStatus::Cancelled,
+            AppointmentStatus::CancelledLate,
+            AppointmentStatus::NoShow,
+        ];
     }
 
     public function canChange(): bool
@@ -23,12 +35,25 @@ final class ActiveTransition extends AbstractAppointmentTransition
         return true;
     }
 
-    public function validate(TransitionData $data): void {}
+    public function validate(TransitionData $data): void
+    {
+        throw_if(
+            $data->noShow && blank($data->noShowMarkedBy),
+            MissingTransitionDataException::class,
+            'A user must be provided when marking an appointment as no-show.'
+        );
+    }
 
     public function processStep(TransitionData $data): void
     {
         if (filled($data->cancellationActor)) {
             $this->cancelProcessStep($data);
+
+            return;
+        }
+
+        if ($data->noShow) {
+            $this->noShowProcessStep($data);
 
             return;
         }
@@ -39,11 +64,62 @@ final class ActiveTransition extends AbstractAppointmentTransition
         event(new AppointmentCompleted($this->appointment));
     }
 
+    /**
+     * Marks the appointment as a no-show, applies the credit rule and writes the
+     * audit trail. Runs inside the handle() DB transaction: the status update,
+     * the credit update (synchronous listeners) and the history row all commit
+     * or roll back together.
+     *
+     * Credit rule (Option A): a no-show consumes the credit exactly like a
+     * completed appointment — the beneficiary booked the slot and did not
+     * free it up in time, so it is billed the same way.
+     */
+    private function noShowProcessStep(TransitionData $data): void
+    {
+        $previousStatus = $this->appointment->status;
+
+        $this->appointment->update(['status' => AppointmentStatus::NoShow]);
+
+        $this->appointment->loadMissing('user');
+        $this->appointment->user->forgetMonthlyAppointmentsLeftCache();
+
+        $hasCreditInUse = $this->appointment->credit()
+            ->where('status', UserCreditStatusEnum::InUse)
+            ->exists();
+
+        $creditImpact = 'none';
+
+        if ($hasCreditInUse) {
+            $creditImpact = 'consumed';
+        }
+
+        event(new AppointmentCreditUsed((string) $this->appointment->getKey()));
+
+        /** @var User $markedBy */
+        $markedBy = $data->noShowMarkedBy;
+
+        resolve(StoreAppointmentHistoryAction::class)->execute(StoreAppointmentHistoryDTO::make([
+            'appointment_id' => (string) $this->appointment->getKey(),
+            'actor_id' => (string) $markedBy->getKey(),
+            'actor_type' => AppointmentHistoryActor::Consultant->value,
+            'action_type' => AppointmentHistoryActionType::NoShowMarked->value,
+            'old_values' => ['status' => $previousStatus->value],
+            'new_values' => [
+                'status' => AppointmentStatus::NoShow->value,
+                'credit_impact' => $creditImpact,
+            ],
+        ]));
+    }
+
     public function notify(TransitionData $data): void
     {
         if (filled($data->cancellationActor)) {
             $this->cancelNotify($data);
 
+            return;
+        }
+
+        if ($data->noShow) {
             return;
         }
 

--- a/app-modules/appointments/src/Actions/Transitions/NoShowTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/NoShowTransition.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Appointments\Actions\Transitions;
+
+final class NoShowTransition extends AbstractAppointmentTransition
+{
+    public function choices(): array
+    {
+        return [];
+    }
+
+    public function canChange(): bool
+    {
+        return false;
+    }
+
+    public function validate(TransitionData $data): void {}
+
+    public function processStep(TransitionData $data): void {}
+
+    public function notify(TransitionData $data): void {}
+}

--- a/app-modules/appointments/src/Actions/Transitions/PendingTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/PendingTransition.php
@@ -26,7 +26,7 @@ final class PendingTransition extends AbstractAppointmentTransition
 
     public function validate(TransitionData $data): void
     {
-        throw_if($data->noShow, InvalidTransitionException::class, 'Only active appointments can be marked as no-show.');
+        throw_if(filled($data->noShowMarkedBy), InvalidTransitionException::class, 'Only active appointments can be marked as no-show.');
 
         if (filled($data->cancellationActor)) {
             return;

--- a/app-modules/appointments/src/Actions/Transitions/PendingTransition.php
+++ b/app-modules/appointments/src/Actions/Transitions/PendingTransition.php
@@ -8,6 +8,7 @@ use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Mail;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Events\AppointmentBooked;
+use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
 use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
 use TresPontosTech\Appointments\Mail\AppointmentScheduledMail;
 
@@ -25,6 +26,8 @@ final class PendingTransition extends AbstractAppointmentTransition
 
     public function validate(TransitionData $data): void
     {
+        throw_if($data->noShow, InvalidTransitionException::class, 'Only active appointments can be marked as no-show.');
+
         if (filled($data->cancellationActor)) {
             return;
         }

--- a/app-modules/appointments/src/Actions/Transitions/TransitionData.php
+++ b/app-modules/appointments/src/Actions/Transitions/TransitionData.php
@@ -16,5 +16,7 @@ final readonly class TransitionData
         public ?string $consultantId = null,
         public ?CarbonInterface $appointmentAt = null,
         public ?string $notes = null,
+        public bool $noShow = false,
+        public ?User $noShowMarkedBy = null,
     ) {}
 }

--- a/app-modules/appointments/src/Actions/Transitions/TransitionData.php
+++ b/app-modules/appointments/src/Actions/Transitions/TransitionData.php
@@ -16,7 +16,6 @@ final readonly class TransitionData
         public ?string $consultantId = null,
         public ?CarbonInterface $appointmentAt = null,
         public ?string $notes = null,
-        public bool $noShow = false,
         public ?User $noShowMarkedBy = null,
     ) {}
 }

--- a/app-modules/appointments/src/Enums/AppointmentHistoryActionType.php
+++ b/app-modules/appointments/src/Enums/AppointmentHistoryActionType.php
@@ -16,6 +16,7 @@ enum AppointmentHistoryActionType: string implements HasColor, HasIcon, HasLabel
     case ConsultantLeft = 'consultant_left';
     case ConsultantChanged = 'consultant_changed';
     case ReScheduled = 're_scheduled';
+    case NoShowMarked = 'no_show_marked';
 
     public function getIcon(): Heroicon
     {
@@ -24,6 +25,7 @@ enum AppointmentHistoryActionType: string implements HasColor, HasIcon, HasLabel
             self::ConsultantLeft => Heroicon::UserMinus,
             self::ConsultantChanged => Heroicon::ArrowsRightLeft,
             self::ReScheduled => Heroicon::Clock,
+            self::NoShowMarked => Heroicon::UserMinus,
         };
     }
 
@@ -42,6 +44,7 @@ enum AppointmentHistoryActionType: string implements HasColor, HasIcon, HasLabel
             self::ConsultantLeft => Color::Red,
             self::ConsultantChanged => Color::Blue,
             self::ReScheduled => Color::Amber,
+            self::NoShowMarked => Color::Purple,
         };
     }
 }

--- a/app-modules/appointments/src/Enums/AppointmentHistoryActor.php
+++ b/app-modules/appointments/src/Enums/AppointmentHistoryActor.php
@@ -21,6 +21,7 @@ enum AppointmentHistoryActor: string implements HasColor, HasIcon, HasLabel
 {
     case Admin = 'admin';
     case User = 'user';
+    case Consultant = 'consultant';
 
     public function getLabel(): string
     {
@@ -32,6 +33,7 @@ enum AppointmentHistoryActor: string implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Admin => Heroicon::ShieldCheck,
             self::User => Heroicon::User,
+            self::Consultant => Heroicon::AcademicCap,
         };
     }
 
@@ -43,6 +45,7 @@ enum AppointmentHistoryActor: string implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Admin => Color::Indigo,
             self::User => Color::Gray,
+            self::Consultant => Color::Purple,
         };
     }
 }

--- a/app-modules/appointments/src/Enums/AppointmentStatus.php
+++ b/app-modules/appointments/src/Enums/AppointmentStatus.php
@@ -12,6 +12,7 @@ use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CancelledLateTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CancelledTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CompletedTransition;
+use TresPontosTech\Appointments\Actions\Transitions\NoShowTransition;
 use TresPontosTech\Appointments\Actions\Transitions\PendingTransition;
 use TresPontosTech\Appointments\Models\Appointment;
 
@@ -27,6 +28,8 @@ enum AppointmentStatus: string implements HasColor, HasIcon, HasLabel
 
     case CancelledLate = 'cancelled_late';
 
+    case NoShow = 'no_show';
+
     public function getIcon(): Heroicon
     {
         return match ($this) {
@@ -35,6 +38,7 @@ enum AppointmentStatus: string implements HasColor, HasIcon, HasLabel
             self::Completed => Heroicon::CheckCircle,
             self::Cancelled => Heroicon::XCircle,
             self::CancelledLate => Heroicon::XMark,
+            self::NoShow => Heroicon::UserMinus,
         };
     }
 
@@ -46,6 +50,7 @@ enum AppointmentStatus: string implements HasColor, HasIcon, HasLabel
             self::Completed => Color::Green,
             self::Cancelled => Color::Red,
             self::CancelledLate => Color::Orange,
+            self::NoShow => Color::Purple,
         };
     }
 
@@ -64,6 +69,7 @@ enum AppointmentStatus: string implements HasColor, HasIcon, HasLabel
             self::Completed => new CompletedTransition($appointment),
             self::Cancelled => new CancelledTransition($appointment),
             self::CancelledLate => new CancelledLateTransition($appointment),
+            self::NoShow => new NoShowTransition($appointment),
         };
     }
 

--- a/app-modules/appointments/src/Enums/CreditImpact.php
+++ b/app-modules/appointments/src/Enums/CreditImpact.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Appointments\Enums;
+
+enum CreditImpact: string
+{
+    case Consumed = 'consumed';
+    case None = 'none';
+}

--- a/app-modules/appointments/src/Events/AppointmentNoShow.php
+++ b/app-modules/appointments/src/Events/AppointmentNoShow.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\Appointments\Events;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+use TresPontosTech\Appointments\Models\Appointment;
+
+final readonly class AppointmentNoShow implements ShouldDispatchAfterCommit
+{
+    use Dispatchable;
+
+    public function __construct(
+        public Appointment $appointment,
+    ) {}
+}

--- a/app-modules/appointments/tests/Feature/Actions/NoShowCreditTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/NoShowCreditTest.php
@@ -16,6 +16,7 @@ use TresPontosTech\Appointments\Models\AppointmentHistory;
 use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
 use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
 use TresPontosTech\Billing\Core\Models\UserCredit;
+use TresPontosTech\Consultants\Models\Consultant;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseMissing;
@@ -32,16 +33,18 @@ beforeEach(function (): void {
 
 function noShowAppointmentWithCredit(): array
 {
+    $consultant = Consultant::factory()->create();
+
     $appointment = Appointment::factory()
         ->withStatus(AppointmentStatus::Active)
-        ->create(['appointment_at' => now()->subHour()]);
+        ->create(['consultant_id' => $consultant->getKey(), 'appointment_at' => now()->subHour()]);
 
     $credit = UserCredit::factory()->inUse()->create([
         'holder_id' => $appointment->user->getKey(),
         'appointment_id' => $appointment->getKey(),
     ]);
 
-    return [$appointment, $credit];
+    return [$appointment, $credit, $consultant];
 }
 
 // ---------------------------------------------------------------------------
@@ -49,12 +52,11 @@ function noShowAppointmentWithCredit(): array
 // ---------------------------------------------------------------------------
 
 it('writes an audit history row with no_show origin and credit impact', function (): void {
-    [$appointment, $credit] = noShowAppointmentWithCredit();
+    [$appointment, $credit, $consultant] = noShowAppointmentWithCredit();
     actingAs($appointment->user);
 
     (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
-        noShowMarkedBy: $appointment->user,
+        noShowMarkedBy: $consultant->user,
     ));
 
     $history = AppointmentHistory::query()
@@ -67,20 +69,20 @@ it('writes an audit history row with no_show origin and credit impact', function
         'credit_impact' => 'consumed',
     ])
         ->and($history->actor_type)->toBe(AppointmentHistoryActor::Consultant)
-        ->and($history->actor_id)->toBe($appointment->user->getKey());
+        ->and($history->actor_id)->toBe($consultant->user->getKey());
 
     expect($credit->refresh()->status)->toBe(UserCreditStatusEnum::Used);
 });
 
 it('records credit impact as none when the appointment has no credit', function (): void {
+    $consultant = Consultant::factory()->create();
     $appointment = Appointment::factory()
         ->withStatus(AppointmentStatus::Active)
-        ->create(['appointment_at' => now()->subHour()]);
+        ->create(['consultant_id' => $consultant->getKey(), 'appointment_at' => now()->subHour()]);
     actingAs($appointment->user);
 
     (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
-        noShowMarkedBy: $appointment->user,
+        noShowMarkedBy: $consultant->user,
     ));
 
     $history = AppointmentHistory::query()
@@ -89,11 +91,12 @@ it('records credit impact as none when the appointment has no credit', function 
         ->firstOrFail();
 
     expect($history->new_values['credit_impact'])->toBe('none')
+        ->and($history->actor_id)->toBe($consultant->user->getKey())
         ->and(UserCredit::query()->where('appointment_id', $appointment->getKey())->exists())->toBeFalse();
 });
 
 it('rolls back the status, credit and history when a failure happens inside the transaction', function (): void {
-    [$appointment, $credit] = noShowAppointmentWithCredit();
+    [$appointment, $credit, $consultant] = noShowAppointmentWithCredit();
     actingAs($appointment->user);
 
     Event::listen(AppointmentCreditUsed::class, function (): void {
@@ -101,8 +104,7 @@ it('rolls back the status, credit and history when a failure happens inside the 
     });
 
     expect(fn () => (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
-        noShowMarkedBy: $appointment->user,
+        noShowMarkedBy: $consultant->user,
     )))->toThrow(RuntimeException::class);
 
     expect($appointment->refresh()->status)->toBe(AppointmentStatus::Active)
@@ -119,12 +121,11 @@ it('rolls back the status, credit and history when a failure happens inside the 
 // ---------------------------------------------------------------------------
 
 it('marks the credit as Used when the appointment is a no-show', function (): void {
-    [$appointment, $credit] = noShowAppointmentWithCredit();
+    [$appointment, $credit, $consultant] = noShowAppointmentWithCredit();
     actingAs($appointment->user);
 
     (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
-        noShowMarkedBy: $appointment->user,
+        noShowMarkedBy: $consultant->user,
     ));
 
     expect($credit->refresh()->status)->toBe(UserCreditStatusEnum::Used);

--- a/app-modules/appointments/tests/Feature/Actions/NoShowCreditTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/NoShowCreditTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification as LaravelNotification;
+use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
+use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActor;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentHistory;
+use TresPontosTech\Billing\Core\Enums\UserCreditStatusEnum;
+use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
+use TresPontosTech\Billing\Core\Models\UserCredit;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseMissing;
+
+beforeEach(function (): void {
+    LaravelNotification::fake();
+    Mail::fake();
+    Bus::fake();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function noShowAppointmentWithCredit(): array
+{
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    $credit = UserCredit::factory()->inUse()->create([
+        'holder_id' => $appointment->user->getKey(),
+        'appointment_id' => $appointment->getKey(),
+    ]);
+
+    return [$appointment, $credit];
+}
+
+// ---------------------------------------------------------------------------
+// Audit trail (common to every credit rule option)
+// ---------------------------------------------------------------------------
+
+it('writes an audit history row with no_show origin and credit impact', function (): void {
+    [$appointment, $credit] = noShowAppointmentWithCredit();
+    actingAs($appointment->user);
+
+    (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    ));
+
+    $history = AppointmentHistory::query()
+        ->where('appointment_id', $appointment->getKey())
+        ->where('action_type', AppointmentHistoryActionType::NoShowMarked)
+        ->firstOrFail();
+
+    expect($history->new_values)->toMatchArray([
+        'status' => AppointmentStatus::NoShow->value,
+        'credit_impact' => 'consumed',
+    ])
+        ->and($history->actor_type)->toBe(AppointmentHistoryActor::Consultant)
+        ->and($history->actor_id)->toBe($appointment->user->getKey());
+
+    expect($credit->refresh()->status)->toBe(UserCreditStatusEnum::Used);
+});
+
+it('records credit impact as none when the appointment has no credit', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+    actingAs($appointment->user);
+
+    (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    ));
+
+    $history = AppointmentHistory::query()
+        ->where('appointment_id', $appointment->getKey())
+        ->where('action_type', AppointmentHistoryActionType::NoShowMarked)
+        ->firstOrFail();
+
+    expect($history->new_values['credit_impact'])->toBe('none')
+        ->and(UserCredit::query()->where('appointment_id', $appointment->getKey())->exists())->toBeFalse();
+});
+
+it('rolls back the status, credit and history when a failure happens inside the transaction', function (): void {
+    [$appointment, $credit] = noShowAppointmentWithCredit();
+    actingAs($appointment->user);
+
+    Event::listen(AppointmentCreditUsed::class, function (): void {
+        throw new RuntimeException('boom');
+    });
+
+    expect(fn () => (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    )))->toThrow(RuntimeException::class);
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::Active)
+        ->and($credit->refresh()->status)->toBe(UserCreditStatusEnum::InUse);
+
+    assertDatabaseMissing(AppointmentHistory::class, [
+        'appointment_id' => $appointment->getKey(),
+        'action_type' => AppointmentHistoryActionType::NoShowMarked->value,
+    ]);
+});
+
+// ---------------------------------------------------------------------------
+// Option A — credit consumed, same as a completed appointment
+// ---------------------------------------------------------------------------
+
+it('marks the credit as Used when the appointment is a no-show', function (): void {
+    [$appointment, $credit] = noShowAppointmentWithCredit();
+    actingAs($appointment->user);
+
+    (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    ));
+
+    expect($credit->refresh()->status)->toBe(UserCreditStatusEnum::Used);
+});

--- a/app-modules/appointments/tests/Feature/Actions/NoShowTransitionTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/NoShowTransitionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification as LaravelNotification;
+use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
+use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
+use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
+use TresPontosTech\Appointments\Models\Appointment;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function (): void {
+    LaravelNotification::fake();
+    Mail::fake();
+    Bus::fake();
+    Event::fake();
+});
+
+it('sets status to NoShow when an active appointment is marked as no-show', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+    actingAs($appointment->user);
+
+    (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    ));
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::NoShow);
+});
+
+it('throws InvalidTransitionException when marking a pending appointment as no-show', function (): void {
+    $appointment = Appointment::factory()->withStatus(AppointmentStatus::Pending)->create();
+
+    expect(fn () => $appointment->current_transition->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    )))->toThrow(InvalidTransitionException::class);
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::Pending);
+});
+
+it('throws InvalidTransitionException when marking a terminal appointment as no-show', function (AppointmentStatus $status): void {
+    $appointment = Appointment::factory()->withStatus($status)->create();
+
+    expect(fn () => $appointment->current_transition->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    )))->toThrow(InvalidTransitionException::class);
+})->with([
+    'Completed' => AppointmentStatus::Completed,
+    'Cancelled' => AppointmentStatus::Cancelled,
+    'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
+]);
+
+it('throws MissingTransitionDataException when no-show has no acting user', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    expect(fn () => (new ActiveTransition($appointment))->handle(new TransitionData(noShow: true)))
+        ->toThrow(MissingTransitionDataException::class);
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::Active);
+});
+
+it('does not notify the beneficiary on no-show', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+    actingAs($appointment->user);
+
+    (new ActiveTransition($appointment))->handle(new TransitionData(
+        noShow: true,
+        noShowMarkedBy: $appointment->user,
+    ));
+
+    Mail::assertNothingQueued();
+    LaravelNotification::assertNothingSent();
+});
+
+it('no longer blocks booking after a no-show', function (): void {
+    $appointment = Appointment::factory()->withStatus(AppointmentStatus::NoShow)->create();
+
+    expect($appointment->user->hasOngoingAppointment())->toBeFalse();
+});

--- a/app-modules/appointments/tests/Feature/Actions/NoShowTransitionTest.php
+++ b/app-modules/appointments/tests/Feature/Actions/NoShowTransitionTest.php
@@ -9,8 +9,9 @@ use Illuminate\Support\Facades\Notification as LaravelNotification;
 use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
 use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Enums\CancellationActor;
+use TresPontosTech\Appointments\Events\AppointmentNoShow;
 use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
-use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
 use TresPontosTech\Appointments\Models\Appointment;
 
 use function Pest\Laravel\actingAs;
@@ -29,18 +30,17 @@ it('sets status to NoShow when an active appointment is marked as no-show', func
     actingAs($appointment->user);
 
     (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
         noShowMarkedBy: $appointment->user,
     ));
 
     expect($appointment->refresh()->status)->toBe(AppointmentStatus::NoShow);
+    Event::assertDispatched(AppointmentNoShow::class, fn ($e): bool => $e->appointment->is($appointment));
 });
 
 it('throws InvalidTransitionException when marking a pending appointment as no-show', function (): void {
     $appointment = Appointment::factory()->withStatus(AppointmentStatus::Pending)->create();
 
     expect(fn () => $appointment->current_transition->handle(new TransitionData(
-        noShow: true,
         noShowMarkedBy: $appointment->user,
     )))->toThrow(InvalidTransitionException::class);
 
@@ -51,7 +51,6 @@ it('throws InvalidTransitionException when marking a terminal appointment as no-
     $appointment = Appointment::factory()->withStatus($status)->create();
 
     expect(fn () => $appointment->current_transition->handle(new TransitionData(
-        noShow: true,
         noShowMarkedBy: $appointment->user,
     )))->toThrow(InvalidTransitionException::class);
 })->with([
@@ -61,13 +60,15 @@ it('throws InvalidTransitionException when marking a terminal appointment as no-
     'NoShow' => AppointmentStatus::NoShow,
 ]);
 
-it('throws MissingTransitionDataException when no-show has no acting user', function (): void {
+it('throws InvalidTransitionException when noShowMarkedBy and cancellationActor are both provided', function (): void {
     $appointment = Appointment::factory()
         ->withStatus(AppointmentStatus::Active)
         ->create(['appointment_at' => now()->subHour()]);
 
-    expect(fn () => (new ActiveTransition($appointment))->handle(new TransitionData(noShow: true)))
-        ->toThrow(MissingTransitionDataException::class);
+    expect(fn () => (new ActiveTransition($appointment))->handle(new TransitionData(
+        cancellationActor: CancellationActor::Admin,
+        noShowMarkedBy: $appointment->user,
+    )))->toThrow(InvalidTransitionException::class);
 
     expect($appointment->refresh()->status)->toBe(AppointmentStatus::Active);
 });
@@ -79,7 +80,6 @@ it('does not notify the beneficiary on no-show', function (): void {
     actingAs($appointment->user);
 
     (new ActiveTransition($appointment))->handle(new TransitionData(
-        noShow: true,
         noShowMarkedBy: $appointment->user,
     ));
 

--- a/app-modules/appointments/tests/Feature/Enums/AppointmentHistoryActionTypeTest.php
+++ b/app-modules/appointments/tests/Feature/Enums/AppointmentHistoryActionTypeTest.php
@@ -13,12 +13,14 @@ it('translates each action type label according to the active locale', function 
     expect(AppointmentHistoryActionType::ConsultantAssigned->getLabel())->toBe('Consultor atribuído')
         ->and(AppointmentHistoryActionType::ConsultantLeft->getLabel())->toBe('Consultor removido')
         ->and(AppointmentHistoryActionType::ConsultantChanged->getLabel())->toBe('Consultor alterado')
-        ->and(AppointmentHistoryActionType::ReScheduled->getLabel())->toBe('Reagendado');
+        ->and(AppointmentHistoryActionType::ReScheduled->getLabel())->toBe('Reagendado')
+        ->and(AppointmentHistoryActionType::NoShowMarked->getLabel())->toBe('Não comparecimento registrado');
 
     App::setLocale('en');
 
     expect(AppointmentHistoryActionType::ConsultantAssigned->getLabel())->toBe('Consultant assigned')
-        ->and(AppointmentHistoryActionType::ReScheduled->getLabel())->toBe('Rescheduled');
+        ->and(AppointmentHistoryActionType::ReScheduled->getLabel())->toBe('Rescheduled')
+        ->and(AppointmentHistoryActionType::NoShowMarked->getLabel())->toBe('No-show recorded');
 });
 
 it('never leaks the raw enum name as a label', function (): void {
@@ -31,12 +33,14 @@ it('maps every action type to a distinct icon', function (): void {
     expect(AppointmentHistoryActionType::ConsultantAssigned->getIcon())->toBe(Heroicon::UserPlus)
         ->and(AppointmentHistoryActionType::ConsultantLeft->getIcon())->toBe(Heroicon::UserMinus)
         ->and(AppointmentHistoryActionType::ConsultantChanged->getIcon())->toBe(Heroicon::ArrowsRightLeft)
-        ->and(AppointmentHistoryActionType::ReScheduled->getIcon())->toBe(Heroicon::Clock);
+        ->and(AppointmentHistoryActionType::ReScheduled->getIcon())->toBe(Heroicon::Clock)
+        ->and(AppointmentHistoryActionType::NoShowMarked->getIcon())->toBe(Heroicon::UserMinus);
 });
 
 it('maps every action type to a semantic color', function (): void {
     expect(AppointmentHistoryActionType::ConsultantAssigned->getColor())->toBe(Color::Green)
         ->and(AppointmentHistoryActionType::ConsultantLeft->getColor())->toBe(Color::Red)
         ->and(AppointmentHistoryActionType::ConsultantChanged->getColor())->toBe(Color::Blue)
-        ->and(AppointmentHistoryActionType::ReScheduled->getColor())->toBe(Color::Amber);
+        ->and(AppointmentHistoryActionType::ReScheduled->getColor())->toBe(Color::Amber)
+        ->and(AppointmentHistoryActionType::NoShowMarked->getColor())->toBe(Color::Purple);
 });

--- a/app-modules/appointments/tests/Feature/Enums/AppointmentStatusTransitionTest.php
+++ b/app-modules/appointments/tests/Feature/Enums/AppointmentStatusTransitionTest.php
@@ -1,10 +1,15 @@
 <?php
 
+use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\App;
 use TresPontosTech\Appointments\Actions\Transitions\ActiveTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CancelledLateTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CancelledTransition;
 use TresPontosTech\Appointments\Actions\Transitions\CompletedTransition;
+use TresPontosTech\Appointments\Actions\Transitions\NoShowTransition;
 use TresPontosTech\Appointments\Actions\Transitions\PendingTransition;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActor;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Enums\CancellationActor;
 use TresPontosTech\Appointments\Models\Appointment;
@@ -41,6 +46,12 @@ it('CancelledLate resolves to CancelledLateTransition', function (): void {
     expect(AppointmentStatus::CancelledLate->transition($appointment))->toBeInstanceOf(CancelledLateTransition::class);
 });
 
+it('NoShow resolves to NoShowTransition', function (): void {
+    $appointment = Appointment::factory()->withStatus(AppointmentStatus::NoShow)->create();
+
+    expect(AppointmentStatus::NoShow->transition($appointment))->toBeInstanceOf(NoShowTransition::class);
+});
+
 // --- canChange() ---
 
 it('non-terminal statuses can change', function (AppointmentStatus $status): void {
@@ -60,6 +71,7 @@ it('terminal statuses cannot change', function (AppointmentStatus $status): void
     'Completed' => AppointmentStatus::Completed,
     'Cancelled' => AppointmentStatus::Cancelled,
     'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
 ]);
 
 // --- choices() ---
@@ -81,6 +93,7 @@ it('Active choices include Completed, Cancelled and CancelledLate', function ():
         ->toContain(AppointmentStatus::Completed)
         ->toContain(AppointmentStatus::Cancelled)
         ->toContain(AppointmentStatus::CancelledLate)
+        ->toContain(AppointmentStatus::NoShow)
         ->not->toContain(AppointmentStatus::Pending);
 });
 
@@ -92,6 +105,7 @@ it('terminal statuses have empty choices', function (AppointmentStatus $status):
     'Completed' => AppointmentStatus::Completed,
     'Cancelled' => AppointmentStatus::Cancelled,
     'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
 ]);
 
 // --- resolveCancellationStatus() ---
@@ -115,4 +129,27 @@ it('resolves to CancelledLate for User actor < 4h before appointment', function 
 
     expect(AppointmentStatus::resolveCancellationStatus($appointment, CancellationActor::User))
         ->toBe(AppointmentStatus::CancelledLate);
+});
+
+// --- NoShow label/icon/color ---
+
+it('translates the NoShow status label according to the active locale', function (): void {
+    App::setLocale('pt_BR');
+    expect(AppointmentStatus::NoShow->getLabel())->toBe('Não compareceu');
+
+    App::setLocale('en');
+    expect(AppointmentStatus::NoShow->getLabel())->toBe('No-show');
+});
+
+it('maps NoShow to the user-minus icon and purple color', function (): void {
+    expect(AppointmentStatus::NoShow->getIcon())->toBe(Heroicon::UserMinus)
+        ->and(AppointmentStatus::NoShow->getColor())->toBe(Color::Purple);
+});
+
+// --- AppointmentHistoryActor::Consultant label ---
+
+it('translates the Consultant history actor label', function (): void {
+    App::setLocale('pt_BR');
+
+    expect(AppointmentHistoryActor::Consultant->getLabel())->toBe('Consultor');
 });

--- a/app-modules/panel-admin/lang/en/resources.php
+++ b/app-modules/panel-admin/lang/en/resources.php
@@ -38,12 +38,23 @@ return [
                 'action' => 'Action',
                 'performed_by' => 'Performed by',
                 'happened_at' => 'Date and time',
+                'previous_status' => 'Previous status',
+                'new_status' => 'New status',
+                'credit_impact' => 'Credit impact',
+            ],
+            'values' => [
+                'credit_impact' => [
+                    'consumed' => 'Credit consumed',
+                    'returned' => 'Credit returned',
+                    'none' => 'No linked credit',
+                ],
             ],
             'sections' => [
                 'consultant_assigned' => 'Consultant Assigned',
                 'consultant_left' => 'Consultant Removed',
                 'consultant_changed' => 'Consultant Change',
                 're_scheduled' => 'Reschedule',
+                'no_show_marked' => 'No-show',
             ],
             'placeholders' => [
                 'empty' => '—',

--- a/app-modules/panel-admin/lang/en/resources.php
+++ b/app-modules/panel-admin/lang/en/resources.php
@@ -45,7 +45,6 @@ return [
             'values' => [
                 'credit_impact' => [
                     'consumed' => 'Credit consumed',
-                    'returned' => 'Credit returned',
                     'none' => 'No linked credit',
                 ],
             ],

--- a/app-modules/panel-admin/lang/en/widgets.php
+++ b/app-modules/panel-admin/lang/en/widgets.php
@@ -114,6 +114,8 @@ return [
         'pending_description' => 'Awaiting completion',
         'cancellations' => 'Cancellations',
         'cancellations_description' => 'Total cancelled consultations',
+        'no_shows' => 'No-shows',
+        'no_shows_description' => 'Total consultations marked as no-show',
         'conclusion_rate' => 'Conclusion Rate',
         'conclusion_rate_description' => ':completed of :total consultations concluded',
         'cancellation_rate' => 'Cancellation Rate',

--- a/app-modules/panel-admin/lang/pt_BR/resources.php
+++ b/app-modules/panel-admin/lang/pt_BR/resources.php
@@ -38,12 +38,23 @@ return [
                 'action' => 'Ação',
                 'performed_by' => 'Realizado por',
                 'happened_at' => 'Data e hora',
+                'previous_status' => 'Status anterior',
+                'new_status' => 'Novo status',
+                'credit_impact' => 'Impacto no crédito',
+            ],
+            'values' => [
+                'credit_impact' => [
+                    'consumed' => 'Crédito consumido',
+                    'returned' => 'Crédito devolvido',
+                    'none' => 'Sem crédito vinculado',
+                ],
             ],
             'sections' => [
                 'consultant_assigned' => 'Consultor Atribuído',
                 'consultant_left' => 'Consultor Removido',
                 'consultant_changed' => 'Alteração de Consultor',
                 're_scheduled' => 'Reagendamento',
+                'no_show_marked' => 'Não Compareceu',
             ],
             'placeholders' => [
                 'empty' => '—',

--- a/app-modules/panel-admin/lang/pt_BR/resources.php
+++ b/app-modules/panel-admin/lang/pt_BR/resources.php
@@ -45,7 +45,6 @@ return [
             'values' => [
                 'credit_impact' => [
                     'consumed' => 'Crédito consumido',
-                    'returned' => 'Crédito devolvido',
                     'none' => 'Sem crédito vinculado',
                 ],
             ],

--- a/app-modules/panel-admin/lang/pt_BR/widgets.php
+++ b/app-modules/panel-admin/lang/pt_BR/widgets.php
@@ -114,6 +114,8 @@ return [
         'pending_description' => 'Aguardando realização',
         'cancellations' => 'Cancelamentos',
         'cancellations_description' => 'Total de consultas canceladas',
+        'no_shows' => 'Não Compareceu',
+        'no_shows_description' => 'Total de consultas marcadas como não compareceu',
         'conclusion_rate' => 'Taxa de Conclusão',
         'conclusion_rate_description' => ':completed de :total consultas concluídas',
         'cancellation_rate' => 'Taxa de Cancelamento',

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/RelationManagers/AppointmentHistoryRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/RelationManagers/AppointmentHistoryRelationManager.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Date;
 use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\AppointmentHistory;
 use TresPontosTech\Consultants\Models\Consultant;
 
@@ -127,6 +128,11 @@ class AppointmentHistoryRelationManager extends RelationManager
                 $this->row('previous_date', $this->formatDate($old['appointment_at'] ?? null)),
                 $this->row('new_date', $this->formatDate($new['appointment_at'] ?? null)),
             ],
+            AppointmentHistoryActionType::NoShowMarked => [
+                $this->row('previous_status', AppointmentStatus::from((string) ($old['status'] ?? AppointmentStatus::Active->value))->getLabel()),
+                $this->row('new_status', AppointmentStatus::NoShow->getLabel()),
+                $this->row('credit_impact', $this->creditImpactLabel($new['credit_impact'] ?? null)),
+            ],
         };
     }
 
@@ -147,6 +153,11 @@ class AppointmentHistoryRelationManager extends RelationManager
                 '%s → %s',
                 $this->formatDate($old['appointment_at'] ?? null),
                 $this->formatDate($new['appointment_at'] ?? null),
+            ),
+            AppointmentHistoryActionType::NoShowMarked => sprintf(
+                '%s → %s',
+                AppointmentStatus::from((string) ($old['status'] ?? AppointmentStatus::Active->value))->getLabel(),
+                AppointmentStatus::NoShow->getLabel(),
             ),
         };
     }
@@ -175,6 +186,15 @@ class AppointmentHistoryRelationManager extends RelationManager
                 ? $consultant->name
                 : (string) __('panel-admin::resources.appointments.history.placeholders.unknown_consultant');
         })();
+    }
+
+    private function creditImpactLabel(mixed $impact): string
+    {
+        if (! is_string($impact) || blank($impact)) {
+            return $this->emptyPlaceholder();
+        }
+
+        return (string) __('panel-admin::resources.appointments.history.values.credit_impact.' . $impact);
     }
 
     private function formatDate(mixed $value): string

--- a/app-modules/panel-admin/src/Filament/Resources/Appointments/RelationManagers/AppointmentHistoryRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Appointments/RelationManagers/AppointmentHistoryRelationManager.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Date;
 use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Enums\CreditImpact;
 use TresPontosTech\Appointments\Models\AppointmentHistory;
 use TresPontosTech\Consultants\Models\Consultant;
 
@@ -190,11 +191,13 @@ class AppointmentHistoryRelationManager extends RelationManager
 
     private function creditImpactLabel(mixed $impact): string
     {
-        if (! is_string($impact) || blank($impact)) {
+        $creditImpact = is_string($impact) ? CreditImpact::tryFrom($impact) : null;
+
+        if (! $creditImpact instanceof CreditImpact) {
             return $this->emptyPlaceholder();
         }
 
-        return (string) __('panel-admin::resources.appointments.history.values.credit_impact.' . $impact);
+        return (string) __('panel-admin::resources.appointments.history.values.credit_impact.' . $creditImpact->value);
     }
 
     private function formatDate(mixed $value): string

--- a/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/AppointmentsStatsOverview.php
@@ -21,7 +21,7 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
     public array $tableFilterState = [];
 
     /**
-     * @var object{total: int, scheduled: int, pending: int, cancelled: int, completed: int}|null
+     * @var object{total: int, scheduled: int, pending: int, cancelled: int, completed: int, noShow: int}|null
      */
     private ?object $aggregates = null;
 
@@ -41,13 +41,14 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
             $this->scheduledStat(),
             $this->pendingStat(),
             $this->cancellationsStat(),
+            $this->noShowStat(),
             $this->conclusionRateStat(),
             $this->cancellationRateStat(),
         ];
     }
 
     /**
-     * @return object{total: int, scheduled: int, pending: int, cancelled: int, completed: int}
+     * @return object{total: int, scheduled: int, pending: int, cancelled: int, completed: int, noShow: int}
      */
     private function aggregates(): object
     {
@@ -93,6 +94,7 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
                     'count(*) filter (where status = ?) as pending',
                     'count(*) filter (where status in (?, ?)) as cancelled',
                     'count(*) filter (where status = ?) as completed',
+                    'count(*) filter (where status = ?) as no_show',
                 ]),
                 [
                     AppointmentStatus::Active->value,
@@ -100,6 +102,7 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
                     AppointmentStatus::Cancelled->value,
                     AppointmentStatus::CancelledLate->value,
                     AppointmentStatus::Completed->value,
+                    AppointmentStatus::NoShow->value,
                 ]
             )
             ->toBase()
@@ -111,6 +114,7 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
             'pending' => (int) ($row->pending ?? 0),
             'cancelled' => (int) ($row->cancelled ?? 0),
             'completed' => (int) ($row->completed ?? 0),
+            'noShow' => (int) ($row->no_show ?? 0),
         ];
     }
 
@@ -148,6 +152,15 @@ class AppointmentsStatsOverview extends StatsOverviewWidget
         return Stat::make(__('panel-admin::widgets.appointments_stats.cancellations'), $cancelled)
             ->description(__('panel-admin::widgets.appointments_stats.cancellations_description'))
             ->color('danger');
+    }
+
+    private function noShowStat(): Stat
+    {
+        $noShow = (int) $this->aggregates()->noShow;
+
+        return Stat::make(__('panel-admin::widgets.appointments_stats.no_shows'), $noShow)
+            ->description(__('panel-admin::widgets.appointments_stats.no_shows_description'))
+            ->color(AppointmentStatus::NoShow->getColor());
     }
 
     private function conclusionRateStat(): Stat

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
@@ -2,6 +2,7 @@
 
 namespace TresPontosTech\PanelAdmin\Filament\Widgets\Metrics;
 
+use Filament\Support\Colors\Color;
 use Filament\Widgets\ChartWidget;
 use Filament\Widgets\Concerns\InteractsWithPageFilters;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
@@ -36,23 +37,18 @@ class AppointmentsByStatus extends ChartWidget
                 $status->value => $results->get($status->value, 0),
             ]);
 
+        $statuses = $counts->keys()->map(fn (string $value): AppointmentStatus => AppointmentStatus::from($value));
+
         return [
             'datasets' => [
                 [
                     'data' => $counts->values()->toArray(),
-                    'backgroundColor' => [
-                        'rgb(251, 191, 36)',
-                        'rgb(59, 130, 246)',
-                        'rgb(34, 197, 94)',
-                        'rgb(239, 68, 68)',
-                        'rgb(249, 115, 22)',
-                        'rgb(168, 85, 247)',
-                    ],
+                    'backgroundColor' => $statuses
+                        ->map(fn (AppointmentStatus $status): string => Color::convertToRgb($status->getColor()[500]))
+                        ->all(),
                 ],
             ],
-            'labels' => $counts->keys()
-                ->map(fn (string $value): string => AppointmentStatus::from($value)->getLabel())
-                ->all(),
+            'labels' => $statuses->map(fn (AppointmentStatus $status): string => $status->getLabel())->all(),
         ];
     }
 

--- a/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
+++ b/app-modules/panel-admin/src/Filament/Widgets/Metrics/AppointmentsByStatus.php
@@ -46,6 +46,7 @@ class AppointmentsByStatus extends ChartWidget
                         'rgb(34, 197, 94)',
                         'rgb(239, 68, 68)',
                         'rgb(249, 115, 22)',
+                        'rgb(168, 85, 247)',
                     ],
                 ],
             ],

--- a/app-modules/panel-admin/tests/Feature/Filament/AppointmentTransitionActionsTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/AppointmentTransitionActionsTest.php
@@ -139,6 +139,7 @@ it('hides cancel action for terminal statuses', function (AppointmentStatus $sta
     'Completed' => AppointmentStatus::Completed,
     'Cancelled' => AppointmentStatus::Cancelled,
     'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
 ]);
 
 it('cancels appointment via action', function (): void {

--- a/app-modules/panel-admin/tests/Feature/Filament/AppointmentsStatsOverviewTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/AppointmentsStatsOverviewTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Filament\Widgets\StatsOverviewWidget\Stat;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\PanelAdmin\Filament\Widgets\AppointmentsStatsOverview;
 
+use function Livewire\invade;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
@@ -32,4 +34,25 @@ it('does not include Completed appointments in the cancellations count', functio
 
     livewire(AppointmentsStatsOverview::class)
         ->assertSee('0');
+});
+
+it('shows the no-show count and keeps the total closing with the sum of the buckets', function (): void {
+    Appointment::factory()->withStatus(AppointmentStatus::Pending)->count(2)->create();
+    Appointment::factory()->withStatus(AppointmentStatus::Cancelled)->count(1)->create();
+    Appointment::factory()->withStatus(AppointmentStatus::Completed)->count(3)->create();
+    Appointment::factory()->withStatus(AppointmentStatus::NoShow)->count(4)->create();
+
+    $widget = livewire(AppointmentsStatsOverview::class)->instance();
+
+    $stats = collect(invade($widget)->getStats());
+    $statValue = fn (string $key): int => (int) $stats
+        ->sole(fn (Stat $stat): bool => $stat->getLabel() === __('panel-admin::widgets.appointments_stats.' . $key))
+        ->getValue();
+
+    $completedCreated = 3;
+
+    expect($statValue('no_shows'))->toBe(4)
+        ->and($statValue('total_requests'))->toBe(10)
+        ->and($statValue('scheduled') + $statValue('pending') + $statValue('cancellations') + $statValue('no_shows') + $completedCreated)
+        ->toBe($statValue('total_requests'));
 });

--- a/app-modules/panel-admin/tests/Feature/Filament/Metrics/AppointmentsByStatusTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/Metrics/AppointmentsByStatusTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Colors\Color;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\PanelAdmin\Filament\Widgets\Metrics\AppointmentsByStatus;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    actingAsAdmin();
+});
+
+function appointmentsByStatusPageFilters(): array
+{
+    return ['pageFilters' => ['startDate' => null, 'endDate' => null]];
+}
+
+it('renders the appointments by status widget', function (): void {
+    livewire(AppointmentsByStatus::class, appointmentsByStatusPageFilters())->assertOk();
+});
+
+it('derives each case color and label from the enum itself, never from its position in the dataset', function (): void {
+    Appointment::factory()->withStatus(AppointmentStatus::NoShow)->count(2)->create();
+    Appointment::factory()->withStatus(AppointmentStatus::Completed)->count(3)->create();
+
+    $widget = livewire(AppointmentsByStatus::class, appointmentsByStatusPageFilters())->instance();
+
+    $data = (new ReflectionMethod($widget, 'getData'))->invoke($widget);
+
+    foreach (AppointmentStatus::cases() as $status) {
+        $index = array_search($status->getLabel(), $data['labels'], true);
+
+        expect($index)->not->toBeFalse();
+        expect($data['datasets'][0]['backgroundColor'][$index])
+            ->toBe(Color::convertToRgb($status->getColor()[500]));
+    }
+});

--- a/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentHistoryTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentHistoryTest.php
@@ -260,3 +260,33 @@ it('shows the credit impact in the no_show_marked history detail modal', functio
         'value' => 'Crédito consumido',
     ]);
 });
+
+it('falls back to the empty placeholder when credit_impact holds an unrecognised value', function (): void {
+    $appointment = Appointment::factory()->create();
+
+    $history = AppointmentHistory::factory()
+        ->actionType(AppointmentHistoryActionType::NoShowMarked)
+        ->create([
+            'appointment_id' => $appointment->id,
+            'actor_type' => AppointmentHistoryActor::Consultant,
+            'old_values' => ['status' => AppointmentStatus::Active->value],
+            'new_values' => [
+                'status' => AppointmentStatus::NoShow->value,
+                'credit_impact' => 'not_a_real_credit_impact',
+            ],
+        ]);
+
+    $component = livewire(AppointmentHistoryRelationManager::class, [
+        'ownerRecord' => $appointment,
+        'pageClass' => ViewAppointment::class,
+    ])
+        ->mountTableAction('view', $history)
+        ->assertHasNoTableActionErrors();
+
+    $changes = invade($component->instance())->buildChangeRows($history);
+
+    expect($changes)->toContain([
+        'label' => 'Impacto no crédito',
+        'value' => '—',
+    ]);
+});

--- a/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentHistoryTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentHistoryTest.php
@@ -20,6 +20,7 @@ use TresPontosTech\PanelAdmin\Filament\Resources\Appointments\Pages\ViewAppointm
 use TresPontosTech\PanelAdmin\Filament\Resources\Appointments\RelationManagers\AppointmentHistoryRelationManager;
 use Zap\Facades\Zap;
 
+use function Livewire\invade;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
@@ -193,4 +194,69 @@ it('resolves consultant names in the history detail modal', function (): void {
         ->assertSee('Ana Prévia')
         ->assertSee('Bruno Atual')
         ->assertSee(AppointmentHistoryActionType::ConsultantChanged->getLabel());
+});
+
+it('renders the no_show_marked history entry in the relation manager table', function (): void {
+    $appointment = Appointment::factory()->create();
+
+    $history = AppointmentHistory::factory()
+        ->actionType(AppointmentHistoryActionType::NoShowMarked)
+        ->create([
+            'appointment_id' => $appointment->id,
+            'actor_type' => AppointmentHistoryActor::Consultant,
+            'old_values' => ['status' => AppointmentStatus::Active->value],
+            'new_values' => [
+                'status' => AppointmentStatus::NoShow->value,
+                'credit_impact' => 'consumed',
+            ],
+        ]);
+
+    livewire(AppointmentHistoryRelationManager::class, [
+        'ownerRecord' => $appointment,
+        'pageClass' => ViewAppointment::class,
+    ])
+        ->assertOk()
+        ->assertCanSeeTableRecords([$history])
+        ->assertSeeText(AppointmentHistoryActionType::NoShowMarked->getLabel())
+        ->assertSeeText(AppointmentStatus::NoShow->getLabel());
+});
+
+/**
+ * Filament renders a mounted action's modal body through a Livewire
+ * partial-render effect rather than the component's main HTML, so
+ * assertSee() after mountTableAction() cannot see it here (its own compiled
+ * view also references $this in a way that needs the real Livewire request
+ * lifecycle to resolve). Mounting the action still proves the ViewAction
+ * wires up against a NoShowMarked record without error; inspecting
+ * buildChangeRows() directly exercises the exact
+ * creditImpactLabel()/translation path the modal's view renders from.
+ */
+it('shows the credit impact in the no_show_marked history detail modal', function (): void {
+    $appointment = Appointment::factory()->create();
+
+    $history = AppointmentHistory::factory()
+        ->actionType(AppointmentHistoryActionType::NoShowMarked)
+        ->create([
+            'appointment_id' => $appointment->id,
+            'actor_type' => AppointmentHistoryActor::Consultant,
+            'old_values' => ['status' => AppointmentStatus::Active->value],
+            'new_values' => [
+                'status' => AppointmentStatus::NoShow->value,
+                'credit_impact' => 'consumed',
+            ],
+        ]);
+
+    $component = livewire(AppointmentHistoryRelationManager::class, [
+        'ownerRecord' => $appointment,
+        'pageClass' => ViewAppointment::class,
+    ])
+        ->mountTableAction('view', $history)
+        ->assertHasNoTableActionErrors();
+
+    $changes = invade($component->instance())->buildChangeRows($history);
+
+    expect($changes)->toContain([
+        'label' => 'Impacto no crédito',
+        'value' => 'Crédito consumido',
+    ]);
 });

--- a/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentsTableFiltersTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/Resources/Appointments/AppointmentsTableFiltersTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\Users\User;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\PanelAdmin\Filament\Resources\Appointments\Pages\ListAppointments;
 
@@ -35,4 +36,14 @@ it('shows all appointments when the user name filter is empty', function (): voi
     livewire(ListAppointments::class)
         ->filterTable('user_name', ['user_name' => ''])
         ->assertCanSeeTableRecords([$johnAppointment, $mariaAppointment]);
+});
+
+it('filters appointments by no-show status', function (): void {
+    $noShow = Appointment::factory()->withStatus(AppointmentStatus::NoShow)->create();
+    $active = Appointment::factory()->withStatus(AppointmentStatus::Active)->create();
+
+    livewire(ListAppointments::class)
+        ->filterTable('status', [AppointmentStatus::NoShow->value])
+        ->assertCanSeeTableRecords([$noShow])
+        ->assertCanNotSeeTableRecords([$active]);
 });

--- a/app-modules/panel-app/src/Filament/Widgets/LatestAppointmentsWidget.php
+++ b/app-modules/panel-app/src/Filament/Widgets/LatestAppointmentsWidget.php
@@ -127,6 +127,12 @@ class LatestAppointmentsWidget extends Widget implements HasActions, HasSchemas,
      * Traduz o agendamento para o que a linha precisa desenhar, mantendo a
      * blade livre de regra de negócio.
      *
+     * `needsRescheduling` agrupa três casos com o mesmo destino — remarcar
+     * pelo botão do cabeçalho: agendamentos cancelados, não comparecidos, e
+     * os que ficaram pendentes/confirmados sem virar concluídos depois de o
+     * horário passar. `isNoShow` sai desse agrupamento para receber cor
+     * própria (roxo do enum), em vez de herdar o vermelho do cancelamento.
+     *
      * @return array<string, mixed>
      */
     private function toRow(Appointment $appointment): array
@@ -137,12 +143,12 @@ class LatestAppointmentsWidget extends Widget implements HasActions, HasSchemas,
         $isCancelled = in_array($appointment->status, [
             AppointmentStatus::Cancelled,
             AppointmentStatus::CancelledLate,
-            AppointmentStatus::NoShow,
         ], strict: true);
 
-        // Cancelada, ou marcada como pendente/confirmada e o horário já passou
-        // sem virar concluída: nos dois casos o caminho adiante é remarcar.
+        $isNoShow = $appointment->status === AppointmentStatus::NoShow;
+
         $needsRescheduling = $isCancelled
+            || $isNoShow
             || ($isPast && in_array($appointment->status, [
                 AppointmentStatus::Pending,
                 AppointmentStatus::Active,
@@ -169,6 +175,7 @@ class LatestAppointmentsWidget extends Widget implements HasActions, HasSchemas,
             'schedule' => $appointment->appointment_at->format('d/m/Y · H\hi'),
             'status' => $appointment->status,
             'needsRescheduling' => $needsRescheduling,
+            'isNoShow' => $isNoShow,
             'isCompleted' => $appointment->status === AppointmentStatus::Completed,
             'isPending' => $appointment->status === AppointmentStatus::Pending && ! $needsRescheduling,
             'meetingUrl' => $appointment->status === AppointmentStatus::Active && ! $isPast

--- a/app-modules/panel-app/src/Filament/Widgets/LatestAppointmentsWidget.php
+++ b/app-modules/panel-app/src/Filament/Widgets/LatestAppointmentsWidget.php
@@ -137,6 +137,7 @@ class LatestAppointmentsWidget extends Widget implements HasActions, HasSchemas,
         $isCancelled = in_array($appointment->status, [
             AppointmentStatus::Cancelled,
             AppointmentStatus::CancelledLate,
+            AppointmentStatus::NoShow,
         ], strict: true);
 
         // Cancelada, ou marcada como pendente/confirmada e o horário já passou

--- a/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/CancelAppointmentActionTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/CancelAppointmentActionTest.php
@@ -57,6 +57,15 @@ it('hides cancel action on CancelledLate appointments', function (): void {
         ->assertTableActionHidden('cancel-appointment', $appointment);
 });
 
+it('hides cancel action on NoShow appointments', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::NoShow)
+        ->create(['user_id' => $this->employee->id, 'appointment_at' => now()->addHours(2)]);
+
+    livewire(ListAppointments::class)
+        ->assertTableActionHidden('cancel-appointment', $appointment);
+});
+
 it('hides cancel action on past appointments even if Pending or Active', function (AppointmentStatus $status): void {
     $appointment = Appointment::factory()
         ->withStatus($status)

--- a/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/RescheduleAppointmentActionTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Resources/Appointments/RescheduleAppointmentActionTest.php
@@ -118,6 +118,7 @@ it('hides the reschedule action on terminal statuses', function (AppointmentStat
     'Completed' => AppointmentStatus::Completed,
     'Cancelled' => AppointmentStatus::Cancelled,
     'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
 ]);
 
 // ---------------------------------------------------------------------------

--- a/app-modules/panel-app/tests/Feature/Filament/Widgets/LatestAppointmentsWidgetTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Widgets/LatestAppointmentsWidgetTest.php
@@ -117,9 +117,21 @@ it('treats a no-show appointment as needing rescheduling, never as completed', f
         ->keyBy('id');
 
     expect($rows[$appointment->getKey()]['needsRescheduling'])->toBeTrue()
+        ->and($rows[$appointment->getKey()]['isNoShow'])->toBeTrue()
         ->and($rows[$appointment->getKey()]['isCompleted'])->toBeFalse()
         ->and($rows[$appointment->getKey()]['canCancel'])->toBeFalse()
         ->and($rows[$appointment->getKey()]['canReschedule'])->toBeFalse();
+});
+
+it('renders the no-show row with the status enum purple, not the cancellation red', function (): void {
+    Appointment::factory()
+        ->withStatus(AppointmentStatus::NoShow)
+        ->create(['user_id' => $this->employee->getKey(), 'appointment_at' => now()->subDay()]);
+
+    livewire(LatestAppointmentsWidget::class)
+        ->assertSuccessful()
+        ->assertSee('bg-purple-500', false)
+        ->assertDontSee('bg-danger-500', false);
 });
 
 it('cancels the appointment picked by the row action', function (): void {

--- a/app-modules/panel-app/tests/Feature/Filament/Widgets/LatestAppointmentsWidgetTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Widgets/LatestAppointmentsWidgetTest.php
@@ -106,6 +106,22 @@ it('does not offer rescheduling for a completed appointment', function (): void 
         ->assertSee(AppointmentStatus::Completed->getLabel());
 });
 
+it('treats a no-show appointment as needing rescheduling, never as completed', function (): void {
+    $appointment = Appointment::factory()
+        ->withStatus(AppointmentStatus::NoShow)
+        ->create(['user_id' => $this->employee->getKey(), 'appointment_at' => now()->subDay()]);
+
+    $rows = livewire(LatestAppointmentsWidget::class)
+        ->assertSuccessful()
+        ->viewData('rows')
+        ->keyBy('id');
+
+    expect($rows[$appointment->getKey()]['needsRescheduling'])->toBeTrue()
+        ->and($rows[$appointment->getKey()]['isCompleted'])->toBeFalse()
+        ->and($rows[$appointment->getKey()]['canCancel'])->toBeFalse()
+        ->and($rows[$appointment->getKey()]['canReschedule'])->toBeFalse();
+});
+
 it('cancels the appointment picked by the row action', function (): void {
     $target = Appointment::factory()
         ->withStatus(AppointmentStatus::Pending)

--- a/app-modules/panel-company/resources/views/filament/widgets/command-dashboard/status-breakdown.blade.php
+++ b/app-modules/panel-company/resources/views/filament/widgets/command-dashboard/status-breakdown.blade.php
@@ -4,7 +4,8 @@
     $dot = [
         'primary' => 'bg-primary-500', 'emerald' => 'bg-emerald-500', 'blue' => 'bg-blue-500',
         'violet' => 'bg-violet-500', 'pink' => 'bg-pink-500', 'amber' => 'bg-amber-500',
-        'teal' => 'bg-teal-500', 'red' => 'bg-red-500', 'orange' => 'bg-orange-500', 'neutral' => 'bg-gray-400',
+        'teal' => 'bg-teal-500', 'red' => 'bg-red-500', 'orange' => 'bg-orange-500',
+        'purple' => 'bg-purple-500', 'neutral' => 'bg-gray-400',
     ];
     $card = 'rounded-2xl border border-gray-200 bg-white p-5 shadow-sm dark:border-white/10 dark:bg-gray-900';
     $label = 'text-sm font-semibold text-gray-500 dark:text-gray-400';

--- a/app-modules/panel-company/src/Actions/Metrics/GetAppointmentStats.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetAppointmentStats.php
@@ -36,11 +36,12 @@ final class GetAppointmentStats
             $total = (clone $base)->count();
             $completed = (clone $base)->where('status', AppointmentStatus::Completed)->count();
             $cancelled = (clone $base)->whereIn('status', [AppointmentStatus::Cancelled, AppointmentStatus::CancelledLate])->count();
+            $noShow = (clone $base)->where('status', AppointmentStatus::NoShow)->count();
 
-            $finalized = $completed + $cancelled;
+            $finalized = $completed + $cancelled + $noShow;
             $attendanceRate = $finalized > 0 ? round($completed / $finalized * 100, 1) : 0.0;
 
-            return new AppointmentStats($total, $completed, $cancelled, $attendanceRate);
+            return new AppointmentStats($total, $completed, $cancelled, $finalized, $attendanceRate);
         });
     }
 }

--- a/app-modules/panel-company/src/Actions/Metrics/GetStatusBreakdown.php
+++ b/app-modules/panel-company/src/Actions/Metrics/GetStatusBreakdown.php
@@ -34,6 +34,7 @@ final class GetStatusBreakdown
             AppointmentStatus::Pending->value => 'amber',
             AppointmentStatus::Cancelled->value => 'red',
             AppointmentStatus::CancelledLate->value => 'orange',
+            AppointmentStatus::NoShow->value => 'purple',
         ];
     }
 

--- a/app-modules/panel-company/src/DTOs/AppointmentStats.php
+++ b/app-modules/panel-company/src/DTOs/AppointmentStats.php
@@ -10,6 +10,7 @@ final readonly class AppointmentStats
         public int $total,
         public int $completed,
         public int $cancelled,
+        public int $finalized,
         public float $attendanceRate,
     ) {}
 }

--- a/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentStatsTilesWidget.php
+++ b/app-modules/panel-company/src/Filament/Widgets/Metrics/AppointmentStatsTilesWidget.php
@@ -55,7 +55,7 @@ class AppointmentStatsTilesWidget extends StatsOverviewWidget
                 ->description(__('panel-company::widgets.appointment_stats.attendance_rate_description', [
                     'rate' => MetricsNumber::percent($stats->attendanceRate),
                     'completed' => $stats->completed,
-                    'total' => $stats->completed + $stats->cancelled,
+                    'total' => $stats->finalized,
                 ]))
                 ->icon('heroicon-o-chart-bar')
                 ->color($attendanceColor),

--- a/app-modules/panel-company/tests/Feature/Actions/GetAppointmentStatsTest.php
+++ b/app-modules/panel-company/tests/Feature/Actions/GetAppointmentStatsTest.php
@@ -27,5 +27,24 @@ it('computes totals and attendance rate', function (): void {
     expect($stats->total)->toBe(4)
         ->and($stats->completed)->toBe(3)
         ->and($stats->cancelled)->toBe(1)
+        ->and($stats->finalized)->toBe(4)
         ->and($stats->attendanceRate)->toBe(75.0);
+});
+
+it('counts no-show appointments in the attendance rate denominator', function (): void {
+    $company = Company::factory()->create();
+
+    Appointment::factory()->count(3)->create([
+        'company_id' => $company->id, 'status' => AppointmentStatus::Completed, 'appointment_at' => now(),
+    ]);
+    Appointment::factory()->count(2)->create([
+        'company_id' => $company->id, 'status' => AppointmentStatus::NoShow, 'appointment_at' => now(),
+    ]);
+
+    $stats = resolve(GetAppointmentStats::class)->handle($company, MetricsPeriod::lastMonths(12), MetricsFilters::none());
+
+    expect($stats->total)->toBe(5)
+        ->and($stats->completed)->toBe(3)
+        ->and($stats->finalized)->toBe(5)
+        ->and($stats->attendanceRate)->toBe(60.0);
 });

--- a/app-modules/panel-company/tests/Feature/Actions/GetStatusBreakdownTest.php
+++ b/app-modules/panel-company/tests/Feature/Actions/GetStatusBreakdownTest.php
@@ -31,3 +31,17 @@ it('breaks appointments down by status with the completed share', function (): v
         ->and($data->completedPercent)->toBe(75.0)
         ->and($data->segments)->toHaveCount(2);
 });
+
+it('maps a no_show appointment to the purple color', function (): void {
+    $company = Company::factory()->create();
+    Appointment::factory()->create([
+        'company_id' => $company->id,
+        'status' => AppointmentStatus::NoShow,
+        'appointment_at' => now(),
+    ]);
+
+    $data = resolve(GetStatusBreakdown::class)->handle($company, MetricsPeriod::lastMonths(12), MetricsFilters::none());
+
+    expect($data->segments)->toHaveCount(1)
+        ->and($data->segments[0]->color)->toBe('purple');
+});

--- a/app-modules/panel-company/tests/Feature/Filament/Widgets/MetricsWidgetsTest.php
+++ b/app-modules/panel-company/tests/Feature/Filament/Widgets/MetricsWidgetsTest.php
@@ -102,6 +102,34 @@ it('renders the appointment stats tiles', function (): void {
         ->assertSee(__('panel-company::widgets.appointment_stats.total_scheduled'));
 });
 
+it('bases the attendance rate legend on the real finalized denominator, including no-shows', function (): void {
+    actingAsCompanyOwner();
+    $company = Filament::getTenant();
+
+    Appointment::factory()->count(3)->create([
+        'company_id' => $company->id,
+        'status' => AppointmentStatus::Completed,
+        'appointment_at' => now(),
+    ]);
+    Appointment::factory()->count(2)->create([
+        'company_id' => $company->id,
+        'status' => AppointmentStatus::NoShow,
+        'appointment_at' => now(),
+    ]);
+
+    $widget = livewire(AppointmentStatsTilesWidget::class, ['pageFilters' => ['startDate' => now()->subDays(30)->toDateString(), 'endDate' => now()->toDateString()]])
+        ->instance();
+
+    $stats = (new ReflectionMethod($widget, 'getStats'))->invoke($widget);
+    $attendanceRateStat = $stats[3];
+
+    expect($attendanceRateStat->getDescription())->toBe(__('panel-company::widgets.appointment_stats.attendance_rate_description', [
+        'rate' => 60,
+        'completed' => 3,
+        'total' => 5,
+    ]));
+});
+
 it('renders the engagement tiles', function (): void {
     actingAsCompanyOwner();
 

--- a/app-modules/panel-consultant/lang/en/resources.php
+++ b/app-modules/panel-consultant/lang/en/resources.php
@@ -19,6 +19,20 @@ return [
             'no_anamnese_description' => 'This client has not filled in their financial profile yet.',
             'meeting_url_pending' => 'Awaiting confirmation',
         ],
+        'mark_no_show' => [
+            'label' => 'No-show',
+            'modal_heading' => 'Record no-show',
+            'modal_description' => 'Confirm that :name did not attend the appointment of :datetime?',
+            'submit' => 'Confirm',
+            'success' => [
+                'title' => 'No-show recorded',
+                'body' => 'The appointment was marked as "No-show".',
+            ],
+            'failure' => [
+                'title' => 'Unable to record',
+                'body' => 'The appointment is no longer in a state that allows recording a no-show.',
+            ],
+        ],
     ],
     'documents' => [
         'navigation_label' => 'Materials',

--- a/app-modules/panel-consultant/lang/pt_BR/resources.php
+++ b/app-modules/panel-consultant/lang/pt_BR/resources.php
@@ -19,6 +19,20 @@ return [
             'no_anamnese_description' => 'Este cliente ainda não preencheu o perfil financeiro.',
             'meeting_url_pending' => 'Aguardando confirmação',
         ],
+        'mark_no_show' => [
+            'label' => 'Não Compareceu',
+            'modal_heading' => 'Registrar não comparecimento',
+            'modal_description' => 'Confirmar que :name não compareceu à consultoria de :datetime?',
+            'submit' => 'Confirmar',
+            'success' => [
+                'title' => 'Não comparecimento registrado',
+                'body' => 'A consultoria foi marcada como "Não compareceu".',
+            ],
+            'failure' => [
+                'title' => 'Não foi possível registrar',
+                'body' => 'A consultoria não está mais em um estado que permita registrar o não comparecimento.',
+            ],
+        ],
     ],
     'documents' => [
         'navigation_label' => 'Materiais',

--- a/app-modules/panel-consultant/src/Filament/Actions/MarkNoShowAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/MarkNoShowAction.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TresPontosTech\PanelConsultant\Filament\Actions;
+
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use Throwable;
+use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
+use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
+use TresPontosTech\Appointments\Models\Appointment;
+
+class MarkNoShowAction extends Action
+{
+    public static function getDefaultName(): ?string
+    {
+        return 'mark-no-show';
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->label(__('panel-consultant::resources.appointments.mark_no_show.label'));
+        $this->icon(Heroicon::UserMinus);
+        $this->color('danger');
+        $this->requiresConfirmation();
+        $this->modalHeading(__('panel-consultant::resources.appointments.mark_no_show.modal_heading'));
+        $this->modalDescription(fn (Appointment $record): string => __('panel-consultant::resources.appointments.mark_no_show.modal_description', [
+            'name' => $record->user->name,
+            'datetime' => $record->appointment_at->format('d/m/Y H:i'),
+        ]));
+        $this->modalSubmitActionLabel(__('panel-consultant::resources.appointments.mark_no_show.submit'));
+
+        $this->visible(fn (Appointment $record): bool => $this->canMarkNoShow($record));
+
+        $this->authorize(fn (Appointment $record): bool => $this->canMarkNoShow($record));
+
+        $this->action(function (Appointment $record): void {
+            $record->refresh();
+
+            if (! $this->canMarkNoShow($record)) {
+                $this->sendMarkNoShowFailureNotification();
+
+                return;
+            }
+
+            try {
+                $record->current_transition->handle(new TransitionData(
+                    noShow: true,
+                    noShowMarkedBy: auth()->user(),
+                ));
+            } catch (InvalidTransitionException|MissingTransitionDataException) {
+                $this->sendMarkNoShowFailureNotification();
+
+                return;
+            } catch (Throwable $exception) {
+                report($exception);
+
+                $this->sendMarkNoShowFailureNotification();
+
+                return;
+            }
+
+            Notification::make()
+                ->success()
+                ->title(__('panel-consultant::resources.appointments.mark_no_show.success.title'))
+                ->body(__('panel-consultant::resources.appointments.mark_no_show.success.body'))
+                ->send();
+        });
+    }
+
+    /**
+     * The appointment must belong to the signed-in consultant, still be Active
+     * and already be past its scheduled time.
+     */
+    private function canMarkNoShow(Appointment $record): bool
+    {
+        return $record->status === AppointmentStatus::Active
+            && $record->appointment_at->isPast()
+            && $record->consultant_id === auth()->user()?->consultant?->getKey();
+    }
+
+    private function sendMarkNoShowFailureNotification(): void
+    {
+        Notification::make()
+            ->danger()
+            ->title(__('panel-consultant::resources.appointments.mark_no_show.failure.title'))
+            ->body(__('panel-consultant::resources.appointments.mark_no_show.failure.body'))
+            ->send();
+    }
+}

--- a/app-modules/panel-consultant/src/Filament/Actions/MarkNoShowAction.php
+++ b/app-modules/panel-consultant/src/Filament/Actions/MarkNoShowAction.php
@@ -11,7 +11,6 @@ use Throwable;
 use TresPontosTech\Appointments\Actions\Transitions\TransitionData;
 use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Exceptions\InvalidTransitionException;
-use TresPontosTech\Appointments\Exceptions\MissingTransitionDataException;
 use TresPontosTech\Appointments\Models\Appointment;
 
 class MarkNoShowAction extends Action
@@ -32,7 +31,7 @@ class MarkNoShowAction extends Action
         $this->modalHeading(__('panel-consultant::resources.appointments.mark_no_show.modal_heading'));
         $this->modalDescription(fn (Appointment $record): string => __('panel-consultant::resources.appointments.mark_no_show.modal_description', [
             'name' => $record->user->name,
-            'datetime' => $record->appointment_at->format('d/m/Y H:i'),
+            'datetime' => $record->appointment_at->isoFormat('L LT'),
         ]));
         $this->modalSubmitActionLabel(__('panel-consultant::resources.appointments.mark_no_show.submit'));
 
@@ -51,10 +50,9 @@ class MarkNoShowAction extends Action
 
             try {
                 $record->current_transition->handle(new TransitionData(
-                    noShow: true,
                     noShowMarkedBy: auth()->user(),
                 ));
-            } catch (InvalidTransitionException|MissingTransitionDataException) {
+            } catch (InvalidTransitionException) {
                 $this->sendMarkNoShowFailureNotification();
 
                 return;
@@ -80,9 +78,13 @@ class MarkNoShowAction extends Action
      */
     private function canMarkNoShow(Appointment $record): bool
     {
+        $consultantId = auth()->user()?->consultant?->getKey();
+
         return $record->status === AppointmentStatus::Active
             && $record->appointment_at->isPast()
-            && $record->consultant_id === auth()->user()?->consultant?->getKey();
+            && filled($record->consultant_id)
+            && filled($consultantId)
+            && $record->consultant_id === $consultantId;
     }
 
     private function sendMarkNoShowFailureNotification(): void

--- a/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
+++ b/app-modules/panel-consultant/src/Filament/Resources/Appointments/Tables/AppointmentsTable.php
@@ -8,6 +8,7 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use TresPontosTech\Consultants\Models\Consultant;
 use TresPontosTech\PanelConsultant\Filament\Actions\CreateAppointmentRecordAction;
+use TresPontosTech\PanelConsultant\Filament\Actions\MarkNoShowAction;
 use TresPontosTech\PanelConsultant\Filament\Actions\ReviewAppointmentRecordAction;
 use TresPontosTech\PanelConsultant\Filament\Actions\ViewPreviousRecordSummaryAction;
 
@@ -33,6 +34,7 @@ class AppointmentsTable
                 ViewPreviousRecordSummaryAction::make(),
                 CreateAppointmentRecordAction::make(),
                 ReviewAppointmentRecordAction::make(),
+                MarkNoShowAction::make(),
                 ViewAction::make(),
             ]);
 

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/MarkNoShowActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/MarkNoShowActionTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Actions\Testing\TestAction;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use TresPontosTech\Appointments\Enums\AppointmentHistoryActionType;
+use TresPontosTech\Appointments\Enums\AppointmentStatus;
+use TresPontosTech\Appointments\Models\Appointment;
+use TresPontosTech\Appointments\Models\AppointmentHistory;
+use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
+use TresPontosTech\PanelConsultant\Filament\Actions\MarkNoShowAction;
+use TresPontosTech\PanelConsultant\Filament\Resources\Appointments\Pages\ListAppointments;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->consultant = actingAsConsultant();
+
+    Mail::fake();
+    Bus::fake();
+});
+
+it('marks an active past appointment as no-show', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    livewire(ListAppointments::class)
+        ->callAction(TestAction::make(MarkNoShowAction::getDefaultName())->table($appointment))
+        ->assertHasNoActionErrors()
+        ->assertNotified();
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::NoShow);
+});
+
+/**
+ * Filament's modal body is delivered through a Livewire partial-render effect
+ * rather than the component's main HTML, so assertSee() after mounting the
+ * action cannot see it. Evaluating the closure through the action instance
+ * directly exercises the exact same modalDescription() the modal renders.
+ */
+it('shows the beneficiary name and appointment date/time in the confirmation modal', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    $action = MarkNoShowAction::make()->record($appointment);
+    $description = (string) $action->getModalDescription();
+
+    expect($description)
+        ->toContain($appointment->user->name)
+        ->toContain($appointment->appointment_at->format('d/m/Y H:i'));
+
+    expect($action->isConfirmationRequired())->toBeTrue();
+});
+
+it('is hidden when the appointment is active but in the future', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->addHour()]);
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(TestAction::make(MarkNoShowAction::getDefaultName())->table($appointment));
+});
+
+it('is hidden for non-active statuses', function (AppointmentStatus $status): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus($status)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    livewire(ListAppointments::class)
+        ->assertActionHidden(TestAction::make(MarkNoShowAction::getDefaultName())->table($appointment));
+})->with([
+    'Pending' => AppointmentStatus::Pending,
+    'Completed' => AppointmentStatus::Completed,
+    'Cancelled' => AppointmentStatus::Cancelled,
+    'CancelledLate' => AppointmentStatus::CancelledLate,
+    'NoShow' => AppointmentStatus::NoShow,
+]);
+
+/**
+ * Stale page: the record still looks Active in memory here, but the row changes
+ * underneath before the click reaches the server. Filament's own visibility gate
+ * would refuse to call a hidden action through the Livewire table, so the
+ * action() closure is invoked directly to reach its refresh()-then-recheck
+ * guard against that race.
+ */
+it('keeps the status when the transition fails', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    $staleAppointment = Appointment::query()->whereKey($appointment->getKey())->firstOrFail();
+
+    Appointment::query()->whereKey($appointment->getKey())->update(['status' => AppointmentStatus::Completed]);
+
+    $actionFunction = MarkNoShowAction::make()->getActionFunction();
+    expect($actionFunction)->not->toBeNull();
+    $actionFunction($staleAppointment);
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::Completed);
+    expect(session('filament.notifications')[0]['status'] ?? null)->toBe('danger');
+});
+
+/**
+ * The credit-consumption event fires synchronously from inside the transition's
+ * DB::transaction(), before the no_show_marked history row is written. A
+ * listener that throws here must roll back the whole transaction, so the
+ * status update and the history insert are undone together.
+ *
+ * The action function is invoked directly (same technique as the "stale page"
+ * test above) because session('filament.notifications') only reflects what
+ * Notification::send() pushed when the closure runs in-process, not through a
+ * simulated Livewire request.
+ */
+it('rolls back the no-show transition and notifies failure when a listener throws mid-transaction', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    Event::listen(AppointmentCreditUsed::class, function (): void {
+        throw new RuntimeException('Forced failure to exercise the transaction rollback.');
+    });
+
+    $actionFunction = MarkNoShowAction::make()->getActionFunction();
+    expect($actionFunction)->not->toBeNull();
+    $actionFunction($appointment);
+
+    expect($appointment->refresh()->status)->toBe(AppointmentStatus::Active);
+    expect(session('filament.notifications')[0]['status'] ?? null)->toBe('danger');
+    expect(AppointmentHistory::query()
+        ->where('appointment_id', $appointment->getKey())
+        ->where('action_type', AppointmentHistoryActionType::NoShowMarked)
+        ->exists()
+    )->toBeFalse();
+});
+
+it('does not allow marking an appointment of another consultant', function (): void {
+    $foreign = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    livewire(ListAppointments::class)
+        ->assertCanNotSeeTableRecords([$foreign]);
+});

--- a/app-modules/panel-consultant/tests/Feature/Filament/Actions/MarkNoShowActionTest.php
+++ b/app-modules/panel-consultant/tests/Feature/Filament/Actions/MarkNoShowActionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Users\User;
 use Filament\Actions\Testing\TestAction;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Event;
@@ -11,9 +12,11 @@ use TresPontosTech\Appointments\Enums\AppointmentStatus;
 use TresPontosTech\Appointments\Models\Appointment;
 use TresPontosTech\Appointments\Models\AppointmentHistory;
 use TresPontosTech\Billing\Core\Events\Credit\AppointmentCreditUsed;
+use TresPontosTech\Consultants\Models\Consultant;
 use TresPontosTech\PanelConsultant\Filament\Actions\MarkNoShowAction;
 use TresPontosTech\PanelConsultant\Filament\Resources\Appointments\Pages\ListAppointments;
 
+use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
@@ -54,9 +57,24 @@ it('shows the beneficiary name and appointment date/time in the confirmation mod
 
     expect($description)
         ->toContain($appointment->user->name)
-        ->toContain($appointment->appointment_at->format('d/m/Y H:i'));
+        ->toContain($appointment->appointment_at->isoFormat('L LT'));
 
     expect($action->isConfirmationRequired())->toBeTrue();
+});
+
+it('formats the appointment date/time in the confirmation modal according to the active locale', function (): void {
+    $appointment = Appointment::factory()
+        ->recycle($this->consultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    app()->setLocale('en');
+    $description = (string) MarkNoShowAction::make()->record($appointment)->getModalDescription();
+    app()->setLocale('pt_BR');
+
+    expect($description)
+        ->toContain($appointment->appointment_at->clone()->locale('en')->isoFormat('L LT'))
+        ->not->toContain($appointment->appointment_at->format('d/m/Y H:i'));
 });
 
 it('is hidden when the appointment is active but in the future', function (): void {
@@ -111,11 +129,6 @@ it('keeps the status when the transition fails', function (): void {
 });
 
 /**
- * The credit-consumption event fires synchronously from inside the transition's
- * DB::transaction(), before the no_show_marked history row is written. A
- * listener that throws here must roll back the whole transaction, so the
- * status update and the history insert are undone together.
- *
  * The action function is invoked directly (same technique as the "stale page"
  * test above) because session('filament.notifications') only reflects what
  * Notification::send() pushed when the closure runs in-process, not through a
@@ -151,4 +164,30 @@ it('does not allow marking an appointment of another consultant', function (): v
 
     livewire(ListAppointments::class)
         ->assertCanNotSeeTableRecords([$foreign]);
+});
+
+it('is unavailable to a user without a linked consultant, even over an unassigned appointment', function (): void {
+    actingAs(User::factory()->createOne());
+
+    $unassigned = Appointment::factory()
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour(), 'consultant_id' => null]);
+
+    $action = MarkNoShowAction::make()->record($unassigned);
+
+    expect($action->isVisible())->toBeFalse();
+    expect($action->isAuthorized())->toBeFalse();
+});
+
+it('is not authorized when invoked directly on another consultant appointment, bypassing the table scope', function (): void {
+    $foreignConsultant = Consultant::factory()->create();
+    $foreign = Appointment::factory()
+        ->recycle($foreignConsultant)
+        ->withStatus(AppointmentStatus::Active)
+        ->create(['appointment_at' => now()->subHour()]);
+
+    $action = MarkNoShowAction::make()->record($foreign);
+
+    expect($action->isVisible())->toBeFalse();
+    expect($action->isAuthorized())->toBeFalse();
 });

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -443,6 +443,7 @@ class User extends Authenticatable implements FilamentUser, HasAvatar, HasDefaul
                 AppointmentStatus::Completed->value,
                 AppointmentStatus::Cancelled->value,
                 AppointmentStatus::CancelledLate->value,
+                AppointmentStatus::NoShow->value,
             ])
             ->exists();
     }

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -54,6 +54,7 @@
     --apt-cyan-300: #00c6bc;
     --apt-lime-300: #87c200;
     --apt-orange-300: #ff8f4c;
+    --apt-purple-300: #c9a3ff;
 
     /* Token de cor Text/text-medium do design system (não confundir com os
        --apt-text-* acima, que são tamanhos). */
@@ -334,6 +335,10 @@
     & .fi-apt-cat-retirement-and-estate-planning .fi-badge .fi-icon,
     & .fi-apt-status-cancelled-late .fi-badge .fi-icon {
         color: var(--apt-orange-300);
+    }
+
+    & .fi-apt-status-no-show .fi-badge .fi-icon {
+        color: var(--apt-purple-300);
     }
 
     /* Cor por tipo de documento (recordClasses nas tabelas de materiais):

--- a/resources/views/filament/app/widgets/latest-appointments.blade.php
+++ b/resources/views/filament/app/widgets/latest-appointments.blade.php
@@ -37,6 +37,7 @@
                         @php
                             // Tom do marcador de status, reutilizado pela bolinha e pelo halo.
                             $dot = match (true) {
+                                $row['isNoShow'] => 'purple',
                                 $row['needsRescheduling'] => 'danger',
                                 $row['isCompleted'] => 'success',
                                 default => 'info',
@@ -61,12 +62,14 @@
                                 <span class="w-0.5 flex-1 bg-gray-200 dark:bg-white/10"></span>
                                 <span @class([
                                     'flex size-5 shrink-0 items-center justify-center rounded-full',
+                                    'bg-purple-500/20' => $dot === 'purple',
                                     'bg-danger-500/20' => $dot === 'danger',
                                     'bg-success-500/20' => $dot === 'success',
                                     'bg-info-500/20' => $dot === 'info',
                                 ])>
                                     <span @class([
                                         'size-2 rounded-full',
+                                        'bg-purple-500' => $dot === 'purple',
                                         'bg-danger-500' => $dot === 'danger',
                                         'bg-success-500' => $dot === 'success',
                                         'bg-info-500' => $dot === 'info',
@@ -86,7 +89,8 @@
                                         :icon="$row['needsRescheduling'] ? 'heroicon-o-exclamation-circle' : 'heroicon-o-clock'"
                                         @class([
                                             'size-4 shrink-0',
-                                            'text-danger-500' => $row['needsRescheduling'],
+                                            'text-purple-500' => $row['isNoShow'],
+                                            'text-danger-500' => $row['needsRescheduling'] && ! $row['isNoShow'],
                                         ])
                                     />
                                     {{ $row['schedule'] }}
@@ -121,7 +125,8 @@
                                 @else
                                     <span @class([
                                         'inline-flex items-center gap-1.5 whitespace-nowrap px-2.5 py-1.5 text-[14px] font-medium',
-                                        'bg-danger-500/10 text-danger-600 dark:text-danger-400' => $row['needsRescheduling'],
+                                        'bg-purple-500/10 text-purple-600 dark:text-purple-400' => $row['isNoShow'],
+                                        'bg-danger-500/10 text-danger-600 dark:text-danger-400' => $row['needsRescheduling'] && ! $row['isNoShow'],
                                         'bg-info-500/10 text-info-600 dark:text-info-400' => $row['isPending'],
                                         'bg-success-500/10 text-success-600 dark:text-success-400' => ! $row['isPending'] && ! $row['needsRescheduling'],
                                     ])>


### PR DESCRIPTION
## Contexto

Épico **[FLM-ÉPICO-69](https://3pontos.monday.com/boards/18392609686/pulses/12699712196)** — quando um beneficiário não comparece a uma consultoria com status `Active`, o consultor não tem como registrar o fato: a consultoria fica presa sem transição válida ou é marcada como `Completed` incorretamente, distorcendo métricas e escondendo do time de operações o que realmente aconteceu.

Este PR adiciona o status **`no_show`** à state machine de agendamentos, o botão **"Não Compareceu"** no painel do consultor, o **consumo do crédito** do beneficiário com trilha de auditoria e a **visibilidade do status** nos painéis admin, app e consultor.

## Decisão de negócio — regra de crédito (US-385)

**Opção A: o no_show consome o crédito**, exatamente como uma consultoria concluída, com origem `no_show` rastreável no histórico do agendamento. Das três opções documentadas no épico (A — consumir; B — preservar; C — mista com a janela de 4h do FLM-57), a A penaliza o não comparecimento (objetivo do épico), é a mais simples e não acopla com a lógica de cancelamento tardio.

> ⚠️ A decisão formal é do PO — falta registrá-la como update na [US-385](https://3pontos.monday.com/boards/18392616637/pulses/12699719248) no Monday.

## O que muda, por story

| Story | Entrega |
| --- | --- |
| **US-383** | Case `NoShow = 'no_show'` no enum `AppointmentStatus` (ícone `UserMinus`, cor roxa, labels pt_BR/en) e classe terminal `NoShowTransition`. A transição `Active → NoShow` acontece em `ActiveTransition`, sinalizada por `TransitionData->noShow` (mesmo mecanismo do cancelamento). `Pending → NoShow` lança exceção. |
| **US-384** | `MarkNoShowAction` no panel-consultant: visível apenas para agendamento `Active` do próprio consultor com horário já passado; modal de confirmação com nome do beneficiário e data/hora; notificações Filament de sucesso e erro. |
| **US-385** | Consumo do crédito e linha de auditoria (`AppointmentHistory` com action type `NoShowMarked`, ator `Consultant` e `credit_impact`) na **mesma transação** da mudança de status, com rollback total em falha. Visível no admin pelo relation manager de histórico. |
| **US-386** | Badge "Não compareceu" nos painéis admin, app, consultor e no breakdown do painel da empresa; filtro por status no admin; reagendar/cancelar bloqueados no app para agendamentos `no_show`; botão do consultor some após a marcação. |

## Fluxo da marcação de no_show

```mermaid
flowchart TD
    A["Consultor clica em<br/>'Não Compareceu'"] --> B{"Guard: Active +<br/>horário passado +<br/>agendamento é dele?"}
    B -- "não" --> C["Notificação de erro<br/>status permanece"]
    B -- "sim" --> D["Modal de confirmação<br/>nome do beneficiário + data/hora"]
    D -- "confirma" --> E["ActiveTransition->handle()<br/>TransitionData(noShowMarkedBy: consultor)"]

    subgraph TX ["DB::transaction — atômico"]
        E --> F["status → no_show"]
        F --> G["AppointmentCreditUsed<br/>crédito InUse → Used<br/>(listener síncrono)"]
        G --> H["AppointmentHistory<br/>no_show_marked + CreditImpact<br/>lido do crédito APÓS a mutação"]
    end

    H --> I["Notificação de sucesso<br/>badge roxo nos painéis<br/>evento AppointmentNoShow (afterCommit)"]
    TX -. "qualquer exceção" .-> R["Rollback total:<br/>status volta a Active,<br/>crédito intacto, sem histórico"]
    R --> J["catch (Throwable) → report()<br/>+ notificação de erro"]
```

## Máquina de estados (transição nova em destaque)

```mermaid
stateDiagram-v2
    [*] --> Pending
    Pending --> Active
    Pending --> Cancelled
    Pending --> CancelledLate
    Active --> Completed
    Active --> Cancelled
    Active --> CancelledLate
    Active --> NoShow : novo (US-383)
    Completed --> [*]
    Cancelled --> [*]
    CancelledLate --> [*]
    NoShow --> [*]
```

## Decisões técnicas

- **Sem migration**: a coluna `status` é `string` livre (sem enum de banco ou CHECK constraint), verificado no schema — `'no_show'` entra sem mudança.
- **`NoShowTransition` é terminal** (`canChange(): false`, `choices(): []`), seguindo o padrão do repositório em que a classe de transição é nomeada pelo status *atual* (como `CompletedTransition`). A execução `Active → NoShow` vive em `ActiveTransition::processStep()`.
- **Auditoria sem mudança de schema**: reusa `appointment_histories` com os novos cases `AppointmentHistoryActionType::NoShowMarked` e `AppointmentHistoryActor::Consultant`; `new_values` carrega `status` e `credit_impact` (enum `CreditImpact`, valor lido do status real do crédito **após** a mutação do listener).
- **Atomicidade herdada do padrão**: o listener de crédito não implementa `ShouldQueue` — roda síncrono dentro da `DB::transaction` de `AbstractAppointmentTransition::handle()`.
- Token de tema `--apt-purple-300` + regra `.fi-apt-status-no-show` para o ícone do badge no panel-app.

## Validação

- **Suíte completa**: 1365 testes, 0 falhas (3 skips pré-existentes não relacionados) — verde em execuções repetidas para descartar flakiness da factory com o novo case.
- **PHPStan nível max**: 0 erros (todos os `match` sobre os enums alterados continuam exaustivos, sem `default`).
- **Pint**: sem ajustes.
- Testes novos cobrem: transições válida e inválidas, visibilidade da action por status/horário/dono, conteúdo do modal, notificação `danger`, **rollback comprovado no banco** (exceção forçada no listener de crédito → status volta a `Active`, sem histórico persistido), consumo do crédito com auditoria, filtro do admin, ações bloqueadas no app e comportamento dos badges.
- Pontos críticos verificados com **mutation testing** (Pest `--mutate`): remoção do `try/catch`, do `requiresConfirmation()`, do mapeamento de cor e das chaves de tradução do `credit_impact` — todas as mutações mortas.

## Revisão de código — 1ª rodada atendida (`d6de38fb`)

Os 12 pontos da review foram aplicados, cada um verificado com teste de sabotagem (reverter a correção quebra o teste correspondente):

- **01 (alta)** — métricas passam a enxergar o no_show: taxa de comparecimento da empresa com no_show no denominador (legenda do tile consistente via `AppointmentStats->finalized`) e bucket + card de no_show no overview do admin, com o total fechando com a soma dos cards.
- **02 (alta)** — `credit_impact` deixou de ser palpite: é lido do status real do crédito **após** a mutação do listener; chave morta `returned` removida.
- **03** — `forgetMonthlyAppointmentsLeftCache()` movido para `DB::afterCommit()` nos dois lugares (no_show e o defeito pré-existente do cancelamento).
- **04** — `TransitionData` colapsado em `?User $noShowMarkedBy` (estado ilegal irrepresentável) + `validate()` rejeita combinação com `cancellationActor`.
- **05** — checagem de dono com `filled()` nos dois lados (elimina o `null === null`), com testes de usuário sem consultant e de agendamento de outro consultor.
- **06** — testes de crédito usam consultor real como ator da auditoria.
- **07** — enum `CreditImpact` persistido e usado na resolução de tradução, com teste do fallback para valor inválido.
- **08** — comentários em prosa removidos.
- **09** — `NoShow` fora do `$isCancelled`; tratamento próprio roxo no widget do beneficiário, coerente com os demais painéis.
- **10** — evento de domínio `AppointmentNoShow` emitido no padrão de `AppointmentCompleted`/`AppointmentCancelled`.
- **11** — cores do gráfico por status derivadas de `getColor()` por case, não posicionais.
- **12** — formato de data do modal por locale (pt_BR `d/m/Y H:i`, en `m/d/Y g:i A`).

## Follow-ups (não bloqueantes)

- [x] ~~Teste de tentativa de marcação em agendamento de outro consultor~~ — coberto na rodada da review (ponto 05).
- [x] ~~Invariante no `TransitionData`: rejeitar no_show + `cancellationActor` simultâneos~~ — implementado na rodada da review (ponto 04).
- [ ] Teste de rollback com falha *após* o INSERT do histórico.
- [ ] Teste do consumo de cota mensal (beneficiário sem `UserCredit`) + invalidação do cache.
- [ ] Guarda temporal ("horário já passou") também no domínio, não só na camada Filament.
- [ ] Abrir card: corrida do job `MarkAppointmentsAsCompleted` com a marcação de no_show — corrida **pré-existente** do job, não introduzida aqui. Detalhe para o card: o job resolve `current_transition` de modelo carregado no `chunkById`; se a marcação acontecer no meio, ele roda `ActiveTransition` sobre registro já `no_show`, força `Completed` e dispara o e-mail de conclusão — um `where('status', Active)` no update condicional (ou `lockForUpdate()`) resolve.

## Riscos aceitos e fora de escopo

- **Janela prática de 24–48h** para o consultor marcar o no_show: o job roda às 08:00 pegando `appointment_at < now()->subDay()`, então a janela varia conforme o horário da consultoria; depois disso o agendamento `Active` é auto-completado. Decisão de produto aceita nesta entrega.
- Fora de escopo do épico (documentado no Monday): notificação ao beneficiário sobre o no_show, relatório de taxa de no_show nas métricas e reversão do no_show pelo consultor.

## Stories no Monday

- [US-383 — Novo status no_show na state machine](https://3pontos.monday.com/boards/18392616637/pulses/12699695056)
- [US-384 — Botão "Não Compareceu" no painel do consultor](https://3pontos.monday.com/boards/18392616637/pulses/12699733871)
- [US-385 — Impacto do no_show no crédito do beneficiário](https://3pontos.monday.com/boards/18392616637/pulses/12699719248)
- [US-386 — Visibilidade do status no_show nos painéis](https://3pontos.monday.com/boards/18392616637/pulses/12699731594)

